### PR TITLE
Product Variant DTO

### DIFF
--- a/src/Contracts/Coupon.php
+++ b/src/Contracts/Coupon.php
@@ -30,7 +30,7 @@ interface Coupon
 
     public function fresh(): self;
 
-    public function data(array $data = []);
+    public function data($data = null);
 
     public function has(string $key): bool;
 

--- a/src/Contracts/Customer.php
+++ b/src/Contracts/Customer.php
@@ -30,7 +30,7 @@ interface Customer
 
     public function fresh(): self;
 
-    public function data(array $data = []);
+    public function data($data = null);
 
     public function has(string $key): bool;
 

--- a/src/Contracts/Order.php
+++ b/src/Contracts/Order.php
@@ -32,7 +32,7 @@ interface Order
 
     public function fresh(): self;
 
-    public function data(array $data = []);
+    public function data($data = null);
 
     public function has(string $key): bool;
 

--- a/src/Contracts/Product.php
+++ b/src/Contracts/Product.php
@@ -30,7 +30,7 @@ interface Product
 
     public function fresh(): self;
 
-    public function data(array $data = []);
+    public function data($data = null);
 
     public function has(string $key): bool;
 

--- a/src/Contracts/Product.php
+++ b/src/Contracts/Product.php
@@ -2,6 +2,9 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Contracts;
 
+use DoubleThreeDigital\SimpleCommerce\Products\ProductVariant;
+use Illuminate\Support\Collection;
+
 interface Product
 {
     public function all();
@@ -44,7 +47,9 @@ interface Product
 
     public function purchasableType(): string;
 
-    public function variantOption(string $optionKey): ?array;
+    public function variants(): Collection;
+
+    public function variant(string $optionKey): ?ProductVariant;
 
     public function isExemptFromTax(): bool;
 

--- a/src/Facades/Product.php
+++ b/src/Facades/Product.php
@@ -8,8 +8,8 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static array all()
  * @method static \Statamic\Entries\EntryCollection query()
- * @method static \DoubleThreeDigital\SimpleCommerce\Contracts\Order find(string $id)
- * @method static \DoubleThreeDigital\SimpleCommerce\Contracts\Order create(array $data = [], string $site = '')
+ * @method static \DoubleThreeDigital\SimpleCommerce\Contracts\Product find(string $id)
+ * @method static \DoubleThreeDigital\SimpleCommerce\Contracts\Product create(array $data = [], string $site = '')
  */
 class Product extends Facade
 {

--- a/src/Orders/Calculator.php
+++ b/src/Orders/Calculator.php
@@ -68,9 +68,9 @@ class Calculator implements Contract
         $product = ProductAPI::find($lineItem['product']);
 
         if ($product->purchasableType() === 'variants') {
-            $productPrice = $product->variantOption(
+            $productPrice = $product->variant(
                 isset($lineItem['variant']['variant']) ? $lineItem['variant']['variant'] : $lineItem['variant']
-            )['price'];
+            )->price();
 
             // Ensure we strip any decimals from price
             $productPrice = (int) str_replace('.', '', (string) $productPrice);

--- a/src/Products/ProductVariant.php
+++ b/src/Products/ProductVariant.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Products;
+
+use DoubleThreeDigital\SimpleCommerce\Support\Traits\HasData;
+use Statamic\Support\Traits\FluentlyGetsAndSets;
+
+class ProductVariant
+{
+    use HasData, FluentlyGetsAndSets;
+
+    protected $key;
+    protected $name;
+    protected $price;
+    protected $data;
+
+    public function key()
+    {
+        return $this
+            ->fluentlyGetOrSet('key')
+            ->args(func_get_args());
+    }
+
+    public function name()
+    {
+        return $this
+            ->fluentlyGetOrSet('name')
+            ->args(func_get_args());
+    }
+
+    public function price()
+    {
+        return $this
+            ->fluentlyGetOrSet('price')
+            ->args(func_get_args());
+    }
+}

--- a/src/Support/Traits/HasData.php
+++ b/src/Support/Traits/HasData.php
@@ -4,9 +4,9 @@ namespace DoubleThreeDigital\SimpleCommerce\Support\Traits;
 
 trait HasData
 {
-    public function data(array $data = [])
+    public function data($data = null)
     {
-        if ($data === []) {
+        if ($data === null) {
             return $this->data;
         }
 

--- a/tests/Http/Controllers/CartItemControllerTest.php
+++ b/tests/Http/Controllers/CartItemControllerTest.php
@@ -103,8 +103,9 @@ class CartItemControllerTest extends TestCase
                 ],
                 'options' => [
                     [
-                        'key'   => 'Red_Small',
-                        'price' => 1000,
+                        'key'     => 'Red_Small',
+                        'variant' => 'Red Small',
+                        'price'   => 1000,
                     ],
                 ],
             ],
@@ -365,8 +366,9 @@ class CartItemControllerTest extends TestCase
                 ],
                 'options' => [
                     [
-                        'key'   => 'Red_Small',
-                        'price' => 1000,
+                        'key'     => 'Red_Small',
+                        'variant' => 'Red Small',
+                        'price'   => 1000,
                     ],
                 ],
             ],
@@ -428,12 +430,14 @@ class CartItemControllerTest extends TestCase
                 ],
                 'options' => [
                     [
-                        'key'   => 'Red_Small',
-                        'price' => 1000,
+                        'key'     => 'Red_Small',
+                        'variant' => 'Red Small',
+                        'price'   => 1000,
                     ],
                     [
-                        'key'   => 'Red_Medium',
-                        'price' => 1000,
+                        'key'     => 'Red_Medium',
+                        'variant' => 'Red Medium',
+                        'price'   => 1000,
                     ],
                 ],
             ],


### PR DESCRIPTION
## Description

<!-- What does this PR change? Has it added anything? Is there any questions you have? -->

This pull request adds a new data transfer object for product variants. It also makes some changes to the `Product` contract and makes the `data` method respect the new `null` state as it was causing issues otherwise.
