### PR TITLE
Throw an exception when no site configured

### DIFF
--- a/src/Exceptions/SiteNotConfiguredException.php
+++ b/src/Exceptions/SiteNotConfiguredException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+
+use Exception;
+use Facade\IgnitionContracts\BaseSolution;
+use Facade\IgnitionContracts\ProvidesSolution;
+use Facade\IgnitionContracts\Solution;
+
+class SiteNotConfiguredException extends Exception implements ProvidesSolution
+{
+    public function getSolution(): Solution
+    {
+        return BaseSolution::create('You may have forgotten to add the site to the Simple Commerce config file.')
+            ->setSolutionDescription('You need to add the site so Simple Commerce knows which currency and shipping methods to use. Follow the steps in the documentation to add a site.')
+            ->setDocumentationLinks([
+                'Multi-site' => 'https://simple-commerce.duncanmcclean.com/multisite',
+            ]);
+    }
+}

--- a/src/Listeners/EnforceBlueprintFields.php
+++ b/src/Listeners/EnforceBlueprintFields.php
@@ -20,7 +20,6 @@ class EnforceBlueprintFields
         if (isset($orderDriver['collection']) && $event->blueprint->namespace() === "collections.{$orderDriver['collection']}") {
             return $this->enforceOrderFields($event);
         }
-
     }
 
     protected function enforceProductFields($event): Blueprint

--- a/src/Support/Currency.php
+++ b/src/Support/Currency.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Support;
 
 use DoubleThreeDigital\SimpleCommerce\Contracts\Currency as Contract;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\CurrencyFormatterNotWorking;
+use DoubleThreeDigital\SimpleCommerce\Exceptions\SiteNotConfiguredException;
 use Illuminate\Support\Facades\Config;
 use Money\Currencies\ISOCurrencies;
 use Money\Currency as MoneyCurrency;
@@ -18,6 +19,10 @@ class Currency implements Contract
     {
         $siteSettings = collect(Config::get('simple-commerce.sites'))
             ->get($site->handle());
+
+        if (! $siteSettings) {
+            throw new SiteNotConfiguredException("Site config not found [{$site->handle()}]");
+        }
 
         return Currencies::where('code', $siteSettings['currency'])
             ->first();


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request improves the error handling a user gets when they create a new site in Statamic but forget to also configure it in the Simple Commerce config file.

Previously, a nasty error about not being able to get properties on null was returned. 

Now, a custom exception will be shown, along with an Ignition solution and a link to the Simple Commerce documentation.

![image](https://user-images.githubusercontent.com/19637309/147934733-249f2cc6-8a42-4a19-a6a9-835c45b7b30f.png)

This was a little tweak I made while trying to reproduce #523.