### PR TITLE
Return Collection instance from data() method

### DIFF
--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -100,7 +100,7 @@ class StripeGateway extends BaseGateway implements Gateway
     {
         $this->setUpWithStripe();
 
-        $charge = PaymentIntent::retrieve($order->data()['gateway_data']['intent']);
+        $charge = PaymentIntent::retrieve($order->data()->get('gateway_data')['intent']);
 
         return new GatewayResponse(true, $charge->toArray());
     }
@@ -115,7 +115,7 @@ class StripeGateway extends BaseGateway implements Gateway
         }
 
         $refund = Refund::create([
-            'payment_intent' => $order->data()['gateway_data']['intent'],
+            'payment_intent' => $order->data()->get('gateway_data')['intent'],
         ]);
 
         return new GatewayResponse(true, $refund->toArray());

--- a/src/Orders/Calculator.php
+++ b/src/Orders/Calculator.php
@@ -18,7 +18,7 @@ class Calculator implements Contract
     public function calculate(OrderContract $order): array
     {
         if ($order->has('is_paid') && $order->get('is_paid') === true) {
-            return $order->data();
+            return $order->data()->toArray();
         }
 
         $this->order = $order;

--- a/src/Support/Traits/HasData.php
+++ b/src/Support/Traits/HasData.php
@@ -13,6 +13,10 @@ trait HasData
         return $this
             ->fluentlyGetOrSet('data')
             ->setter(function ($data) {
+                if (! $this->data) {
+                    return $data;
+                }
+
                 return array_merge($this->data, $data);
             })
             ->getter(function ($data) {

--- a/src/Support/Traits/HasData.php
+++ b/src/Support/Traits/HasData.php
@@ -2,34 +2,30 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Support\Traits;
 
+use Statamic\Support\Traits\FluentlyGetsAndSets;
+
 trait HasData
 {
+    use FluentlyGetsAndSets;
+
     public function data($data = null)
     {
-        if ($data === null) {
-            return $this->data;
-        }
-
-        foreach ($data as $key => $value) {
-            $this->data[$key] = $value;
-        }
-
-        return $this;
+        return $this
+            ->fluentlyGetOrSet('data')
+            ->getter(function ($data) {
+                return collect($data);
+            })
+            ->args(func_get_args());
     }
 
     public function has(string $key): bool
     {
-        return isset($this->data[$key])
-            && !is_null($this->data[$key]);
+        return $this->data()->has($key);
     }
 
     public function get(string $key)
     {
-        if (!$this->has($key)) {
-            return null;
-        }
-
-        return $this->data[$key];
+        return $this->data()->get($key);
     }
 
     public function set(string $key, $value): self
@@ -42,6 +38,6 @@ trait HasData
 
     public function toArray(): array
     {
-        return $this->data;
+        return $this->data()->toArray();
     }
 }

--- a/src/Support/Traits/HasData.php
+++ b/src/Support/Traits/HasData.php
@@ -12,6 +12,9 @@ trait HasData
     {
         return $this
             ->fluentlyGetOrSet('data')
+            ->setter(function ($data) {
+                return array_merge($this->data, $data);
+            })
             ->getter(function ($data) {
                 return collect($data);
             })

--- a/tests/Support/Traits/HasDataTest.php
+++ b/tests/Support/Traits/HasDataTest.php
@@ -24,10 +24,10 @@ class HasDataTest extends TestCase
 
         $data = $this->trait->data();
 
-        $this->assertIsArray($data);
+        $this->assertIsObject($data);
 
-        $this->assertArrayHasKey('foo', $data);
-        $this->assertArrayHasKey('fiz', $data);
+        $this->assertTrue($data->has('foo'));
+        $this->assertTrue($data->has('fiz'));
     }
 
     /** @test */


### PR DESCRIPTION
## Description

<!-- What does this PR change? Has it added anything? Is there any questions you have? -->

The `data()` method provided by the `HasData` trait has been swapped out to return a Collection instance, rather than an array.

This means this change is a breaking change to existing code. This PR also includes updates to existing code where it could cause issues.
