### PR TITLE
Saves the payment method for future usage

### DIFF
--- a/src/Gateways/StripeGateway.php
+++ b/src/Gateways/StripeGateway.php
@@ -32,6 +32,7 @@ class StripeGateway implements Gateway
             'amount'   => $data['grand_total'],
             'currency' => Currency::get(Site::current())['code'],
             'description' => "Order: {$cart->title}",
+            'setup_future_usage' => 'off_session',
             'metadata' => [
                 'order_id' => $cart->id,
             ],


### PR DESCRIPTION
Added the ability to save the payment method for future usage.

Should this be optional and configurable?