### PR TITLE
Provide default values for custom option fields

### DIFF
--- a/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
@@ -121,7 +121,7 @@ export default {
         },
 
         baseContainer() {
-             let parent = this.$parent
+            let parent = this.$parent
 
             while (parent && parent.$options._componentTag !== 'publish-container') {
                 parent = parent.$parent
@@ -170,11 +170,7 @@ export default {
         },
 
         updatedOptions(optionIndex, fieldHandle, value) {
-            this.options[optionIndex][fieldHandle] = value;
-        },
-
-        optionUpdated(row, value) {
-            //
+            this.options[optionIndex][fieldHandle] = value
         },
 
         metaUpdated(fieldHandle, event) {
@@ -201,6 +197,10 @@ export default {
                         existingData = {
                             price: 0,
                         }
+
+                        Object.entries(this.meta.option_field_defaults).forEach(([key, value]) => {
+                            existingData[key] = value
+                        })
                     }
 
                     return {

--- a/src/Fieldtypes/ProductVariantsFieldtype.php
+++ b/src/Fieldtypes/ProductVariantsFieldtype.php
@@ -76,6 +76,17 @@ class ProductVariantsFieldtype extends Fieldtype
                         })
                         ->toArray(),
                 ),
+                'option_field_defaults' => collect($this->config('option_fields'))
+                    ->mapWithKeys(function ($field) {
+                        $field = (
+                            new Field($field['handle'], $field['field'])
+                        );
+
+                        return [
+                            $field->handle() => $field->fieldtype()->preProcess($field->defaultValue())
+                        ];
+                    })
+                    ->toArray(),
                 'variant' => resolve(Textarea::class)->preload(),
                 'price'   => resolve(MoneyFieldtype::class)->preload(),
             ],

--- a/src/Fieldtypes/ProductVariantsFieldtype.php
+++ b/src/Fieldtypes/ProductVariantsFieldtype.php
@@ -83,7 +83,7 @@ class ProductVariantsFieldtype extends Fieldtype
                         );
 
                         return [
-                            $field->handle() => $field->fieldtype()->preProcess($field->defaultValue())
+                            $field->handle() => $field->fieldtype()->preProcess($field->defaultValue()),
                         ];
                     })
                     ->toArray(),


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request resolves an issue where custom option fields wouldn't behave as expected prior to them being saved. This was commonly seen when you tried to update a Toggle field when creating a product.

All that was needed was to provide default values for the option fields as part of the fieldtype's meta data.

## Related Issues

<!-- 
  Does this PR fix any open issues? 
  -- If so, please do something like this: 'Closes #1'
-->

Fixes #503