### PR TITLE
Fix wrong currency being displayed in CP Listing View

### DIFF
--- a/src/Fieldtypes/MoneyFieldtype.php
+++ b/src/Fieldtypes/MoneyFieldtype.php
@@ -75,6 +75,6 @@ class MoneyFieldtype extends Fieldtype
             return;
         }
 
-        return $this->augment($value);
+        return Currency::parse($value, Site::selected());
     }
 }


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request fixes an issue where the wrong currency would be displayed after switching sites in the Statamic Control Panel.

Now, the currency for the CP index values is based on what's currently selected within the CP, not based on the current site (which would always be the default one).

![image](https://user-images.githubusercontent.com/19637309/147936556-ddc6f58d-ab1b-4719-8aab-7e3862e8615c.png)

The currency displayed in the fieldtype was and still is showing correct after switching sites.

## Related Issues

<!-- 
  Does this PR fix any open issues? 
  -- If so, please do something like this: 'Closes #1'
-->

Fixes #523.