### PR TITLE
Fixed vat calculation

### DIFF
--- a/src/Orders/Calculator.php
+++ b/src/Orders/Calculator.php
@@ -45,11 +45,10 @@ class Calculator
                             '.',
                             '',
                             round(
-                                ((float) substr_replace($itemTotal, '.', -2, 0) / 100) * $siteTax['rate'],
+                                ((float) substr_replace($itemTotal, '.', -2, 0) / ($siteTax['rate'] + 100)) * $siteTax['rate'],
                                 2
                             )
                         );
-
                         $itemTotal -= $itemTax;
                         $data['tax_total'] += $itemTax;
                     } else {
@@ -60,7 +59,7 @@ class Calculator
                                 ((float) substr_replace($itemTotal, '.', -2, 0) / 100) * $siteTax['rate'],
                                 2
                             )
-                        );
+                        ) * 100;
                     }
                 }
 


### PR DESCRIPTION
The vat calculation in the current master build goes wrong in included and excluded mode.
**Included you got:** 
  Item price: €100
  Vat rate: 21%
  Vat: 0,21
  Total: €99,79
**Excluded you got:** 
  Item price: €100
  Vat rate: 21%
  Vat: 0,21
  Total: €100,21
  
I fixed this so the calculation goes right.