### PR TITLE
Use the real Stripe API to run tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,3 +42,6 @@ jobs:
 
       - name: Run PHPUnit
         run: composer test
+        env:
+          STRIPE_KEY: ${{ secrets.STRIPE_KEY }}
+          STRIPE_SECRET: ${{ secrets.STRIPE_SECRET }}

--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -29,6 +29,13 @@ class BaseGateway
         return collect($this->config);
     }
 
+    public function setConfig(array $config)
+    {
+        $this->config = $config;
+
+        return $this;
+    }
+
     public function handle(): string
     {
         return $this->handle;

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -246,7 +246,7 @@ class StripeGatewayTest extends TestCase
         $order = $order->fresh();
 
         $this->assertTrue($order->get('is_paid'));
-        $this->assertNotNull($order->get('paud_date'));
+        $this->assertNotNull($order->get('paid_date'));
     }
 
     /** @test */

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -5,6 +5,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Tests\Gateways\Builtin;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Prepare;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway;
+use DoubleThreeDigital\SimpleCommerce\Gateways\Response as GatewayResponse;
 use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
 use Illuminate\Http\Request;
 use Statamic\Facades\Collection;
@@ -40,14 +41,16 @@ class StripeGatewayTest extends TestCase
     /** @test */
     public function can_prepare()
     {
-        $this->markTestSkipped();
+        // $this->markTestSkipped();
 
         $prepare = $this->gateway->prepare(new Prepare(
             new Request(),
-            Order::create()->entry()
+            Order::create()
         ));
 
         $this->assertIsObject($prepare);
+        $this->assertTrue($prepare instanceof GatewayResponse);
+
         $this->assertTrue($prepare->success());
         $this->assertArrayHasKey('intent', $prepare->data());
         $this->assertArrayHasKey('client_secret', $prepare->data());

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Tests\Gateways\Builtin;
 
 use DoubleThreeDigital\SimpleCommerce\Gateways\Prepare;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Response as GatewayResponse;
 use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
@@ -43,9 +44,22 @@ class StripeGatewayTest extends TestCase
     {
         // $this->markTestSkipped();
 
+        $product = Product::create(['title' => 'Concert Ticket', 'price' => 5500]);
+
         $prepare = $this->gateway->prepare(new Prepare(
             new Request(),
-            Order::create()
+            $order = Order::create([
+                'items' => [
+                    [
+                        'id' => app('stache')->generateId(),
+                        'product' => $product->id,
+                        'quantity' => 1,
+                        'total' => 5500,
+                        'metadata' => [],
+                    ],
+                ],
+                'grand_total' => 5500,
+            ])
         ));
 
         $this->assertIsObject($prepare);
@@ -54,6 +68,18 @@ class StripeGatewayTest extends TestCase
         $this->assertTrue($prepare->success());
         $this->assertArrayHasKey('intent', $prepare->data());
         $this->assertArrayHasKey('client_secret', $prepare->data());
+    }
+
+    /** @test */
+    public function can_prepare_with_customer_email()
+    {
+        //
+    }
+
+    /** @test */
+    public function can_prepare_with_receipt_email()
+    {
+        //
     }
 
     /** @test */

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -17,7 +17,13 @@ class StripeGatewayTest extends TestCase
     {
         parent::setUp();
 
-        $this->gateway = new StripeGateway();
+        if (! env('STRIPE_SECRET')) {
+            $this->markTestSkipped("No STRIPE_SECRET has been defined, tests has been skipped.");
+        }
+
+        $this->gateway = new StripeGateway([
+            'secret' => env('STRIPE_SECRET'),
+        ]);
 
         Collection::make('orders')->title('Order')->save();
     }

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -2,14 +2,20 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Tests\Gateways\Builtin;
 
+use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Prepare;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway;
+use DoubleThreeDigital\SimpleCommerce\Gateways\Purchase;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Response as GatewayResponse;
 use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
 use Illuminate\Http\Request;
 use Statamic\Facades\Collection;
+use Stripe\Customer as StripeCustomer;
+use Stripe\PaymentIntent;
+use Stripe\PaymentMethod;
+use Stripe\Stripe;
 
 class StripeGatewayTest extends TestCase
 {
@@ -18,10 +24,6 @@ class StripeGatewayTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-
-        if (! env('STRIPE_SECRET')) {
-            $this->markTestSkipped("No STRIPE_SECRET has been defined, tests has been skipped.");
-        }
 
         $this->gateway = new StripeGateway([
             'secret' => env('STRIPE_SECRET'),
@@ -42,7 +44,9 @@ class StripeGatewayTest extends TestCase
     /** @test */
     public function can_prepare()
     {
-        // $this->markTestSkipped();
+        if (! env('STRIPE_SECRET')) {
+            $this->markTestSkipped("Skipping, no Stripe Secret has been defined for this environment.");
+        }
 
         $product = Product::create(['title' => 'Concert Ticket', 'price' => 5500]);
 
@@ -59,6 +63,7 @@ class StripeGatewayTest extends TestCase
                     ],
                 ],
                 'grand_total' => 5500,
+                'title' => '#0001',
             ])
         ));
 
