### PR TITLE
[feature]: add params to sc:countries tags

### DIFF
--- a/docs/tags/countries.md
+++ b/docs/tags/countries.md
@@ -16,7 +16,9 @@ It also supports some optional parameters:
 
 For example:
 
-`{{ sc:countries only="GB|IE" }}`
+```
+{{ sc:countries only="GB|IE" }}
+```
 
 This will only return countries passed and in the order they are passed. It accepts a piped list of either iso values or country names.
 
@@ -25,7 +27,9 @@ This will only return countries passed and in the order they are passed. It acce
 
 For example:
 
-`{{ sc:countries exclude="GB|IE" }}`
+```
+{{ sc:countries exclude="GB|IE" }}
+```
 
 This will exclude any countries passed from the list. It Accepts a piped list of either iso values or country names. This param has no effect when the `only` param is used.
 
@@ -34,6 +38,8 @@ This will exclude any countries passed from the list. It Accepts a piped list of
 
 For example:
 
-`{{ sc:countries common="GB|IE" }}`
+```
+{{ sc:countries common="GB|IE" }}
+```
 
-This will creates a "common" countries list above the rest of the country list, allowing you to make it eaiser to get to the most common countries your visitors select. It accepts a piped list of either iso values or country names. This param has no effect when the `only` param is used.
+This will creates a 'common' countries list above the rest of the country list, allowing you to make it eaiser to get to the most common countries your visitors select. It accepts a piped list of either iso values or country names. This param has no effect when the `only` param is used.

