### PR TITLE
Fix PostCheckout event causing off-site gateways to fail

### DIFF
--- a/docs/extending/events.md
+++ b/docs/extending/events.md
@@ -87,6 +87,7 @@ This event is fired after the checkout process has been completed.
 public function handle(PostCheckout $event)
 {
 	$event->order;
+    $event->request;
 }
 ```
 

--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -127,7 +127,7 @@ class MollieGateway extends BaseGateway implements Gateway
 
             $this->markOrderAsPaid($order);
 
-            event(new PostCheckout($order));
+            event(new PostCheckout($order, $request));
         }
     }
 

--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -217,7 +217,7 @@ class PayPalGateway extends BaseGateway implements Gateway
             $order->set('gateway_data', $responseBody)->save();
             $this->markOrderAsPaid($order);
 
-            event(new PostCheckout($order));
+            event(new PostCheckout($order, $request));
         }
 
         return new HttpResponse();


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request fixes an issue where checking out with SC's two off-site gateways would fail due to a missing parameter when the `PostCheckout` event was dispatched.



## Related Issues

<!-- 
  Does this PR fix any open issues? 
  -- If so, please do something like this: 'Closes #1'
-->

Fixes #535
