### PR TITLE
Add an `{{ sc:cart:quantity }}` tag

### DIFF
--- a/docs/tags/cart.md
+++ b/docs/tags/cart.md
@@ -27,7 +27,7 @@ The variables available in this tag are also augmented. Allowing you to get data
 
 To get a count of the items in the customers' cart, use `{{ sc:cart:count }}`.
 
-To get the total quantity of products in the customers' cart, use `{{ sc:cart:quantity }}`.
+To get the total quantity of products in the customers' cart, use `{{ sc:cart:quantityTotal }}`.
 
 ## Check if customer has a cart
 

--- a/docs/tags/cart.md
+++ b/docs/tags/cart.md
@@ -27,6 +27,8 @@ The variables available in this tag are also augmented. Allowing you to get data
 
 To get a count of the items in the customers' cart, use `{{ sc:cart:count }}`.
 
+To get the total quantity of products in the customers' cart, use `{{ sc:cart:quantity }}`.
+
 ## Check if customer has a cart
 
 This tag allows you to check if the current customer has a cart attached to them. It'll return a boolean, meaning you can use it in one of Antlers' if statements.

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -37,7 +37,7 @@ class CartTags extends SubTag
         return $this->getCart()->lineItems()->count();
     }
 
-    public function quantity()
+    public function quantityTotal()
     {
         if (!$this->hasCart()) {
             return 0;

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -37,6 +37,15 @@ class CartTags extends SubTag
         return $this->getCart()->lineItems()->count();
     }
 
+    public function quantity()
+    {
+        if (!$this->hasCart()) {
+            return 0;
+        }
+
+        return $this->getCart()->lineItems()->sum('quantity');
+    }
+
     public function total()
     {
         return $this->grandTotal();

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -110,7 +110,7 @@ class CartTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_cart_items_quantity()
+    public function can_get_cart_items_quantity_total()
     {
         $productOne = Product::create([
             'title' => 'Dog Food',
@@ -127,13 +127,13 @@ class CartTagTest extends TestCase
                 [
                     'id'       => Stache::generateId(),
                     'product'  => $productOne->id,
-                    'quantity' => 5,
+                    'quantity' => 7,
                     'total'    => 1000,
                 ],
                 [
                     'id'       => Stache::generateId(),
                     'product'  => $productTwo->id,
-                    'quantity' => 5,
+                    'quantity' => 4,
                     'total'    => 1200,
                 ],
             ],
@@ -141,7 +141,7 @@ class CartTagTest extends TestCase
 
         $this->fakeCart($cart);
 
-        $this->assertSame('10', (string) $this->tag('{{ sc:cart:quantity }}'));
+        $this->assertSame('11', (string) $this->tag('{{ sc:cart:quantityTotal }}'));
     }
 
     /** @test */

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -110,6 +110,41 @@ class CartTagTest extends TestCase
     }
 
     /** @test */
+    public function can_get_cart_items_quantity()
+    {
+        $productOne = Product::create([
+            'title' => 'Dog Food',
+            'price' => 1000,
+        ]);
+
+        $productTwo = Product::create([
+            'title' => 'Cat Food',
+            'price' => 1200,
+        ]);
+
+        $cart = Order::create([
+            'items' => [
+                [
+                    'id'       => Stache::generateId(),
+                    'product'  => $productOne->id,
+                    'quantity' => 5,
+                    'total'    => 1000,
+                ],
+                [
+                    'id'       => Stache::generateId(),
+                    'product'  => $productTwo->id,
+                    'quantity' => 5,
+                    'total'    => 1200,
+                ],
+            ],
+        ]);
+
+        $this->fakeCart($cart);
+
+        $this->assertSame('10', (string) $this->tag('{{ sc:cart:quantity }}'));
+    }
+
+    /** @test */
     public function can_get_cart_total()
     {
         $cart = Order::create([


### PR DESCRIPTION
## Description

Like `{{ sc:cart:count }}`, but returns the total quantity of products rather than the number of line items. Useful if total quantity would read better/be more logical in a basket summary or something.
