### PR TITLE
Refactored Product Variants fieldtype to use Publish Fields instead of Grid Rows

### DIFF
--- a/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
@@ -38,37 +38,36 @@
             <button class="btn" @click="addVariant">Add Variant</button>
         </div>
 
-      <!-- Variant Options -->
-      <div class="grid-fieldtype-container mb-4">
-        <div class="grid-stacked">
-          <div
-              v-for="(option, index) in options"
-              :key="index"
-              class="bg-grey-10 shadow-sm mb-2 rounded border variants-sortable-item"
-          >
-            <div
-                class="grid-item-header"
-            >
-              {{ option.variant || 'Variants' }}
+        <!-- Variant Options -->
+        <div class="grid-fieldtype-container mb-4">
+            <div class="grid-stacked">
+                <div
+                    v-for="(option, index) in options"
+                    :key="index"
+                    class="bg-grey-10 shadow-sm mb-2 rounded border variants-sortable-item"
+                >
+                    <div class="grid-item-header">
+                        {{ option.variant || 'Variants' }}
+                    </div>
+
+                    <publish-fields-container>
+                        <publish-field
+                            v-for="(optionField, optionIndex) in meta.option_fields"
+                            :key="'option-'+ optionField.handle"
+                            :config="optionField"
+                            :value="option[optionField.handle]"
+                            :meta="optionField"
+                            :errors="errors(optionField.handle)"
+                            class="p-2"
+                            @input="updatedOptions(index, optionField.handle, $event)"
+                            @meta-updated="metaUpdated(option.handle, $event)"
+                            @focus="$emit('focus')"
+                            @blur="$emit('blur')"
+                        />
+                    </publish-fields-container>
+                </div>
             </div>
-            <publish-fields-container>
-              <publish-field
-                  v-for="(optionField, optionIndex) in meta.option_fields"
-                  :key="'option-'+ optionField.handle"
-                  :config="optionField"
-                  :value="option[optionField.handle]"
-                  :meta="optionField"
-                  :errors="errors(optionField.handle)"
-                  class="p-2"
-                  @input="updatedOptions(index, optionField.handle, $event)"
-                  @meta-updated="metaUpdated(option.handle, $event)"
-                  @focus="$emit('focus')"
-                  @blur="$emit('blur')"
-              />
-            </publish-fields-container>
-          </div>
         </div>
-      </div>
     </div>
 </template>
 

--- a/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
@@ -38,48 +38,37 @@
             <button class="btn" @click="addVariant">Add Variant</button>
         </div>
 
-        <!-- Variant Options -->
-        <div class="grid-fieldtype-container">
-            <table class="grid-table" v-if="options.length > 0">
-                <thead>
-                    <tr>
-                        <grid-header-cell
-                            v-for="field in meta.option_fields"
-                            :key="field.handle"
-                            :field="field"
-                        />
-                    </tr>
-                </thead>
-                <sortable-list
-                    :value="options"
-                    :vertical="true"
-                    :item-class="sortableItemClass"
-                    :handle-class="sortableHandleClass"
-                    @dragstart="$emit('focus')"
-                    @dragend="$emit('blur')"
-                    @input="(rows) => $emit('sorted', rows)"
-                >
-                    <tbody slot-scope="{}">
-                        <grid-row
-                            v-for="(row, index) in options"
-                            :key="`row-${index}`"
-                            :index="index"
-                            :fields="meta.option_fields"
-                            :values="row"
-                            :can-delete="false"
-                            :meta="meta"
-                            name="options"
-                            :error-key-prefix="options+index"
-                            @updated="optionUpdated(row, value)"
-                            @meta-updated="$emit('meta-updated', row._id, $event)"
-                            @removed="(row) => $emit('removed', row)"
-                            @focus="$emit('focus')"
-                            @blur="$emit('blur')"
-                        />
-                    </tbody>
-                </sortable-list>
-            </table>
+      <!-- Variant Options -->
+      <div class="grid-fieldtype-container mb-4">
+        <div class="grid-stacked">
+          <div
+              v-for="(option, index) in options"
+              :key="index"
+              class="bg-grey-10 shadow-sm mb-2 rounded border variants-sortable-item"
+          >
+            <div
+                class="grid-item-header"
+            >
+              {{ option.variant || 'Variants' }}
+            </div>
+            <publish-fields-container>
+              <publish-field
+                  v-for="(optionField, optionIndex) in meta.option_fields"
+                  :key="'option-'+ optionField.handle"
+                  :config="optionField"
+                  :value="option[optionField.handle]"
+                  :meta="optionField"
+                  :errors="errors(optionField.handle)"
+                  class="p-2"
+                  @input="updatedOptions(index, optionField.handle, $event)"
+                  @meta-updated="metaUpdated(option.handle, $event)"
+                  @focus="$emit('focus')"
+                  @blur="$emit('blur')"
+              />
+            </publish-fields-container>
+          </div>
         </div>
