### PR TITLE
Write an (ugly) update script for adding fields to blueprints

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -59,6 +59,7 @@ class ServiceProvider extends AddonServiceProvider
 
     protected $updateScripts = [
         UpdateScripts\MigrateLineItemMetadata::class,
+        UpdateScripts\UpdateBlueprints::class,
     ];
 
     public function boot()

--- a/src/UpdateScripts/UpdateBlueprints.php
+++ b/src/UpdateScripts/UpdateBlueprints.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts;
+
+use Statamic\Facades\Blueprint;
+use Statamic\UpdateScripts\UpdateScript;
+
+class UpdateBlueprints extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('2.3.0');
+    }
+
+    public function update()
+    {
+        $this->updateOrderBlueprint();
+    }
+
+    protected function updateOrderBlueprint()
+    {
+        $orderCollection = config('simple-commerce.collections.orders');
+        $orderCollectionSingular = str_singular($orderCollection);
+
+        $blueprint = Blueprint::find("collections.{$orderCollection}.{$orderCollectionSingular}");
+
+        if (! $blueprint) {
+            $this->console()->error("Failed to update order blueprint.");
+        }
+
+        $contents = $blueprint->fileData();
+
+        // Add metadata field to line items
+        foreach ($contents['sections'] as $sectionKey => $section) {
+            foreach ($section['fields'] as $sectionFieldKey => $sectionField) {
+                if ($sectionField['handle'] === 'items') {
+                    $metaDataFieldAlreadyExists = collect($sectionField['field']['fields'])
+                        ->where('handle', 'metadata')
+                        ->count();
+
+                    if ($metaDataFieldAlreadyExists === 0) {
+                        $contents['sections'][$sectionKey]['fields'][$sectionFieldKey]['field']['fields'][] = [
+                            'handle' => 'metadata',
+                            'field' => [
+                                'type' => 'array',
+                                'listable' => false,
+                                'display' => 'Metadata',
+                                'mode' => 'dynamic',
+                                'icon' => 'array',
+                            ],
+                        ];
+                    }
+                }
+            }
+        }
+
+        $blueprint
+            ->setContents($contents)
+            ->save();
+
+        $this->console()->info("Successfully updated order blueprint.");
+    }
+}


### PR DESCRIPTION
## Description

<!-- What does this PR change? Has it added anything? Is there any questions you have? -->

This pull request adds a new v2.3 update script that will add new fields to blueprints. Right now, it's only adding a `metadata` field to the `items` grid.

_(yes, I forgot to create a new branch for this change, whoopsie!)_
