### PR TITLE
Fixes 'Create Customer' button not working

### DIFF
--- a/resources/views/cp/customers/index.blade.php
+++ b/resources/views/cp/customers/index.blade.php
@@ -83,16 +83,10 @@
             </div>
         @endif
     @else
-        @component('statamic::partials.create-first', [
+        @include('statamic::partials.create-first', [
             'resource' => 'Customer',
             'svg' => 'empty/collection',
+            'route' => $createUrl
         ])
-            <a
-                    class="btn btn-primary"
-                    href="{{ $createUrl }}"
-            >
-                Create Customer
-            </a>
-        @endcomponent
     @endif
 @endsection

--- a/resources/views/cp/product-categories/index.blade.php
+++ b/resources/views/cp/product-categories/index.blade.php
@@ -79,16 +79,10 @@
             </div>
         @endif
     @else
-        @component('statamic::partials.create-first', [
+        @include('statamic::partials.create-first', [
             'resource' => 'Product Category',
             'svg' => 'empty/collection',
+            'route' => $createUrl
         ])
-            <a
-                    class="btn btn-primary"
-                    href="{{ $createUrl }}"
-            >
-                Create Product Category
-            </a>
-        @endcomponent
     @endif
 @endsection

--- a/resources/views/cp/products/index.blade.php
+++ b/resources/views/cp/products/index.blade.php
@@ -86,16 +86,10 @@
             </div>
         @endif
     @else
-        @component('statamic::partials.create-first', [
+        @include('statamic::partials.create-first', [
             'resource' => 'Product',
             'svg' => 'empty/collection',
+            'route' => $createUrl
         ])
-            <a
-                    class="btn btn-primary"
-                    href="{{ $createUrl }}"
-            >
-                Create Product
-            </a>
-        @endcomponent
     @endif
 @endsection


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41837763/74589106-4a963e00-4ffa-11ea-8d7e-3bcbe039efde.png)

The larger 'Create Customer' button in the 'statamic::partials.create-first' partial wasn't using the correct URL. It was being used as a component, but should have been used as a regular included partial, as there is no slot so the `<a>` tag there wasn't actually being rendered.