### PR TITLE
feature(add new SimpleCommerce::registerGateway() method for third party add-ons)

### DIFF
--- a/src/SimpleCommerce.php
+++ b/src/SimpleCommerce.php
@@ -46,6 +46,11 @@ class SimpleCommerce
             ->toArray();
     }
 
+    public static function registerGateway(string $gateway, array $config = [])
+    {
+        static::$gateways[] = [$gateway, $config];
+    }
+
     public static function freshOrderNumber()
     {
         $minimum = 2000;


### PR DESCRIPTION
This PR adds a new `SimpleCommerce::registerGateway()` method that allows third party add-ons to register custom gateways without needing them inside of the config file.