### PR TITLE
Custom Attribute fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     },
     "require": {
         "doctrine/dbal": "2.10.x-dev",
+        "laravel/helpers": "^1.0@dev",
         "laravel/slack-notification-channel": "^3.0@dev",
         "statamic/cms": "^3.0@beta",
         "stripe/stripe-php": "^7.7"

--- a/resources/blueprints/product.yaml
+++ b/resources/blueprints/product.yaml
@@ -29,7 +29,6 @@ sections:
                 character_limit: 0
                 type: text
                 localizable: false
-                width: 100
                 display: 'Variant Name'
                 listable: hidden
                 input_type: text
@@ -88,43 +87,8 @@ sections:
                 localizable: false
                 display: Description
             -
-              handle: variant_attributes
-              field:
-                fields:
-                  -
-                    handle: uuid
-                    field:
-                      character_limit: 0
-                      type: hidden
-                      localization: false
-                      display: UUID
-                  -
-                    handle: key
-                    field:
-                      character_limit: 0
-                      type: text
-                      localizable: false
-                      display: Key
-                      listable: hidden
-                      input_type: text
-                      validate: required
-                  -
-                    handle: value
-                    field:
-                      character_limit: 0
-                      type: text
-                      localizable: false
-                      display: Value
-                      listable: hidden
-                      input_type: text
-                      validate: required
-                mode: table
-                reorderable: false
-                type: grid
-                localizable: false
-                display: Attributes
-                listable: true
-                add_row: 'Add Attribute'
+              import: variant_attributes
+              prefix: attributes_
           mode: stacked
           min_rows: 1
           add_row: 'New Variant'

--- a/resources/blueprints/product.yaml
+++ b/resources/blueprints/product.yaml
@@ -101,43 +101,8 @@ sections:
     display: Attributes
     fields:
       -
-        handle: product_attributes
-        field:
-          fields:
-            -
-              handle: uuid
-              field:
-                type: hidden
-                localizable: false
-                listable: hidden
-                display: UUID
-            -
-              handle: key
-              field:
-                html_type: text
-                type: text
-                localizable: false
-                listable: hidden
-                display: Key
-                input_type: text
-                validate: required
-            -
-              handle: value
-              field:
-                html_type: text
-                type: text
-                localizable: false
-                listable: hidden
-                display: Value
-                input_type: text
-                validate: required
-          mode: table
-          add_row: 'Add Attribute'
-          reorderable: false
-          type: grid
-          localizable: false
-          listable: true
-          display: Attributes
+        import: product_attributes
+        prefix: attributes_
   sidebar:
     display: Sidebar
     fields:

--- a/resources/blueprints/product.yaml
+++ b/resources/blueprints/product.yaml
@@ -63,16 +63,16 @@ sections:
                 validate: required
                 default: 1
             -
-              handle: stock_number
+              handle: stock
               field:
                 type: integer
                 localizable: false
                 width: 33
                 display: 'Stock Number'
                 listable: hidden
+                validate: required
                 unless:
                   unlimited_stock: 'equals true'
-                validate: required
             -
               handle: unlimited_stock
               field:

--- a/resources/fieldsets/product_attributes.yaml
+++ b/resources/fieldsets/product_attributes.yaml
@@ -1,0 +1,1 @@
+title: 'Simple Commerce: Product Attributes'

--- a/resources/fieldsets/variant_attributes.yaml
+++ b/resources/fieldsets/variant_attributes.yaml
@@ -1,0 +1,1 @@
+title: 'Simple Commerce: Variant Attributes'

--- a/src/Http/Controllers/Cp/ProductController.php
+++ b/src/Http/Controllers/Cp/ProductController.php
@@ -74,7 +74,7 @@ class ProductController extends CpController
                     'name'              => $theVariant['name'],
                     'sku'               => $theVariant['sku'],
                     'price'             => $theVariant['price'],
-                    'stock'             => $theVariant['stock_number'],
+                    'stock'             => $theVariant['stock'],
                     'unlimited_stock'   => $theVariant['unlimited_stock'],
                     'max_quantity'      => $theVariant['max_quantity'],
                     'description'       => $theVariant['description'],
@@ -128,7 +128,6 @@ class ProductController extends CpController
 
                 return array_merge($variant, [
                     '_id'           => "row-{$key}",
-                    'stock_number'  => $variant['stock'], // TODO: need to change the blueprint field handle to be the same as the db column name
                 ]);
             }),
         ]);
