### PR TITLE
Fix mollie webhook

### DIFF
--- a/src/Gateways/MollieGateway.php
+++ b/src/Gateways/MollieGateway.php
@@ -44,15 +44,6 @@ class MollieGateway extends BaseGateway implements Gateway
             ],
         ]);
 
-        if($payment){
-          Cart::find($cart->id)->update([
-              'gateway' => $this->name(),
-              'gateway_data' => [
-                  'id' => $payment->id
-              ],
-          ]);
-        }
-        
         return new GatewayResponse(true, [
             'id' => $payment->id,
         ], $payment->getCheckoutUrl());

--- a/src/Gateways/MollieGateway.php
+++ b/src/Gateways/MollieGateway.php
@@ -43,7 +43,17 @@ class MollieGateway extends BaseGateway implements Gateway
                 'order_id' => $cart->id,
             ],
         ]);
-
+        
+        //Stores payment_id needed in webhook. Might be a cleaner way to do this?
+        if($payment){
+          Cart::find($cart->id)->update([
+              'gateway' => $this->name(),
+              'gateway_data' => [
+                  'id' => $payment->id
+              ],
+          ]);
+        }
+        
         return new GatewayResponse(true, [
             'id' => $payment->id,
         ], $payment->getCheckoutUrl());
@@ -132,7 +142,7 @@ class MollieGateway extends BaseGateway implements Gateway
                         === $mollieId;
                 })
                 ->map(function ($entry) {
-                    return Cart::find($entry->id);
+                    return Cart::find($entry->id());
                 })
                 ->first();
 

--- a/src/Gateways/MollieGateway.php
+++ b/src/Gateways/MollieGateway.php
@@ -43,8 +43,7 @@ class MollieGateway extends BaseGateway implements Gateway
                 'order_id' => $cart->id,
             ],
         ]);
-        
-        //Stores payment_id needed in webhook. Might be a cleaner way to do this?
+
         if($payment){
           Cart::find($cart->id)->update([
               'gateway' => $this->name(),

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -65,6 +65,10 @@ class CheckoutTags extends SubTag
 
         $prepare = $prepare->prepare(request(), $cart->entry());
 
+        $cart->update([
+            $gateway['handle'] => $prepare->data(),
+        ]);
+
         if (! $prepare->checkoutUrl()) {
             throw new Exception('This gateway is not an off-site gateway. Please use the normal checkout tag.');
         }


### PR DESCRIPTION
The webhook was still throwing some errors. The order Entry couldn't be found because the mollie payment wasn't being saved right after creating the payment. It needs to be set on that point because otherwise there is no way to link the payment to the right order because this data is apperantly saved after the $purchase->success 'event' in the GatewayRepository. Here it is fixed together with the parsing of the Entry id in Cart::find(). Tested this out and seems to fix the remaining issues I had with the Mollie webhook.

There is probably a cleaner way or place to do this but I hope it clarifies the issue that was happening in preparing the order and webhook in the Mollie gateway.