### PR TITLE
Naming inconsistencies postal/zip codes

### DIFF
--- a/resources/blueprints/collections/orders/order.yaml
+++ b/resources/blueprints/collections/orders/order.yaml
@@ -155,7 +155,7 @@ sections:
           listable: hidden
           display: 'Shipping Country'
       -
-        handle: shipping_postal_code
+        handle: shipping_zip_code
         field:
           input_type: text
           type: text
@@ -219,7 +219,7 @@ sections:
           unless:
             use_shipping_address_for_billing: 'equals true'
       -
-        handle: billing_postal_code
+        handle: billing_zip_code
         field:
           input_type: text
           type: text

--- a/src/Data/Address.php
+++ b/src/Data/Address.php
@@ -27,7 +27,7 @@ class Address
             'address'  => $this->address,
             'city'     => $this->city,
             'country'  => $this->country,
-            'zip_code' => $this->postal,
+            'zip_code' => $this->zipCode,
         ];
     }
 


### PR DESCRIPTION
Hi!

While tinkering with the get receipt route I found some inconsistencies with the postal/zip code naming.
$this->postal was causing an undefined property error when calling '/receipt/{orderId}'. Changing postal to zipCode fixed it. Also checked if it was happening in other places and found the order blueprint also needed a change. I left the display name in the order blueprint unchanged because I think "Postal Code" is more recognizable for people who don't speak english. So if the dev left the Statamic cp unchanged the end-user is more likely to recognize it but that is just my opinion. Maybe I'm just thinking too much about edge-cases 😅 