### PR TITLE
Add a `StaticCartDriver` for use in tests

### DIFF
--- a/tests/StaticCartDriver.php
+++ b/tests/StaticCartDriver.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Tests;
+
+use DoubleThreeDigital\SimpleCommerce\Contracts\CartDriver;
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
+use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+
+class StaticCartDriver implements CartDriver
+{
+    public static $cart;
+
+    public static function use(): self
+    {
+        app()->bind(CartDriver::class, static::class);
+
+        return new static();
+    }
+
+    public static function setCart(OrderContract $order): self
+    {
+        static::$cart = $order;
+
+        return new static();
+    }
+
+    public function getCartKey(): string
+    {
+        return static::$cart->id();
+    }
+
+    public function getCart(): OrderContract
+    {
+        if ($this->hasCart()) {
+            return static::$cart;
+        }
+
+        return $this->makeCart();
+    }
+
+    public function hasCart(): bool
+    {
+        return is_null(static::$cart);
+    }
+
+    public function makeCart(): OrderContract
+    {
+        static::$cart = Order::create();
+
+        return static::$cart;
+    }
+
+    public function getOrMakeCart(): OrderContract
+    {
+        if ($this->hasCart()) {
+            return $this->getCart();
+        }
+
+        return $this->makeCart();
+    }
+
+    public function forgetCart()
+    {
+        static::$cart = null;
+    }
+}


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request adds in a new `StaticCartDriver` which we'll be able to use in Simple Commerce's tests. 

**This isn't meant to be used anywhere else apart from the Simple Commerce test suite.**

## Usage

```php
StaticCartDriver::use()->setCart(Order::create());

$usage = $this->tag->whatever();
```
