### PR TITLE
`sc:cart:alreadyExists` tag

### DIFF
--- a/docs/tags/cart.md
+++ b/docs/tags/cart.md
@@ -115,3 +115,23 @@ If you want to empty all the items from the cart and start from scratch. You can
   <button>I messed up.. there's too much in my cart. I need a fresh start.</button>
 {{ /sc:cart:empty }}
 ```
+
+## Checking if a product exists in the customer's cart
+
+Sometimes you'll want to know if a certain product (or product variant) exists in a customer's cart. Well, it's a good thing it's easy peasy to check.
+
+**Standard Products**
+
+```antlers
+{{ if {sc:cart:alreadyExists :product="id"} }}
+  This product is already in your cart.
+{{ /if }}
+```
+
+**Variant Products**
+
+```antlers
+{{ if {sc:cart:alreadyExists :product="id" variant="Red_Small"} }}
+  This product is already in your cart.
+{{ /if }}
+```

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Tags;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 
 class CartTags extends SubTag

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Tags;
 
+use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 
 class CartTags extends SubTag
@@ -190,6 +191,14 @@ class CartTags extends SubTag
             [],
             'DELETE'
         );
+    }
+
+    public function alreadyExists()
+    {
+        return $this->getCart()->lineItems()
+            ->where('product', $this->params->get('product'))
+            ->where('variant', $this->params->get('variant'))
+            ->count() >= 1;
     }
 
     public function wildcard($method)

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -321,6 +321,111 @@ class CartTagTest extends TestCase
     }
 
     /** @test */
+    public function can_output_if_product_already_exists_in_cart()
+    {
+        $product = Product::create([
+            'title' => 'Dog Food',
+            'price' => 1000,
+        ]);
+
+        $cart = Order::create([
+            'items' => [
+                [
+                    'id' => 'one-two-three',
+                    'product' => $product->id,
+                    'quantity' => 1,
+                    'total' => 1000,
+                ],
+            ],
+        ]);
+
+        $this->fakeCart($cart);
+
+        $this->tag->setParameters([
+            'product' => $product->id,
+        ]);
+
+        $usage = $this->tag->alreadyExists();
+
+        $this->assertTrue($usage);
+    }
+
+    /** @test */
+    public function can_output_if_product_and_variant_already_exists_in_cart()
+    {
+        $product = Product::create([
+            'title' => 'Dog Food',
+            'product_variants' => [
+                'variants' => [
+                    [
+                        'name'   => 'Colours',
+                        'values' => [
+                            'Red',
+                        ],
+                    ],
+                    [
+                        'name'   => 'Sizes',
+                        'values' => [
+                            'Small',
+                        ],
+                    ],
+                ],
+                'options' => [
+                    [
+                        'key'     => 'Red_Small',
+                        'variant' => 'Red Small',
+                        'price'   => 5000,
+                    ],
+                ],
+            ],
+        ]);
+
+        $cart = Order::create([
+            'items' => [
+                [
+                    'id' => 'one-two-three',
+                    'product' => $product->id,
+                    'variant' => 'Red_Small',
+                    'quantity' => 1,
+                    'total' => 5000,
+                ],
+            ],
+        ]);
+
+        $this->fakeCart($cart);
+
+        $this->tag->setParameters([
+            'product' => $product->id,
+            'variant' => 'Red_Small',
+        ]);
+
+        $usage = $this->tag->alreadyExists();
+
+        $this->assertTrue($usage);
+    }
+
+    /** @test */
+    public function can_output_if_product_does_not_already_exists_in_cart()
+    {
+        $product = Product::create([
+            'title' => 'Dog Food',
+            'price' => 1000,
+        ]);
+
+        $cart = Order::create([]);
+
+        $this->fakeCart($cart);
+
+        $this->tag->setParameters([
+            'product' => $product->id,
+        ]);
+
+        $usage = $this->tag->alreadyExists();
+
+        $this->assertFalse($usage);
+    }
+
+    /** @test */
     public function can_get_data_from_cart()
     {
         $cart = Order::create([


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request introduces a new tag to allow you to easily check if a given product exists in the customer's cart.

```antlers
{{ if {sc:cart:alreadyExists :product="id"} }}
  This product is already in your cart.
{{ /if }}
```

