### PR TITLE
Coupon Total should be based on items total, not the overall grand total

### DIFF
--- a/src/Orders/Calculator.php
+++ b/src/Orders/Calculator.php
@@ -53,11 +53,11 @@ class Calculator implements Contract
             })
             ->toArray();
 
+        $data = $this->calculateOrderCoupons($data)['data'];
+
         $data = $this->calculateOrderShipping($data)['data'];
 
-        $data['grand_total'] = ($data['items_total'] + $data['shipping_total'] + $data['tax_total']);
-
-        $data = $this->calculateOrderCoupons($data)['data'];
+        $data['grand_total'] = (($data['items_total'] - $data['coupon_total']) + $data['shipping_total'] + $data['tax_total']);
 
         return $data;
     }
@@ -159,14 +159,12 @@ class Calculator implements Contract
 
             // Otherwise do all the other stuff...
             if ($coupon->get('type') === 'percentage') {
-                $data['coupon_total'] = (int) (($value * $data['grand_total']) / 100);
+                $data['coupon_total'] = (int) (($value * $data['items_total']) / 100);
             }
 
             if ($coupon->get('type') === 'fixed') {
-                $data['coupon_total'] = (int) $data['grand_total'] - ($data['grand_total'] - $value);
+                $data['coupon_total'] = (int) $data['items_total'] - ($data['items_total'] - $value);
             }
-
-            $data['grand_total'] = (int) str_replace('.', '', (string) ($data['grand_total'] - $data['coupon_total']));
         }
 
         return [

--- a/tests/Orders/CalculatorTest.php
+++ b/tests/Orders/CalculatorTest.php
@@ -464,11 +464,11 @@ class CalculatorTest extends TestCase
 
         $this->assertIsArray($calculate);
 
-        $this->assertSame($calculate['grand_total'], 1325);
+        $this->assertSame($calculate['grand_total'], 1650);
         $this->assertSame($calculate['items_total'], 2000);
         $this->assertSame($calculate['shipping_total'], 250);
         $this->assertSame($calculate['tax_total'], 400);
-        $this->assertSame($calculate['coupon_total'], 1325);
+        $this->assertSame($calculate['coupon_total'], 1000);
 
         $this->assertSame($calculate['items'][0]['total'], 2000);
     }


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request changes how Simple Commerce calculates the `coupon_total`. 

Right now, the `coupon_total` will be calculated at the end of the calculation process and will get 20% (or whatever the coupon is for) of the `grand_total` amount.

With this PR in place, the `coupon_total` amount will be calculated at the end of the calculation process for line items and 20% of the `items_total` will be the `coupon_total`.

## Related Issues

<!-- 
  Does this PR fix any open issues? 
  -- If so, please do something like this: 'Closes #1'
-->

Closes #453