### PR TITLE
Refactor the way Shipping Methods are registered

### DIFF
--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -41,9 +41,9 @@ That command will create a Shipping Method class in your `app\ShippingMethods` f
 
 namespace App\ShippingMethods;
 
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\Data\Address;
-use Statamic\Entries\Entry;
 
 class FirstClass implements ShippingMethod
 {
@@ -57,7 +57,7 @@ class FirstClass implements ShippingMethod
         return 'Description of your shipping method';
     }
 
-    public function calculateCost(Entry $order): int
+    public function calculateCost(Order $order): int
     {
         return 0;
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -84,6 +84,7 @@ class ServiceProvider extends AddonServiceProvider
         });
 
         SimpleCommerce::bootGateways();
+        SimpleCommerce::bootShippingMethods();
 
         Filters\OrderStatusFilter::register();
     }

--- a/src/SimpleCommerce.php
+++ b/src/SimpleCommerce.php
@@ -5,11 +5,13 @@ namespace DoubleThreeDigital\SimpleCommerce;
 use Closure;
 use Illuminate\Support\Str;
 use Statamic\Facades\Collection;
+use Statamic\Facades\Site;
 use Statamic\Statamic;
 
 class SimpleCommerce
 {
     protected static $gateways = [];
+    protected static $shippingMethods = [];
 
     public static $productPriceHook;
     public static $productVariantPriceHook;
@@ -59,6 +61,33 @@ class SimpleCommerce
             $gateway,
             $config,
         ];
+    }
+
+    public static function bootShippingMethods()
+    {
+        return Statamic::booted(function () {
+            foreach (config('simple-commerce.sites') as $siteHandle => $value) {
+                if (! isset($value['shipping']['methods'])) {
+                    continue;
+                }
+
+                static::$shippingMethods[$siteHandle] = $value['shipping']['methods'];
+            }
+        });
+    }
+
+    public static function shippingMethods(string $site = null)
+    {
+        if ($site) {
+            return static::$shippingMethods[$site] ?? [];
+        }
+
+        return static::$shippingMethods[Site::default()->handle()] ?? [];
+    }
+
+    public static function registerShippingMethod(string $site, string $shippingMethod)
+    {
+        static::$shippingMethods[$site][] = $shippingMethod;
     }
 
     public static function freshOrderNumber()

--- a/src/SimpleCommerce.php
+++ b/src/SimpleCommerce.php
@@ -73,6 +73,8 @@ class SimpleCommerce
 
                 static::$shippingMethods[$siteHandle] = $value['shipping']['methods'];
             }
+
+            return new static();
         });
     }
 

--- a/src/SimpleCommerce.php
+++ b/src/SimpleCommerce.php
@@ -79,10 +79,10 @@ class SimpleCommerce
     public static function shippingMethods(string $site = null)
     {
         if ($site) {
-            return static::$shippingMethods[$site] ?? [];
+            return collect(static::$shippingMethods[$site] ?? []);
         }
 
-        return static::$shippingMethods[Site::default()->handle()] ?? [];
+        return collect(static::$shippingMethods[Site::default()->handle()] ?? []);
     }
 
     public static function registerShippingMethod(string $site, string $shippingMethod)

--- a/src/Tags/ShippingTags.php
+++ b/src/Tags/ShippingTags.php
@@ -5,6 +5,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Tags;
 use DoubleThreeDigital\SimpleCommerce\Facades\Currency;
 use DoubleThreeDigital\SimpleCommerce\Facades\Shipping;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Facades\Config;
 use Statamic\Facades\Site;
 
@@ -16,10 +17,7 @@ class ShippingTags extends SubTag
     {
         $order = $this->getCart();
 
-        $siteConfig = collect(Config::get('simple-commerce.sites'))
-            ->get(Site::current()->handle());
-
-        return collect($siteConfig['shipping']['methods'])
+        return SimpleCommerce::shippingMethods(Site::current()->handle())
             ->map(function ($method) use ($order) {
                 $instance = Shipping::use($method);
 

--- a/src/Tags/ShippingTags.php
+++ b/src/Tags/ShippingTags.php
@@ -6,7 +6,6 @@ use DoubleThreeDigital\SimpleCommerce\Facades\Currency;
 use DoubleThreeDigital\SimpleCommerce\Facades\Shipping;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use Illuminate\Support\Facades\Config;
 use Statamic\Facades\Site;
 
 class ShippingTags extends SubTag

--- a/tests/Tags/ShippingTagsTest.php
+++ b/tests/Tags/ShippingTagsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Tests\Tags;
+
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
+use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
+use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DoubleThreeDigital\SimpleCommerce\Orders\Address;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DoubleThreeDigital\SimpleCommerce\Tags\ShippingTags;
+use DoubleThreeDigital\SimpleCommerce\Tests\StaticCartDriver;
+use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
+use Illuminate\Support\Facades\Config;
+use Statamic\Facades\Antlers;
+
+class ShippingTagsTest extends TestCase
+{
+    protected $tag;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tag = resolve(ShippingTags::class)
+            ->setParser(Antlers::parser())
+            ->setContext([]);
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_available_shipping_method()
+    {
+        // This will add onto the existing one we have from the default config
+        SimpleCommerce::registerShippingMethod('default', RoyalMail::class);
+        SimpleCommerce::registerShippingMethod('default', DPD::class);
+
+        $order = Order::create([
+            'shipping_name' => 'Santa',
+            'shipping_address' => 'Christmas Lane',
+            'shipping_city' => 'Snowcity',
+            'shipping_country' => 'North Pole',
+            'shipping_zip_code' => 'N0R P0L',
+            'shipping_region' => null,
+        ]);
+
+        StaticCartDriver::use()->setCart($order);
+
+        $usage = $this->tag->methods();
+
+        $this->assertIsArray($usage);
+        $this->assertCount(2, $usage);
+
+        $this->assertSame($usage[0]['name'], 'Standard Post');
+        $this->assertSame($usage[1]['name'], 'Royal Mail');
+    }
+}
+
+class RoyalMail implements ShippingMethod
+{
+    public function name(): string
+    {
+        return 'Royal Mail';
+    }
+
+    public function description(): string
+    {
+        return 'Description of your shipping method';
+    }
+
+    public function calculateCost(OrderContract $order): int
+    {
+        return 0;
+    }
+
+    public function checkAvailability(Address $address): bool
+    {
+        return true;
+    }
+}
+
+
+class DPD implements ShippingMethod
+{
+    public function name(): string
+    {
+        return 'DPD';
+    }
+
+    public function description(): string
+    {
+        return 'Description of your shipping method';
+    }
+
+    public function calculateCost(OrderContract $order): int
+    {
+        return 0;
+    }
+
+    public function checkAvailability(Address $address): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

I've refactored how Shipping Methods are registered and made it possible for them to be registered on-demand (eg. not in the config file).

I've also added a single test to cover the shipping tag which I reckon is probably good enough for now as it's not a very complicated tag.

### How to register custom shipping methods

```php
SimpleCommerce::registerShippingMethod('default', RoyalMail::class);
```

The first parameter is the handle of the Statamic site you wish to register it in, the second is the actual shipping method.