--- a/docs/tags/countries.md
+++ b/docs/tags/countries.md
@@ -9,3 +9,31 @@ This tag lets you loop through countries.
   <option value="{{ iso }}">{{ name }}</option>
 {{ /sc:countries }}
 ```
+
+It also supports some optional parameters:
+
+### only
+
+For example:
+
+`{{ sc:countries only="GB|IE" }}`
+
+This will only return countries passed and in the order they are passed. It accepts a piped list of either iso values or country names.
+
+
+### exclude
+
+For example:
+
+`{{ sc:countries exclude="GB|IE" }}`
+
+This will exclude any countries passed from the list. It Accepts a piped list of either iso values or country names. This param has no effect when the `only` param is used.
+
+
+### common
+
+For example:
+
+`{{ sc:countries common="GB|IE" }}`
+
+This will creates a "common" countries list above the rest of the country list, allowing you to make it eaiser to get to the most common countries your visitors select. It accepts a piped list of either iso values or country names. This param has no effect when the `only` param is used.

--- a/src/Tags/SimpleCommerceTag.php
+++ b/src/Tags/SimpleCommerceTag.php
@@ -55,47 +55,43 @@ class SimpleCommerceTag extends Tags
 
     public function countries()
     {
-        $countries = collect(Countries::all());
-            
+        $countries = Countries::values();
+
         if ($inclusions = $this->params->explode('only', [])) {
-
-            $countries = $countries->filter(function ($country) use ($inclusions) {
-                return in_array($country['iso'], $inclusions) OR in_array($country['name'], $inclusions);
-            })->sortBy(function ($country) use ($inclusions) {
-                return array_search($country['iso'], $inclusions);
-            });
-
-        } else {         
-            
+            $countries = $countries
+                ->filter(function ($country) use ($inclusions) {
+                    return in_array($country['iso'], $inclusions)
+                        || in_array($country['name'], $inclusions);
+                })->sortBy(function ($country) use ($inclusions) {
+                    return array_search($country['iso'], $inclusions);
+                });
+        } else {
             if ($exclusions = $this->params->explode('exclude', [])) {
-    
                 $countries = $countries->filter(function ($country) use ($exclusions) {
-                    return !(in_array($country['iso'], $exclusions) OR in_array($country['name'], $exclusions));
+                    return ! (in_array($country['iso'], $exclusions)
+                        || in_array($country['name'], $exclusions));
                 });
-    
             }
-            
             if ($common = $this->params->explode('common', [])) {
-                            
-                $common_countries = $countries->filter(function ($country) use ($common) {
-                    return in_array($country['iso'], $common) OR in_array($country['name'], $common);
-                })->sortBy(function ($country) use ($common) {
-                    return array_search($country['iso'], $common);
-                });
-               
-                $common_countries->push([
+                $commonCountries = $countries
+                    ->filter(function ($country) use ($common) {
+                        return in_array($country['iso'], $common)
+                            || in_array($country['name'], $common);
+                    })->sortBy(function ($country) use ($common) {
+                        return array_search($country['iso'], $common);
+                    });
+
+                $commonCountries->push([
                     'iso' => '',
                     'name' => '-',
                 ]);
-                
-                $countries = $common_countries->concat($countries->filter(function ($country) use ($common) {
-                    return !(in_array($country['iso'], $common) OR in_array($country['name'], $common));
+
+                $countries = $commonCountries->concat($countries->filter(function ($country) use ($common) {
+                    return ! (in_array($country['iso'], $common) || in_array($country['name'], $common));
                 }));
-    
             }
-        
         }
-            
+
         return $countries->toArray();
     }
 

--- a/src/Tags/SimpleCommerceTag.php
+++ b/src/Tags/SimpleCommerceTag.php
@@ -55,7 +55,48 @@ class SimpleCommerceTag extends Tags
 
     public function countries()
     {
-        return Countries::toArray();
+        $countries = collect(Countries::all());
+            
+        if ($inclusions = $this->params->explode('only', [])) {
+
+            $countries = $countries->filter(function ($country) use ($inclusions) {
+                return in_array($country['iso'], $inclusions) OR in_array($country['name'], $inclusions);
+            })->sortBy(function ($country) use ($inclusions) {
+                return array_search($country['iso'], $inclusions);
+            });
+
+        } else {         
+            
+            if ($exclusions = $this->params->explode('exclude', [])) {
+    
+                $countries = $countries->filter(function ($country) use ($exclusions) {
+                    return !(in_array($country['iso'], $exclusions) OR in_array($country['name'], $exclusions));
+                });
+    
+            }
+            
+            if ($common = $this->params->explode('common', [])) {
+                            
+                $common_countries = $countries->filter(function ($country) use ($common) {
+                    return in_array($country['iso'], $common) OR in_array($country['name'], $common);
+                })->sortBy(function ($country) use ($common) {
+                    return array_search($country['iso'], $common);
+                });
+               
+                $common_countries->push([
+                    'iso' => '',
+                    'name' => '-',
+                ]);
+                
+                $countries = $common_countries->concat($countries->filter(function ($country) use ($common) {
+                    return !(in_array($country['iso'], $common) OR in_array($country['name'], $common));
+                }));
+    
+            }
+        
+        }
+            
+        return $countries->toArray();
     }
 
     public function currencies()

--- a/tests/Tags/SimpleCommerceTagTest.php
+++ b/tests/Tags/SimpleCommerceTagTest.php
@@ -29,6 +29,39 @@ class SimpleCommerceTagTest extends TestCase
     }
 
     /** @test */
+    public function can_get_countries_with_only_parameter()
+    {
+        $usage = $this->tag('{{ sc:countries only="GB|Ireland" }}{{ name }},{{ /sc:countries }}');
+
+        $this->assertStringContainsString('United Kingdom', $usage);
+        $this->assertStringContainsString('Ireland', $usage);
+
+        $this->assertStringNotContainsString('United States', $usage);
+    }
+
+    /** @test */
+    public function can_get_countries_with_exclude_parameter()
+    {
+        $usage = $this->tag('{{ sc:countries exclude="United Kingdom|Ireland" }}{{ name }},{{ /sc:countries }}');
+
+        $this->assertStringNotContainsString('United Kingdom', $usage);
+        $this->assertStringNotContainsString('Ireland', $usage);
+
+        $this->assertStringContainsString('United States', $usage);
+    }
+
+     /** @test */
+     public function can_get_countries_with_common_parameter()
+     {
+         $usage = $this->tag('{{ sc:countries common="IE" }}{{ name }},{{ /sc:countries }}');
+
+         $this->assertStringContainsString('Ireland,-,', $usage);
+
+         $this->assertStringContainsString('United Kingdom', $usage);
+         $this->assertStringContainsString('United States', $usage);
+     }
+
+    /** @test */
     public function can_get_currencies()
     {
         $usage = $this->tag('{{ sc:currencies }}{{ name }},{{ /sc:currencies }}');


### PR DESCRIPTION
## Description
Hope you don't mind the totally unsolicited PR, but this adds the following params to the `sc:countries` tag, allowing the country list to be filtered.

`only="GB|IE"` or `only="United Kingdom|Ireland"`
Only show countries passed and in the order they are passed. Accepts either iso or name.

`exclude="GB|IE'` or `exclude="United Kingdom|Ireland"`
Exclude the countries passed. Accepts either iso or name. Not available when only param is used.

`common="GB|IE'` or `common="United Kingdom|Ireland"`
Creates a "common" countries list above the rest of the country list.  Accepts either iso or name. Not available when only param is used.

## Related Issues
None

