### PR TITLE
Fix/tax calculation

### DIFF
--- a/src/Orders/Calculator.php
+++ b/src/Orders/Calculator.php
@@ -114,8 +114,8 @@ class Calculator implements Contract
         $itemTotal = $lineItem['total'];
 
         if ($taxConfiguration['included_in_prices']) {
-            $taxAmount = ($itemTotal / 100) * ($taxConfiguration['rate'] / (100 + $taxConfiguration['rate']));
-            $itemTax = (int) round($taxAmount * 100);
+            $taxAmount = $itemTotal / (100 + $taxConfiguration['rate']) * $taxConfiguration['rate'];
+            $itemTax = (int) round($taxAmount);
 
             $lineItem['total'] -= $itemTax;
             $data['tax_total'] += $itemTax;

--- a/src/Orders/Calculator.php
+++ b/src/Orders/Calculator.php
@@ -112,15 +112,16 @@ class Calculator implements Contract
         }
 
         $itemTotal = $lineItem['total'];
-        $taxAmount = ($itemTotal / 100) * ($taxConfiguration['rate'] / (100 + $taxConfiguration['rate']));
 
         if ($taxConfiguration['included_in_prices']) {
+            $taxAmount = ($itemTotal / 100) * ($taxConfiguration['rate'] / (100 + $taxConfiguration['rate']));
             $itemTax = (int) round($taxAmount * 100);
 
             $lineItem['total'] -= $itemTax;
             $data['tax_total'] += $itemTax;
         } else {
-            $data['tax_total'] += (int) round($taxAmount * 100);
+            $taxAmount = $itemTotal * ($taxConfiguration['rate'] / 100);
+            $data['tax_total'] += (int) round($taxAmount);
         }
 
         return [


### PR DESCRIPTION
## Description

Refactored the calculator to correctly calculate taxes for `included_in_prices: false`.

Taxes = Amount * TaxRate/100

Simplified the calculation for `included_in_prices: true`

Taxes = Amount / (TaxRate+100) * TaxRate

## Related Issues

None, but related to PR #438 