+      </div>
     </div>
 </template>
 
@@ -179,6 +168,10 @@ export default {
 
         updated(variantIndex, fieldHandle, value) {
             this.variants[variantIndex][fieldHandle] = value
+        },
+
+        updatedOptions(optionIndex, fieldHandle, value) {
+            this.options[optionIndex][fieldHandle] = value;
         },
 
         optionUpdated(row, value) {

--- a/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
@@ -56,7 +56,7 @@
                             :key="'option-'+ optionField.handle"
                             :config="optionField"
                             :value="option[optionField.handle]"
-                            :meta="optionField"
+                            :meta="meta[optionField.handle]"
                             :errors="errors(optionField.handle)"
                             class="p-2"
                             @input="updatedOptions(index, optionField.handle, $event)"

--- a/src/Fieldtypes/ProductVariantsFieldtype.php
+++ b/src/Fieldtypes/ProductVariantsFieldtype.php
@@ -145,21 +145,23 @@ class ProductVariantsFieldtype extends Fieldtype
     protected function processInsideFields(array $fieldValues, array $fields, string $method)
     {
         return collect($fieldValues)
-            ->map(function ($optionAttributes) use ($fields, $method) {
-                return collect($optionAttributes)
-                    ->map(function ($value, $key) use ($fields, $method) {
-                        if ($key === 'key') {
-                            return $value;
-                        }
+            ->map(function ($optionAttributeValues) use ($fields, $method) {
+                $optionAttributes = collect($fields)->pluck('handle');
 
-                        return collect($fields)
-                            ->where('handle', $key)
+                return collect($optionAttributes)
+                    ->mapWithKeys(function ($fieldHandle) use ($fields, $method, $optionAttributeValues) {
+                        $value = $optionAttributeValues[$fieldHandle] ?? null;
+
+                        $fieldValue = collect($fields)
+                            ->where('handle', $fieldHandle)
                             ->map(function ($field) use ($value, $method) {
                                 return (new FieldtypeRepository())
                                     ->find($field['type'])
                                     ->{$method}($value);
                             })
                             ->first();
+
+                        return [$fieldHandle => $fieldValue];
                     })
                     ->toArray();
             })
@@ -173,7 +175,7 @@ class ProductVariantsFieldtype extends Fieldtype
 
     public function preProcessIndex($value)
     {
-        if (!$value) {
+        if (! $value) {
             return __('simple-commerce::messages.product_has_no_variants');
         }
 

--- a/src/Fieldtypes/ProductVariantsFieldtype.php
+++ b/src/Fieldtypes/ProductVariantsFieldtype.php
@@ -56,13 +56,15 @@ class ProductVariantsFieldtype extends Fieldtype
                             'display'   => 'Variant',
                             'read_only' => true,
                             'validate'  => 'required',
+                            'width'     => 50,
                         ]))->toPublishArray(),
                         (new Field('price', [
                             'type'      => 'money',
                             'read_only' => false,
                             'listable'  => 'hidden',
-                            'display'   => 'price',
+                            'display'   => 'Price',
                             'validate'  => 'required',
+                            'width'     => 50,
                         ]))->toPublishArray(),
                     ],
                     collect($this->config('option_fields'))


### PR DESCRIPTION
## Description

This PR changes the way that product variants fieldtype renders the option fields using publish fields instead of grid rows.
This partially fixes #493 (assets fieldtype now is working, toggle fieldtype not yet but I think it's a Statamic bug) and add some functionalities as the default Statamic column sizing and the possibility to add more fields without breaking the layout.

![image](https://user-images.githubusercontent.com/4233569/141972321-f064efa5-5e01-4f8e-bc9e-7ad2f34a037f.png)

## Related Issues

'Partially fixes #493'
