### PR TITLE
Product Specific Coupons

### DIFF
--- a/resources/blueprints/collections/coupons/coupon.yaml
+++ b/resources/blueprints/collections/coupons/coupon.yaml
@@ -67,6 +67,16 @@ sections:
           width: 50
           listable: hidden
           display: 'Minimum Cart Value'
+      -
+        handle: products
+        field:
+          mode: default
+          collections:
+            - products
+          display: Products
+          type: entries
+          icon: entries
+          listable: hidden
   sidebar:
     display: Sidebar
     fields:

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -83,7 +83,7 @@ class Coupon implements Contract
     protected function isProductSpecific()
     {
         return $this->has('products')
-            && collect($this->get('products'))->count() >= 0;
+            && collect($this->get('products'))->count() >= 1;
     }
 
     public static function bindings(): array

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Coupons;
 
 use DoubleThreeDigital\SimpleCommerce\Contracts\Coupon as Contract;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\CouponNotFound;
+use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Support\Traits\HasData;
 use DoubleThreeDigital\SimpleCommerce\Support\Traits\IsEntry;
 use Statamic\Entries\Entry as EntryInstance;
@@ -38,14 +39,26 @@ class Coupon implements Contract
     // TODO: refactor
     public function isValid(EntryInstance $order): bool
     {
+        $order = Order::find($order->id());
+
         if ($this->has('minimum_cart_value') && $order->has('items_total')) {
-            if ($order->data()->get('items_total') < $this->get('minimum_cart_value')) {
+            if ($order->get('items_total') < $this->get('minimum_cart_value')) {
                 return false;
             }
         }
 
         if ($this->has('redeemed') && $this->has('maximum_uses')) {
             if ($this->has('redeemed') >= $this->get('maximum_uses')) {
+                return false;
+            }
+        }
+
+        if ($this->isProductSpecific()) {
+            $couponProductsInOrder = $order->lineItems()->filter(function ($lineItem) {
+                return in_array($lineItem['product'], $this->get('products'));
+            });
+
+            if ($couponProductsInOrder === 0) {
                 return false;
             }
         }
@@ -65,6 +78,12 @@ class Coupon implements Contract
     public function collection(): string
     {
         return config('simple-commerce.collections.coupons');
+    }
+
+    protected function isProductSpecific()
+    {
+        return $this->has('products')
+            && collect($this->get('products'))->count() >= 0;
     }
 
     public static function bindings(): array

--- a/src/Orders/Calculator.php
+++ b/src/Orders/Calculator.php
@@ -163,6 +163,14 @@ class Calculator implements Contract
             $coupon = Coupon::find($this->order->data['coupon']);
             $value = (int) $coupon->data['value'];
 
+            // Double check coupon is still valid
+            if (! $coupon->isValid()) {
+                return [
+                    'data' => $data,
+                ];
+            }
+
+            // Otherwise do all the other stuff...
             if ($coupon->data['type'] === 'percentage') {
                 $data['coupon_total'] = (int) (($value * $data['items_total']) / 100);
             }

--- a/src/Orders/Calculator.php
+++ b/src/Orders/Calculator.php
@@ -164,7 +164,7 @@ class Calculator implements Contract
             $value = (int) $coupon->data['value'];
 
             // Double check coupon is still valid
-            if (! $coupon->isValid()) {
+            if (! $coupon->isValid($this->order->entry())) {
                 return [
                     'data' => $data,
                 ];

--- a/tests/Http/Controllers/CouponControllerTest.php
+++ b/tests/Http/Controllers/CouponControllerTest.php
@@ -29,8 +29,6 @@ class CouponControllerTest extends TestCase
     /** @test */
     public function can_store_coupon()
     {
-        $this->markTestSkipped();
-
         Event::fake();
 
         $this->buildCartWithProducts();

--- a/tests/Http/Controllers/CouponControllerTest.php
+++ b/tests/Http/Controllers/CouponControllerTest.php
@@ -29,20 +29,24 @@ class CouponControllerTest extends TestCase
     /** @test */
     public function can_store_coupon()
     {
-        $this->markTestIncomplete();
-
         Event::fake();
 
         $this->buildCartWithProducts();
 
-        $coupon = Coupon::create([
-            'slug'               => 'half-price',
-            'title'              => 'Half Price',
-            'redeemed'           => 0,
-            'value'              => 50,
-            'type'               => 'percentage',
-            'minimum_cart_value' => null,
-        ])->save();
+        Entry::make()
+            ->collection('coupons')
+            ->id(Stache::generateId())
+            ->slug('half-price')
+            ->data([
+                'title'              => 'Half Price',
+                'redeemed'           => 0,
+                'value'              => 50,
+                'type'               => 'percentage',
+                'minimum_cart_value' => null,
+            ])
+            ->save();
+
+        $coupon = Entry::findBySlug('half-price', 'coupons');
 
         $data = [
             'code' => 'half-price',

--- a/tests/Http/Controllers/CouponControllerTest.php
+++ b/tests/Http/Controllers/CouponControllerTest.php
@@ -29,6 +29,8 @@ class CouponControllerTest extends TestCase
     /** @test */
     public function can_store_coupon()
     {
+        $this->markTestIncomplete();
+
         Event::fake();
 
         $this->buildCartWithProducts();

--- a/tests/Http/Controllers/CouponControllerTest.php
+++ b/tests/Http/Controllers/CouponControllerTest.php
@@ -270,6 +270,7 @@ class CouponControllerTest extends TestCase
                 'minimum_cart_value' => null,
             ])
             ->save();
+
         $coupon = Entry::findBySlug('half-price', 'coupons');
 
         $this->cart->data([
@@ -306,6 +307,7 @@ class CouponControllerTest extends TestCase
                 'minimum_cart_value' => null,
             ])
             ->save();
+
         $coupon = Entry::findBySlug('half-price', 'coupons');
 
         $this->cart->data([


### PR DESCRIPTION
## Description

<!-- What does this PR change? Has it added anything? Is there any questions you have? -->

This pull request adds the ability to have coupons which are only valid if certain products are in the cart.

## Related Issues

<!-- 
  Does this PR fix an open issue? 
  Link it with a keyword: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #390.
