### PR TITLE
Fixed variants that are added from edit screen not saving due to undefined index

### DIFF
--- a/src/Http/Controllers/Cp/ProductController.php
+++ b/src/Http/Controllers/Cp/ProductController.php
@@ -168,7 +168,7 @@ class ProductController extends CpController
         collect($request->variants)
             ->each(function ($variant) use ($product) {
                 $item = Variant::updateOrCreate([
-                    'uuid' => $variant['uuid'],
+                    'uuid' => $variant['uuid'] ?? null,
                 ], [
                     'name' => $variant['name'],
                     'sku' => $variant['sku'],


### PR DESCRIPTION
No issue for this one, just spotted it whilst working on something else so here's a fix.

When the new variant is added from the 'Edit' screen, there's no UUID set so it will throw an 'Undefined index...' error, this just fixes it with a simple default null value.