### PR TITLE
PayPal on-site mode

### DIFF
--- a/docs/gateways/paypal.md
+++ b/docs/gateways/paypal.md
@@ -43,6 +43,8 @@ To redirect the customer off to PayPal's checkout page, you can use the `sc:chec
 {{ sc:checkout:paypal redirect="/thanks" error_redirect="/payment-error" }}
 ```
 
+However, bear in mind that where-ever you use that tag, the customer will be redirected away from your site. So it's probably best to have it sitting on it's own page.
+
 ## On-site payment flow
 
 Set the gateway configuretion to use on-site mode:
@@ -76,8 +78,6 @@ A rough example of a PayPal implementation is provided below.
     }).render('#paypal-button');
 </script>
 ```
-
-However, bear in mind that where-ever you use that tag, the customer will be redirected away from your site. So it's probably best to have it sitting on it's own page.
 
 ### Handling PayPal's webhook
 

--- a/docs/gateways/paypal.md
+++ b/docs/gateways/paypal.md
@@ -26,9 +26,9 @@ Make sure that `PAYPAL_ENVIRONMENT` is set to `sandbox` while you're in developm
 
 > It's best practice to use `.env` file for any API keys you need, rather than referencing them directly in your config file. [Review Statamic Docs](https://statamic.dev/configuration#environment-variables).
 
-## Payment flow
+## Off-site payment flow
 
-PayPal is an off-site gateway, which means the customer is redirected onto PayPal's checkout page to complete payment. Here's a quick run down of how the whole process works:
+Here's a quick run down of how the whole process works:
 
 1. After filling out shipping info etc, the store redirects the customer to PayPal
 2. The customer enters their payment information on PayPal's checkout
@@ -41,6 +41,40 @@ To redirect the customer off to PayPal's checkout page, you can use the `sc:chec
 
 ```antlers
 {{ sc:checkout:paypal redirect="/thanks" error_redirect="/payment-error" }}
+```
+
+## On-site payment flow
+
+Set the gateway configuretion to use on-site mode:
+
+```php
+'gateways' => [
+	\DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\PayPalGateway::class => [
+        ///
+        'mode' => 'onsite',
+    ],
+],
+```
+
+The payment form should be included inside your `{{ sc:checkout }}` form, and any PayPal magic should also be wrapped in the `{{ sc:gateways }}` tag to ensure you can make full use of your gateway's configuration values.
+
+A rough example of a PayPal implementation is provided below.
+
+```antlers
+<div id="paypal-button"></div>
+<input id="paypal-payment-id" type="hidden" name="payment_id">
+<script src="https://www.paypal.com/sdk/js?client-id={{ gateway-config:client_id }}&currency={{ paypal.result.currency_code }}"></script>
+<script>
+    paypal.Buttons({
+        createOrder: () => {
+            return Promise.resolve('{{ paypal.result.id }}');
+        },
+        onApprove: (data, actions) => {
+            document.getElementById('paypal-payment-id').value = data.orderID;
+            document.getElementById('checkout-form').submit();
+        },
+    }).render('#paypal-button');
+</script>
 ```
 
 However, bear in mind that where-ever you use that tag, the customer will be redirected away from your site. So it's probably best to have it sitting on it's own page.

--- a/docs/gateways/paypal.md
+++ b/docs/gateways/paypal.md
@@ -45,6 +45,14 @@ To redirect the customer off to PayPal's checkout page, you can use the `sc:chec
 
 However, bear in mind that where-ever you use that tag, the customer will be redirected away from your site. So it's probably best to have it sitting on it's own page.
 
+### Handling the redirect back to your site
+
+On the return back to your site from PayPal, you can have customers redirected to seperate URLs, depending on whether the payment was successful or failed/cancelled.
+
+The `redirect` parameter on the `sc:checkout:paypal` tag will handle the successful payment redirects.
+
+Where as `error_redirect` will handle any other payment states.
+
 ## On-site payment flow
 
 Set the gateway configuretion to use on-site mode:
@@ -79,7 +87,7 @@ A rough example of a PayPal implementation is provided below.
 </script>
 ```
 
-### Handling PayPal's webhook
+## Handling PayPal's webhook
 
 The PayPal gateway has a webhook which is hit by PayPal whenever a payment is made.
 
@@ -101,10 +109,4 @@ protected $except = [
 
 When you're going through the payment flow in your development environment, you will need to use something like Expose or Ngrok to proxy request to your local server. Otherwise, PayPal wouldn't be able to hit the webhook. You will also need to update the `APP_URL` in your `.env`.
 
-### Handling the redirect back to your site
 
-On the return back to your site from PayPal, you can have customers redirected to seperate URLs, depending on whether the payment was successful or failed/cancelled.
-
-The `redirect` parameter on the `sc:checkout:paypal` tag will handle the successful payment redirects.
-
-Where as `error_redirect` will handle any other payment states.

--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -37,7 +37,7 @@ class PayPalGateway extends BaseGateway implements Gateway
 
     public function isOffsiteGateway(): bool
     {
-        return true;
+        return $this->config()->get('mode', 'offsite') === 'offsite';
     }
 
     public function prepare(Prepare $data): Response
@@ -79,26 +79,29 @@ class PayPalGateway extends BaseGateway implements Gateway
 
         return new Response(true, [
             'result' => [
-                'id' => $response->result->id,
+                'id'            => $response->result->id,
+                'currency_code' => $response->result->purchase_units[0]->amount->currency_code,
             ],
-        ], $checkoutUrl->href);
+        ], $this->isOffsiteGateway() ? $checkoutUrl->href : '');
     }
 
     public function purchase(Purchase $data): Response
     {
-        // We don't actually do anything here as PayPal is an
-        // off-site gateway, so it has it's own checkout page.
+        $this->setupPayPal();
 
-        throw new GatewayDoesNotSupportPurchase("Gateway [paypal] does not support the `purchase` method.");
+        $request = new OrdersGetRequest($data->request()->payment_id);
+
+        /** @var \PayPalHttp\HttpResponse $response */
+        $response = $this->paypalClient->execute($request);
+
+        return new Response($response->result->status === 'APPROVED');
     }
 
     public function purchaseRules(): array
     {
-        // PayPal is off-site, therefore doesn't use the traditional
-        // checkout process provided by Simple Commerce. Hence why no rules
-        // are defined here.
-
-        return [];
+        return $this->isOffsiteGateway() ? [] : [
+            'payment_id' => 'required|string',
+        ];
     }
 
     public function getCharge(Order $order): Response


### PR DESCRIPTION
## Description

Here is the initial implementation of the on-site PayPal integration.

There are a couple of issues with it, which I'm hoping you can advise on:

1. There seems to be a glitch where the first time the payment page is loaded the `{{ paypal.result.* }}` variables aren't defined. However if you refresh the page it works fine. Not sure if this is an SC glitch or I've set something up wrong in the starter.
2. The PayPal SDK requires a currency code parameter, and I couldn't figure out how to get the current site's currency in the antlers template. What I've done (passing it into `paypal.result`) is very much a bodge. Hopefully you can correct this.

This has been developed using the SC starter. The example code in the docs is a direct copy of my `/resources/views/checkout/gateways/_paypal.antlers.html` file. The `payment.antlers.html` file hasn't changed.

I'm sure it will need some tweaks to the variable names/values and docs to better follow your usual conventions for SC.