### PR TITLE
Fix currency display issues on widget

### DIFF
--- a/resources/js/components/Widgets/SalesWidget.vue
+++ b/resources/js/components/Widgets/SalesWidget.vue
@@ -2,6 +2,7 @@
     <div>
         <div class="flex justify-between items-center mb-2">
             <h3 class="font-bold text-grey">Sales</h3>
+
             <select class="text-xs" v-model="count">
                 <option value="sevenDays">7 Days</option>
                 <option value="fourteenDays">14 Days</option>
@@ -14,9 +15,7 @@
         <div v-if="count === 'thirtyDays'" class="text-4xl mb-2">{{ thirtyDaysCount }}</div>
 
         <div class="flex items-center">
-            <span v-if="count === 'sevenDays'" class="leading-none text-sm">{{ sevenDaysTotal }} total in sales</span>
-            <span v-if="count === 'fourteenDays'" class="leading-none text-sm">{{ fourteenDaysTotal }} total in sales</span>
-            <span v-if="count === 'thirtyDays'" class="leading-none text-sm">{{ thirtyDaysTotal }} total in sales</span>
+            <span class="leading-none text-sm" v-html="totalSalesText"></span>
         </div>
     </div>
 </template>
@@ -38,6 +37,24 @@ export default {
         return {
             count: 'sevenDays',
         }
+    },
+
+    computed: {
+        totalSalesText() {
+            if (this.count === 'sevenDays') {
+                return this.sevenDaysTotal + ' total in sales'
+            }
+
+            if (this.count === 'fourteenDays') {
+                return this.fourteenDaysTotal + ' total in sales'
+            }
+
+            if (this.count === 'thirtyDays') {
+                return this.thirtyDaysTotal + ' total in sales'
+            }
+
+            return 'Unknown'
+        },
     },
 }
 </script>


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request fixes issues with currency amounts not being displayed properly. Fixes #527, where `NOK` was being used as the currency.

The issue only occurred when the currency format included a space, that's why it would happen with `NOK 15.20` but not with `£15.20`.

![image](https://user-images.githubusercontent.com/19637309/147946147-0f657117-4237-477b-89ca-eebeb7acdbbc.png)

