### PR TITLE
v2.4: Different carts per site

### DIFF
--- a/src/Orders/Cart/Drivers/CookieDriver.php
+++ b/src/Orders/Cart/Drivers/CookieDriver.php
@@ -16,7 +16,7 @@ class CookieDriver implements CartDriver
 {
     public function getCartKey(): string
     {
-        return Cookie::get(Config::get('simple-commerce.cart.key'));
+        return Cookie::get($this->getKey());
     }
 
     public function getCart(): Order
@@ -34,7 +34,7 @@ class CookieDriver implements CartDriver
 
     public function hasCart(): bool
     {
-        return Cookie::has(Config::get('simple-commerce.cart.key'));
+        return Cookie::has($this->getKey());
     }
 
     public function makeCart(): Order
@@ -44,7 +44,7 @@ class CookieDriver implements CartDriver
             $this->guessSiteFromRequest()
         );
 
-        Cookie::queue(config('simple-commerce.cart.key'), $cart->id);
+        Cookie::queue($this->getKey(), $cart->id);
 
         return $cart;
     }
@@ -61,7 +61,7 @@ class CookieDriver implements CartDriver
     public function forgetCart()
     {
         Cookie::queue(
-            Cookie::forget(Config::get('simple-commerce.cart.key'))
+            Cookie::forget($this->getKey())
         );
     }
 
@@ -86,5 +86,16 @@ class CookieDriver implements CartDriver
         }
 
         return Site::current();
+    }
+
+    protected function getKey(): string
+    {
+        $site = $this->guessSiteFromRequest();
+
+        if (Config::get('simple-commerce.cart.single_cart')) {
+            return Config::get('simple-commerce.cart.key');
+        }
+
+        return Config::get('simple-commerce.cart.key') . '_' . $site->handle();
     }
 }

--- a/src/Orders/Cart/Drivers/CookieDriver.php
+++ b/src/Orders/Cart/Drivers/CookieDriver.php
@@ -93,7 +93,7 @@ class CookieDriver implements CartDriver
         $site = $this->guessSiteFromRequest();
 
         if (Site::hasMultiple() && ! Config::get('simple-commerce.cart.single_cart')) {
-            return Config::get('simple-commerce.cart.key') . '_' . $site->handle();
+            return Config::get('simple-commerce.cart.key').'-'. $site->handle();
         }
 
         return Config::get('simple-commerce.cart.key');

--- a/src/Orders/Cart/Drivers/CookieDriver.php
+++ b/src/Orders/Cart/Drivers/CookieDriver.php
@@ -93,7 +93,7 @@ class CookieDriver implements CartDriver
         $site = $this->guessSiteFromRequest();
 
         if (Site::hasMultiple() && ! Config::get('simple-commerce.cart.single_cart')) {
-            return Config::get('simple-commerce.cart.key').'-'. $site->handle();
+            return Config::get('simple-commerce.cart.key').'-'.$site->handle();
         }
 
         return Config::get('simple-commerce.cart.key');

--- a/src/Orders/Cart/Drivers/CookieDriver.php
+++ b/src/Orders/Cart/Drivers/CookieDriver.php
@@ -92,10 +92,10 @@ class CookieDriver implements CartDriver
     {
         $site = $this->guessSiteFromRequest();
 
-        if (Config::get('simple-commerce.cart.single_cart')) {
-            return Config::get('simple-commerce.cart.key');
+        if (Site::hasMultiple() && ! Config::get('simple-commerce.cart.single_cart')) {
+            return Config::get('simple-commerce.cart.key') . '_' . $site->handle();
         }
 
-        return Config::get('simple-commerce.cart.key') . '_' . $site->handle();
+        return Config::get('simple-commerce.cart.key');
     }
 }

--- a/src/Orders/Cart/Drivers/SessionDriver.php
+++ b/src/Orders/Cart/Drivers/SessionDriver.php
@@ -81,7 +81,7 @@ class SessionDriver implements CartDriver
         $site = $this->guessSiteFromRequest();
 
         if (Site::hasMultiple() && ! Config::get('simple-commerce.cart.single_cart')) {
-            return Config::get('simple-commerce.cart.key') . '_' . $site->handle();
+            return Config::get('simple-commerce.cart.key').'-'.$site->handle();
         }
 
         return Config::get('simple-commerce.cart.key');