@@ -183,7 +182,7 @@ class ProductController extends CpController
                     'name'              => $variant['name'],
                     'sku'               => $variant['sku'],
                     'price'             => $variant['price'],
-                    'stock'             => $variant['stock_number'],
+                    'stock'             => $variant['stock'],
                     'unlimited_stock'   => $variant['unlimited_stock'],
                     'max_quantity'      => $variant['max_quantity'],
                     'description'       => $variant['description'],

--- a/src/Http/Controllers/Cp/ProductController.php
+++ b/src/Http/Controllers/Cp/ProductController.php
@@ -17,7 +17,7 @@ class ProductController extends CpController
         $this->authorize('view', Product::class);
 
         return view('simple-commerce::cp.products.index', [
-            'products' => Product::paginate(config('statamic.cp.pagination_size')),
+            'products'  => Product::paginate(config('statamic.cp.pagination_size')),
             'createUrl' => (new Product())->createUrl(),
         ]);
     }
@@ -46,11 +46,11 @@ class ProductController extends CpController
         $this->authorize('create', Product::class);
 
         $product = Product::create([
-            'title' => $request->title,
-            'slug' => $request->slug,
-            'description' => $request->description,
-            'product_category_id' => $request->category[0] ?? null,
-            'is_enabled' => $request->is_enabled,
+            'title'                 => $request->title,
+            'slug'                  => $request->slug,
+            'description'           => $request->description,
+            'product_category_id'   => $request->category[0] ?? null,
+            'is_enabled'            => $request->is_enabled,
         ]);
 
         collect($request)
@@ -59,27 +59,25 @@ class ProductController extends CpController
                     return true;
                 }
             })