@@ -68,24 +73,180 @@ class StripeGatewayTest extends TestCase
         $this->assertTrue($prepare->success());
         $this->assertArrayHasKey('intent', $prepare->data());
         $this->assertArrayHasKey('client_secret', $prepare->data());
+
+        $paymentIntent = PaymentIntent::retrieve($prepare->data()['intent']);
+
+        $this->assertSame($paymentIntent->id, $prepare->data()['intent']);
+        $this->assertSame($paymentIntent->amount, $order->get('grand_total'));
+        $this->assertNull($paymentIntent->customer);
+        $this->assertNull($paymentIntent->receipt_email);
     }
 
     /** @test */
-    public function can_prepare_with_customer_email()
+    public function can_prepare_with_customer()
     {
-        //
+        if (! env('STRIPE_SECRET')) {
+            $this->markTestSkipped("Skipping, no Stripe Secret has been defined for this environment.");
+        }
+
+        $product = Product::create(['title' => 'Theatre Ticket', 'price' => 1299]);
+        $customer = Customer::create(['name' => 'George', 'email' => 'george@example.com']);
+
+        $prepare = $this->gateway->prepare(new Prepare(
+            new Request(),
+            $order = Order::create([
+                'items' => [
+                    [
+                        'id' => app('stache')->generateId(),
+                        'product' => $product->id,
+                        'quantity' => 1,
+                        'total' => 1299,
+                        'metadata' => [],
+                    ],
+                ],
+                'grand_total' => 1299,
+                'title' => '#0002',
+                'customer' => $customer->id(),
+            ])
+        ));
+
+        $this->assertIsObject($prepare);
+        $this->assertTrue($prepare instanceof GatewayResponse);
+
+        $this->assertTrue($prepare->success());
+        $this->assertArrayHasKey('intent', $prepare->data());
+        $this->assertArrayHasKey('client_secret', $prepare->data());
+
+        $paymentIntent = PaymentIntent::retrieve($prepare->data()['intent']);
+
+        $this->assertSame($paymentIntent->id, $prepare->data()['intent']);
+        $this->assertSame($paymentIntent->amount, $order->get('grand_total'));
+        $this->assertNotNull($paymentIntent->customer);
+        $this->assertNull($paymentIntent->receipt_email);
+
+        $stripeCustomer = StripeCustomer::retrieve($paymentIntent->customer);
+
+        $this->assertSame($stripeCustomer->id, $paymentIntent->customer);
+        $this->assertSame($stripeCustomer->name, 'George');
+        $this->assertSame($stripeCustomer->email, 'george@example.com');
     }
 
     /** @test */
     public function can_prepare_with_receipt_email()
     {
-        //
+        if (! env('STRIPE_SECRET')) {
+            $this->markTestSkipped("Skipping, no Stripe Secret has been defined for this environment.");
+        }
+
+        $product = Product::create(['title' => 'Talent Show Ticket', 'price' => 1299]);
+        $customer = Customer::create(['name' => 'George', 'email' => 'george@example.com']);
+
+        $this->gateway->setConfig([
+            'secret' => env('STRIPE_SECRET'),
+            'receipt_email' => true,
+        ]);
+
+        $prepare = $this->gateway->prepare(new Prepare(
+            new Request(),
+            $order = Order::create([
+                'items' => [
+                    [
+                        'id' => app('stache')->generateId(),
+                        'product' => $product->id,
+                        'quantity' => 1,
+                        'total' => 1299,
+                        'metadata' => [],
+                    ],
+                ],
+                'grand_total' => 1299,
+                'title' => '#0003',
+                'customer' => $customer->id(),
+            ])
+        ));
+
+        $this->assertIsObject($prepare);
+        $this->assertTrue($prepare instanceof GatewayResponse);
+
+        $this->assertTrue($prepare->success());
+        $this->assertArrayHasKey('intent', $prepare->data());
+        $this->assertArrayHasKey('client_secret', $prepare->data());
+
+        $paymentIntent = PaymentIntent::retrieve($prepare->data()['intent']);
+
+        $this->assertSame($paymentIntent->id, $prepare->data()['intent']);
+        $this->assertSame($paymentIntent->amount, $order->get('grand_total'));
+        $this->assertNotNull($paymentIntent->customer);
+        $this->assertSame($paymentIntent->receipt_email, $customer->email());
+
+        $stripeCustomer = StripeCustomer::retrieve($paymentIntent->customer);
+
+        $this->assertSame($stripeCustomer->id, $paymentIntent->customer);
+        $this->assertSame($stripeCustomer->name, 'George');
+        $this->assertSame($stripeCustomer->email, 'george@example.com');
     }
 
     /** @test */
     public function can_purchase()
     {
-        // TODO: Write test for this that doesn't need to touch the Stripe API
+        if (! env('STRIPE_SECRET')) {
+            $this->markTestSkipped("Skipping, no Stripe Secret has been defined for this environment.");
+        }
+
+        Stripe::setApiKey(env('STRIPE_SECRET'));
+
+        $product = Product::create(['title' => 'Zoo Ticket', 'price' => 1234]);
+
+        $order = Order::create([
+            'items' => [
+                [
+                    'id' => app('stache')->generateId(),
+                    'product' => $product->id,
+                    'quantity' => 1,
+                    'total' => 1234,
+                    'metadata' => [],
+                ],
+            ],
+            'grand_total' => 1234,
+            'title' => '#0004',
+            'stripe' => [
+                'intent' => $paymentIntent = PaymentIntent::create([
+                    'amount' => 1234,
+                    'currency' => 'GBP',
+                ])->id,
+            ],
+        ]);
+
+        $paymentMethod = PaymentMethod::create([
+            'type' => 'card',
+            'card' => [
+                'number' => '4242424242424242',
+                'exp_month' => 7,
+                'exp_year' => 2022,
+                'cvc' => '314',
+            ],
+        ]);
+
+        PaymentIntent::retrieve($paymentIntent)->confirm([
+            'payment_method' => $paymentMethod->id,
+        ]);
+
+        $request = new Request(['payment_method' => $paymentMethod->id]);
+
+        $purchase = $this->gateway->purchase(new Purchase($request, $order));
+
+        $this->assertIsObject($purchase);
+        $this->assertTrue($purchase instanceof GatewayResponse);
+
+        $this->assertSame($purchase->data()['id'], $paymentMethod->id);
+        $this->assertSame($purchase->data()['object'], $paymentMethod->object);
+        // $this->assertSame($purchase->data()['card'], $paymentMethod->card);
+        $this->assertSame($purchase->data()['customer'], $paymentMethod->customer);
+        $this->assertSame($purchase->data()['livemode'], $paymentMethod->livemode);
+
+        $order = $order->fresh();
+
+        $this->assertTrue($order->get('is_paid'));
+        $this->assertNotNull($order->get('paud_date'));
     }
 
     /** @test */


### PR DESCRIPTION
## Description

<!-- What does this PR change? Has it added anything? Is there any questions you have? -->

This pull request wires up GH Actions so it can run tests of the Stripe Gateway against the real Stripe API (using a test mode account, of course). It also introduces some additional tests around the Stripe Gateway to ensure the payment flow works as expected from the given inputs.

