### PR TITLE
More notification triggers

### DIFF
--- a/src/Listeners/SendConfiguredNotifications.php
+++ b/src/Listeners/SendConfiguredNotifications.php
@@ -2,38 +2,69 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Listeners;
 
-use DoubleThreeDigital\SimpleCommerce\Customers\Customer;
 use DoubleThreeDigital\SimpleCommerce\Events\OrderPaid;
-use DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderPaid;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
 
 class SendConfiguredNotifications implements ShouldQueue
 {
     public function handle(OrderPaid $event)
     {
-        foreach (config('simple-commerce.notifications.order_paid') as $notification => $notificationConfig) {
-            if ($notificationConfig['to'] === 'customer') {
-                if ($customer = $event->order->customer()) {
-                    Notification::route('mail', $customer->email())
-                        ->notify(new CustomerOrderPaid($event->order));
-                } elseif ($event->order->has('email')) {
-                    (new Customer)
-                        ->set('email', $this->order->get('customer'))
-                        ->notify(new $notification($event->order));
+        $eventName = Str::of(get_class($event))
+            ->afterLast('\\')
+            ->snake()
+            ->__toString();
+
+        $notifications = collect(Config::get('simple-commerce.notifications'))->get($eventName);
+
+        foreach ($notifications as $notification => $config) {
+            $freshNotification = null;
+
+            $notifiables = $this->getNotifiables($config, $notification, $event);
+            $notification = new $notification($event->order);
+
+            foreach ($notifiables as $channel => $route) {
+                if (! $freshNotification) {
+                    $freshNotification = Notification::route($channel, $route);
+                } else {
+                    $freshNotification->route($channel, $route);
                 }
-
-                continue;
             }
 
-            if (is_string($notificationConfig['to'])) {
-                Notification::route('mail', $notificationConfig['to'])
-                    ->notify(new $notification($event->order));
-
-                continue;
-            }
-
-            throw new \Exception("You did not specify a recipient for the notification [{$notification}]");
+            optional($freshNotification)->notify($notification);
         }
+    }
+
+    protected function getNotifiables(array $config, $notification, $event): array
+    {
+        if ($config['to'] === 'customer') {
+            if ($customer = $event->order->customer()) {
+                return [
+                    ['channel' => 'mail', 'route' => $customer->email()],
+                ];
+            }
+
+            if ($email = $event->order->get('email')) {
+                return [
+                    ['channel' => 'mail', 'route' => $email],
+                ];
+            }
+
+            if ($email = $event->order->get('customer')) {
+                return [
+                    ['channel' => 'mail', 'route' => $email],
+                ];
+            }
+        }
+
+        if (is_string($config['to'])) {
+            return [
+                ['channel' => 'mail', 'route' => $config['to']]
+            ];
+        }
+
+        throw new \Exception("No notifiable specified for [{$notification}]");
     }
 }

--- a/src/Listeners/SendConfiguredNotifications.php
+++ b/src/Listeners/SendConfiguredNotifications.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
+use ReflectionClass;
 
 class SendConfiguredNotifications implements ShouldQueue
 {
@@ -21,6 +22,9 @@ class SendConfiguredNotifications implements ShouldQueue
 
         foreach ($notifications as $notification => $config) {
             $freshNotification = null;
+
+            // $reflection = new ReflectionClass($notification);
+            // $constructor = $reflection->getConstructor();
 
             $notifiables = $this->getNotifiables($config, $notification, $event);
             $notification = new $notification($event->order);

--- a/src/Listeners/SendConfiguredNotifications.php
+++ b/src/Listeners/SendConfiguredNotifications.php
@@ -8,7 +8,7 @@ use DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderPaid;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Notification;
 
-class SendOrderPaidNotifications implements ShouldQueue
+class SendConfiguredNotifications implements ShouldQueue
 {
     public function handle(OrderPaid $event)
     {

--- a/src/Listeners/SendOrderPaidNotifications.php
+++ b/src/Listeners/SendOrderPaidNotifications.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Listeners;
 
 use DoubleThreeDigital\SimpleCommerce\Customers\Customer;
 use DoubleThreeDigital\SimpleCommerce\Events\OrderPaid;
+use DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderPaid;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Notification;
 
@@ -14,7 +15,8 @@ class SendOrderPaidNotifications implements ShouldQueue
         foreach (config('simple-commerce.notifications.order_paid') as $notification => $notificationConfig) {
             if ($notificationConfig['to'] === 'customer') {
                 if ($customer = $event->order->customer()) {
-                    $customer->notify(new $notification($event->order));
+                    Notification::route('mail', $customer->email())
+                        ->notify(new CustomerOrderPaid($event->order));
                 } elseif ($event->order->has('email')) {
                     (new Customer)
                         ->set('email', $this->order->get('customer'))

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -36,6 +36,12 @@ class ServiceProvider extends AddonServiceProvider
         Events\OrderPaid::class => [
             Listeners\SendConfiguredNotifications::class,
         ],
+        Events\StockRunningLow::class => [
+            Listeners\SendConfiguredNotifications::class,
+        ],
+        Events\StockRunOut::class => [
+            Listeners\SendConfiguredNotifications::class,
+        ],
     ];
 
     protected $routes = [

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -34,7 +34,7 @@ class ServiceProvider extends AddonServiceProvider
             Listeners\EnforceBlueprintFields::class,
         ],
         Events\OrderPaid::class => [
-            Listeners\SendOrderPaidNotifications::class,
+            Listeners\SendConfiguredNotifications::class,
         ],
     ];
 


### PR DESCRIPTION
## Description

<!-- What does this PR change? Has it added anything? Is there any questions you have? -->

This pull request adds a couple of new notification triggers to the SC notifications system.

## Triggers

* [X] `OrderPaid`
* [x] `StockRunningLow`
* [x] `StockRunOut`

## Related Issues

<!-- 
  Does this PR fix an open issue? 
  Link it with a keyword: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #423
