### PR TITLE
Customer ID overwrite

### DIFF
--- a/src/Http/Controllers/CartController.php
+++ b/src/Http/Controllers/CartController.php
@@ -68,13 +68,21 @@ class CartController extends BaseActionController
         }
 
         if (isset($data['email'])) {
-            $customer = Customer::make()
-                ->site($this->guessSiteFromRequest())
-                ->data([
-                    'name' => isset($data['name']) ? $data['name'] : '',
-                    'email' => $data['email'],
-                ])
-                ->save();
+            try {
+                if (isset($data['email']) && $data['email'] !== null) {
+                    $customer = Customer::findByEmail($data['email']);
+                } else {
+                    throw new CustomerNotFound(__('simple-commerce::customers.customer_not_found', ['id' => $data['customer']]));
+                }
+            } catch (CustomerNotFound $e) {
+                $customer = Customer::make()
+                    ->site($this->guessSiteFromRequest())
+                    ->data([
+                        'name' => isset($data['name']) ? $data['name'] : '',
+                        'email' => $data['email'],
+                    ])
+                    ->save();
+            }
 
             $cart->update([
                 'customer' => $customer->id,


### PR DESCRIPTION
Found a bug or maybe it was intentional?

When going through the checkout proces at the moment your personal info gets saved to the cart it checks if the email field is set. In this check it doesn't check if the email is already taken by a customer in your application. So it makes a new customer and overwrites the old one. 

This causes an issue with your order detail in the control panel. Because the customer id isn't linked anymore you first need to clear your cache to open that order without an Statamic exception. When you open that order the customer won't be linked anymore because the id won't exist.

I used basically the same code of the customer check (right above it) to fix this issue. It's probably better to put this in a findOrCreate() function within the CustomerRepository to prevent duplicate code. If you prefer it that way I can give it a shot but first I wanted to get your feedback on this before I'm changing to much code.