-            ->map(function ($value, $key) use ($product) {
+            ->each(function ($value, $key) use ($product) {
                 $key = str_replace('attributes_', '', $key);
 
-                $attribute = $product->attributes()->create([
+                $product->attributes()->create([
                     'key'   => $key,
                     'value' => $value,
                 ]);
-
-                return $attribute;
             });
 
         collect($request->variants)
             ->each(function ($theVariant) use ($product, $request) {
                 $variant = $product->variants()->create([
-                    'name' => $theVariant['name'],
-                    'sku' => $theVariant['sku'],
-                    'price' => $theVariant['price'],
-                    'stock' => $theVariant['stock_number'],
-                    'unlimited_stock' => $theVariant['unlimited_stock'],
-                    'max_quantity' => $theVariant['max_quantity'],
-                    'description' => $theVariant['description'],
+                    'name'              => $theVariant['name'],
+                    'sku'               => $theVariant['sku'],
+                    'price'             => $theVariant['price'],
+                    'stock'             => $theVariant['stock_number'],
+                    'unlimited_stock'   => $theVariant['unlimited_stock'],
+                    'max_quantity'      => $theVariant['max_quantity'],
+                    'description'       => $theVariant['description'],
                 ]);
 
                 collect($theVariant)
@@ -153,11 +151,11 @@ class ProductController extends CpController
         $this->authorize('update', $product);
 
         $product->update([
-            'title' => $request->title,
-            'slug' => $request->slug,
-            'description' => $request->description,
-            'product_category_id' => $request->category,
-            'is_enabled' => $request->is_enabled,
+            'title'                 => $request->title,
+            'slug'                  => $request->slug,
+            'description'           => $request->description,
+            'product_category_id'   => $request->category,
+            'is_enabled'            => $request->is_enabled,
         ]);
 
         collect($request)
@@ -166,32 +164,30 @@ class ProductController extends CpController
                     return true;
                 }
             })
-            ->map(function ($value, $key) use ($product) {
+            ->each(function ($value, $key) use ($product) {
                 $key = str_replace('attributes_', '', $key);
 
-                $attribute = $product->attributes()->updateOrCreate([
-                    'key' => $key,
+                $product->attributes()->updateOrCreate([
+                    'key'   => $key,
                 ], [
-                    'key' => $key,
+                    'key'   => $key,
                     'value' => $value,
                 ]);
-
-                return $attribute;
             });
 
         collect($request->variants)
             ->map(function ($variant) use ($product) {
                 $item = Variant::updateOrCreate([
-                    'uuid' => $variant['uuid'] ?? null,
+                    'uuid'              => $variant['uuid'] ?? null,
                 ], [
-                    'name' => $variant['name'],
-                    'sku' => $variant['sku'],
-                    'price' => $variant['price'],
-                    'stock' => $variant['stock_number'],
-                    'unlimited_stock' => $variant['unlimited_stock'],
-                    'max_quantity' => $variant['max_quantity'],
-                    'description' => $variant['description'],
-                    'product_id' => $product->id,
+                    'name'              => $variant['name'],
+                    'sku'               => $variant['sku'],
+                    'price'             => $variant['price'],
+                    'stock'             => $variant['stock_number'],
+                    'unlimited_stock'   => $variant['unlimited_stock'],
+                    'max_quantity'      => $variant['max_quantity'],
+                    'description'       => $variant['description'],
+                    'product_id'        => $product->id,
                 ]);
 
                 collect($variant)
@@ -200,17 +196,15 @@ class ProductController extends CpController
                             return true;
                         }
                     })
-                    ->map(function ($value, $key) use ($item) {
+                    ->each(function ($value, $key) use ($item) {
                         $key = str_replace('attributes_', '', $key);
 
-                        $attribute = $item->attributes()->updateOrCreate([
-                            'key' => $key,
+                        $item->attributes()->updateOrCreate([
+                            'key'   => $key,
                         ], [
-                            'key' => $key,
+                            'key'   => $key,
                             'value' => $value,
                         ]);
-
-                        return $attribute;
                     });
 
                 return $variant;

--- a/src/Http/Controllers/Cp/ProductController.php
+++ b/src/Http/Controllers/Cp/ProductController.php
@@ -6,6 +6,7 @@ use DoubleThreeDigital\SimpleCommerce\Http\Requests\ProductRequest;
 use DoubleThreeDigital\SimpleCommerce\Models\Attribute;
 use DoubleThreeDigital\SimpleCommerce\Models\Product;
 use DoubleThreeDigital\SimpleCommerce\Models\Variant;
+use Illuminate\Support\Arr;
 use Statamic\CP\Breadcrumbs;
 use Statamic\Http\Controllers\CP\CpController;
 
@@ -76,16 +77,17 @@ class ProductController extends CpController
                     'description' => $theVariant['description'],
                 ]);
 
-                collect($theVariant['variant_attributes'])
-                    ->each(function ($attribute) use ($variant) {
-                        if ($attribute['key'] === null) {
-                            return;
-                        }
+                collect($theVariant)
+                    ->each(function ($value, $key) use ($variant) {
+                        if (str_contains($key, 'attributes_')) {
+                            $attributeKey = str_replace('attributes_', '', $key);
+                            $attributeValue = $value;
 
-                        $variant->attributes()->create([
-                            'key' => $attribute['key'],
-                            'value' => $attribute['value'],
-                        ]);
+                            $variant->attributes()->create([
+                                'key'   => $attributeKey,
+                                'value' => $attributeValue,
+                            ]);
+                        }
                     });
             });
 
@@ -107,21 +109,17 @@ class ProductController extends CpController
             ->first();
 
         $values = array_merge($product->toArray(), [
-            'category' => $product->product_category_id,
-            'variants' => $product->variants->map(function (Variant $variant, $key) {
-                return array_merge($variant->toArray(), [
-                    '_id' => 'row-'.$key,
-                    'stock_number' => $variant->stock,
-                    'variant_attributes' => collect($variant->attributes)
-                        ->map(function (Attribute $attribute, $key) {
-                            return [
-                                '_id' => 'row-'.$key,
-                                'uuid' => $attribute->uuid,
-                                'key' => $attribute->key,
-                                'value' => $attribute->value,
-                            ];
-                        })
-                        ->toArray(),
+            'category'  => $product->product_category_id,
+            'variants'  => $product->variants->map(function (Variant $originalVariant, $key) {
+                $variant = $originalVariant->toArray();
+
+                $originalVariant->attributes->each(function (Attribute $attribute) use (&$variant) {
+                    $variant["attributes_{$attribute->key}"] = $attribute['value'];
+                });
+
+                return array_merge($variant, [
+                    '_id'           => "row-{$key}",
+                    'stock_number'  => $variant['stock'], // TODO: need to change the blueprint field handle to be the same as the db column name
                 ]);
             }),
             'product_attributes' => collect($product->attributes)
@@ -224,7 +222,7 @@ class ProductController extends CpController
         $this->authorize('delete', $product);
 
         $product->attributes()->delete();
-        $product->variants()->attributes()->delete();
+        //$product->variants()->attributes()->delete(); // TODO: if variants have no attributes, this goes off on one
         $product->variants()->delete();
         $product->delete();
 

--- a/src/Models/Attribute.php
+++ b/src/Models/Attribute.php
@@ -16,6 +16,10 @@ class Attribute extends Model
         'updated' => AttributeUpdated::class,
     ];
 
+    protected $casts = [
+        'value' => 'array',
+    ];
+
     public function attributable()
     {
         return $this->morphTo();

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -73,4 +73,13 @@ class Product extends Model
     {
         return Blueprint::find('product');
     }
+
+    public function delete()
+    {
+        parent::delete();
+
+        if ($this->attributes()->count() > 0) {
+            $this->attributes()->delete();
+        }
+    }
 }

--- a/src/Models/Variant.php
+++ b/src/Models/Variant.php
@@ -45,4 +45,13 @@ class Variant extends Model
 
         return false;
     }
+
+    public function delete()
+    {
+        parent::delete();
+
+        if ($this->attributes()->count() > 0) {
+            $this->attributes()->delete();
+        }
+    }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -139,6 +139,7 @@ class ServiceProvider extends AddonServiceProvider
         $this->publishes([__DIR__.'/../resources/views/web' => resource_path('views/vendor/simple-commerce/web')]);
         $this->publishes([__DIR__.'/../database/migrations' => database_path('migrations')]);
         $this->publishes([__DIR__.'/../resources/blueprints' => resource_path('blueprints')]);
+        $this->publishes([__DIR__.'/../resources/fieldsets' => resource_path('fieldsets')]);
         $this->publishes([__DIR__.'/../dist/js/cp.js', public_path('vendor/doublethreedigital/simple-commerce/js')]);
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'simple-commerce');
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');

--- a/src/Tags/SimpleCommerceTag.php
+++ b/src/Tags/SimpleCommerceTag.php
@@ -39,7 +39,7 @@ class SimpleCommerceTag extends Tags
 
     public function products()
     {
-        $products = Product::with('variants', 'productCategory', 'attributes')->get();
+        $products = Product::with('variants', 'variants.attributes', 'productCategory', 'attributes')->get();
 
         if ($this->getParam('category') != null) {
             $category = ProductCategory::where('slug', $this->getParam('category'))->first();


### PR DESCRIPTION
This pull request opens up the ability for developers to add their own custom fields to the product publish form.

Instead of the content editor having a gird of product or variant attributes, the developer can define what fields can be used. They can do this by updating a fieldset.

These fields will be entered into the `attributes` table and are attached to the product or variant.

