### PR TITLE
Prerequisite Products

### DIFF
--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -82,16 +82,22 @@ class CartItemController extends BaseActionController
                 return $this->withErrors($request, __('Please login/register before purchasing this product.'));
             }
 
+            $prerequisiteProduct = Product::find($product->get('prerequisite_product'));
+
             $hasPurchasedPrerequisiteProduct = $customer->orders()
                 ->filter(function ($order) {
                     return $order->get('is_paid') === true;
                 })
-                ->filter(function ($order) {
-                    // return $order
-
-                    dd($order);
+                ->filter(function ($order) use ($product) {
+                    return collect($order->get('items'))
+                        ->where('product', $product->get('prerequisite_product'))
+                        ->count() > 0;
                 })
                 ->count() > 0;
+
+            if (! $hasPurchasedPrerequisiteProduct) {
+                return $this->withErrors($request, __("Before purchasing this product, you must purchase {$prerequisiteProduct->title()} first."));
+            }
         }
 
         // Ensure the product doesn't already exist in the cart

--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -40,10 +40,14 @@ class CartItemController extends BaseActionController
                     throw new CustomerNotFound("Customer with ID [{$request->get('customer')}] could not be found.");
                 }
             } catch (CustomerNotFound $e) {
-                $customer = Customer::create([
-                    'name'  => isset($request->get('customer')['name']) ? $request->get('customer')['name'] : '',
-                    'email' => $request->get('customer')['email'],
-                ], $this->guessSiteFromRequest()->handle());
+                if (is_array($request->get('customer'))) {
+                    $customer = Customer::create([
+                        'name'  => isset($request->get('customer')['name']) ? $request->get('customer')['name'] : $request->get('customer')['email'],
+                        'email' => $request->get('customer')['email'],
+                    ], $this->guessSiteFromRequest()->handle());
+                } elseif (is_string($request->get('customer'))) {
+                    $customer = Customer::find($request->get('customer'));
+                }
             }
 
             $cart->data([
@@ -54,7 +58,7 @@ class CartItemController extends BaseActionController
                 $customer = Customer::findByEmail($request->get('email'));
             } catch (CustomerNotFound $e) {
                 $customer = Customer::create([
-                    'name'  => $request->has('name') ? $request->get('name') : '',
+                    'name'  => $request->get('name') ?? $request->get('email'),
                     'email' => $request->get('email'),
                 ], $this->guessSiteFromRequest()->handle());
             }

--- a/tests/Http/Controllers/CartItemControllerTest.php
+++ b/tests/Http/Controllers/CartItemControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Tests\Http\Controllers;
 
+use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Tests\SetupCollections;
@@ -306,6 +307,59 @@ class CartItemControllerTest extends TestCase
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
         $response->assertRedirect('/checkout');
+        $response->assertSessionHas('simple-commerce-cart');
+
+        $cart = Order::find(session()->get('simple-commerce-cart'));
+
+        $this->assertSame(1000, $cart->data['items_total']);
+
+        $this->assertArrayHasKey('items', $cart->data);
+        $this->assertStringContainsString($product->id, json_encode($cart->data['items']));
+    }
+
+    /** @test */
+    public function can_store_item_where_product_requires_prerequisite_product()
+    {
+        $prerequisiteProduct = Product::create([
+            'title' => 'Dog Food',
+            'price' => 1000,
+        ]);
+
+        $product = Product::create([
+            'title' => 'Dog Food',
+            'price' => 1000,
+            'prerequisite_product' => $prerequisiteProduct->id,
+        ]);
+
+        $customer = Customer::create([
+            'name' => 'Test Test',
+            'email' => 'test@test.test',
+        ]);
+
+        Order::create([
+            'items' => [
+                [
+                    'product' => $prerequisiteProduct->id,
+                    'quantity' => 1,
+                    'total' => 1599,
+                ],
+            ],
+            'items_total' => 1599,
+            'grand_total' => 1599,
+            'customer' => $customer->id,
+        ]);
+
+        $data = [
+            'product'  => $product->id,
+            'quantity' => 1,
+            'customer' => $customer->id,
+        ];
+
+        $response = $this
+            ->from('/products/'.$product->slug)
+            ->post(route('statamic.simple-commerce.cart-items.store'), $data);
+
+        $response->assertRedirect('/products/'.$product->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $cart = Order::find(session()->get('simple-commerce-cart'));

--- a/tests/Http/Controllers/CartItemControllerTest.php
+++ b/tests/Http/Controllers/CartItemControllerTest.php
@@ -384,7 +384,7 @@ class CartItemControllerTest extends TestCase
         // Assert customer has been created with provided details
         $this->assertNotNull($cart->get('customer'));
 
-        $this->assertSame($cart->customer()->name(), '');
+        $this->assertSame($cart->customer()->name(), 'donald@duck.disney');
         $this->assertSame($cart->customer()->email(), 'donald@duck.disney');
     }
 


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request introduces the ability to have 'prerequisite products'. Essentially, meaning you can stop users from purchasing product X unless they've purchased product Z in the past.

## How it works

To enable this feature, add an Entries field to your product blueprint, called `prerequisite_product`. Then on product entries, you can define a certain required product.

Then when a customer attempts to purchase said product, it will check the customer's previous orders to see if they have ever purchased the required product in the past. If they have, they can follow along with the cart process, otherwise a session error will be returned, asking the customer to login to their account/purchase the previous product first.

Bearing in mind, the order will need to have a customer set on it (by defining a `customer` on the order)

## Related Issues

<!-- 
  Does this PR fix any open issues? 
  -- If so, please do something like this: 'Closes #1'
-->

Closes #452