--- a/src/Orders/Cart/Drivers/SessionDriver.php
+++ b/src/Orders/Cart/Drivers/SessionDriver.php
@@ -15,7 +15,7 @@ class SessionDriver implements CartDriver
 {
     public function getCartKey(): string
     {
-        return Session::get(Config::get('simple-commerce.cart.key'));
+        return Session::get($this->getKey());
     }
 
     public function getCart(): Order
@@ -25,7 +25,7 @@ class SessionDriver implements CartDriver
 
     public function hasCart(): bool
     {
-        return Session::has(Config::get('simple-commerce.cart.key'));
+        return Session::has($this->getKey());
     }
 
     public function makeCart(): Order
@@ -34,7 +34,7 @@ class SessionDriver implements CartDriver
             ->site($this->guessSiteFromRequest())
             ->save();
 
-        Session::put(config('simple-commerce.cart.key'), $cart->id);
+        Session::put($this->getKey(), $cart->id);
 
         return $cart;
     }
@@ -50,7 +50,7 @@ class SessionDriver implements CartDriver
 
     public function forgetCart()
     {
-        Session::forget(config('simple-commerce.cart.key'));
+        Session::forget($this->getKey());
     }
 
     protected function guessSiteFromRequest(): ASite
@@ -74,5 +74,16 @@ class SessionDriver implements CartDriver
         }
 
         return Site::current();
+    }
+
+    protected function getKey(): string
+    {
+        $site = $this->guessSiteFromRequest();
+
+        if (Config::get('simple-commerce.cart.single_cart')) {
+            return Config::get('simple-commerce.cart.key');
+        }
+
+        return Config::get('simple-commerce.cart.key') . '_' . $site->handle();
     }
 }

--- a/src/Orders/Cart/Drivers/SessionDriver.php
+++ b/src/Orders/Cart/Drivers/SessionDriver.php
@@ -80,10 +80,10 @@ class SessionDriver implements CartDriver
     {
         $site = $this->guessSiteFromRequest();
 
-        if (Config::get('simple-commerce.cart.single_cart')) {
-            return Config::get('simple-commerce.cart.key');
+        if (Site::hasMultiple() && ! Config::get('simple-commerce.cart.single_cart')) {
+            return Config::get('simple-commerce.cart.key') . '_' . $site->handle();
         }
 
-        return Config::get('simple-commerce.cart.key') . '_' . $site->handle();
+        return Config::get('simple-commerce.cart.key');
     }
 }

--- a/src/UpdateScripts/MigrateSingleCartConfig.php
+++ b/src/UpdateScripts/MigrateSingleCartConfig.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts;
+
+use Statamic\Facades\Site;
+use Statamic\UpdateScripts\UpdateScript;
+use Stillat\Proteus\Support\Facades\ConfigWriter;
+
+class MigrateSingleCartConfig extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('2.4.0-beta.1')
+            && Site::hasMultiple();
+    }
+
+    public function update()
+    {
+        ConfigWriter::write('simple-commerce.cart.single_cart', true);
+
+        $this->console()->info("We've set the 'single_cart' config value to true, for backwards compatibility reasons (due to you running multi-site).");
+    }
+}


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request introduces a change focused towards multi-site users. 

Right now, if two sites are sharing the same domain they'll find themselves sharing the same cart (because we use session/cookies which scope to the current site). Often times, if these sites have different currencies or shipping methods, you wouldn't want them to mix with each other. 

For example: you could add a product to your cart on the English site, then add another product to the cart on the German site and you would end up with two products in your cart. 

For new sites (eg. ones not migrated), Simple Commerce will append the site handle to the cart key used for looking up cookies/session entries. So instead of `simple-commerce-cart`, you would have `simple-commerce-cart-en` (where `en` is the site handle).

For sites migrated to v2.4, they will keep the existing behaviour of having a single cart as this could potentially be a major breaking change (depending on how the site has been built).

```php
'cart' => [
    'driver' => \DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CookieDriver::class,
    'key' => 'simple-commerce-cart',
    'single_cart' => true,
],
```