### PR TITLE
Fix some formatting and errors on products index table

### DIFF
--- a/resources/views/cp/products/index.blade.php
+++ b/resources/views/cp/products/index.blade.php
@@ -36,11 +36,15 @@
                         </td>
 
                         <td>
-                            {{ $product->variants->count() }} variants
+                            {{ $product->variant_count }} 
                         </td>
 
                         <td>
-                            <a href="{{ $product->productCategory->showUrl() }}">{{ $product->productCategory->title }}</a>
+                            @if($product->productCategory)
+                                <a href="{{ $product->productCategory->showUrl() }}">{{ $product->productCategory->title }}</a>
+                            @else
+                                &mdash;
+                            @endif
                         </td>
 
                         <td class="flex justify-end">

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -19,7 +19,7 @@ class Product extends Model
     ];
 
     protected $appends = [
-        'from_price', 'to_price', 'url', 'variant_count'
+        'from_price', 'to_price', 'url'
     ];
 
     public function getRouteKeyName()

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -19,7 +19,7 @@ class Product extends Model
     ];
 
     protected $appends = [
-        'from_price', 'to_price', 'url'
+        'from_price', 'to_price', 'url', 'variant_count',
     ];
 
     public function getRouteKeyName()

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Models;
 
 use DoubleThreeDigital\SimpleCommerce\Models\Traits\HasAttributes;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 class Product extends Model
 {
@@ -18,7 +19,7 @@ class Product extends Model
     ];
 
     protected $appends = [
-        'from_price', 'to_price', 'url',
+        'from_price', 'to_price', 'url', 'variant_count'
     ];
 
     public function getRouteKeyName()
@@ -49,6 +50,11 @@ class Product extends Model
     public function getUrlAttribute()
     {
         return route('products.show', ['product' => $this->attributes['slug']]);
+    }
+
+    public function getVariantCountAttribute()
+    {
+        return sprintf('%s %s', $count = $this->variants->count(), Str::plural('variant', $count));
     }
 
     public function createUrl()


### PR DESCRIPTION
Before:

There was a category error when the product has no category set, so I've just wrapped that in an if.

Variants column:

![image](https://user-images.githubusercontent.com/41837763/74589457-6fd87b80-4ffd-11ea-8248-4358562000a5.png)

After:

Variants column:

![image](https://user-images.githubusercontent.com/41837763/74589476-93032b00-4ffd-11ea-9c0d-e16f44a77796.png)

Pluralisation of the word `variant` has been fixed.