### PR TITLE
Purchasable type enums

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,15 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "barryvdh/laravel-dompdf": "^0.9.0",
+        "laravel/framework": "^7.0|^8.0",
         "mollie/mollie-api-php": "^2.30.0",
         "moneyphp/money": "^3.0",
         "paypal/paypal-checkout-sdk": "^1.0",
         "pixelfear/composer-dist-plugin": "^0.1.0",
+        "spatie/enum": "^3.11",
         "statamic/cms": "3.1.* || 3.2.*",
         "stillat/proteus": "^1.0",
-        "stripe/stripe-php": "^7.7",
-        "laravel/framework": "^7.0|^8.0"
+        "stripe/stripe-php": "^7.7"
     },
     "require-dev": {
         "nunomaduro/collision": "^4.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f64f0965265188fe154b6de04b2dd403",
+    "content-hash": "f1fbdcf487008447f3a65bae0e2f2ab8",
     "packages": [
         {
             "name": "ajthinking/archetype",
@@ -4373,6 +4373,82 @@
                 }
             ],
             "time": "2020-11-29T19:47:08+00:00"
+        },
+        {
+            "name": "spatie/enum",
+            "version": "3.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/enum.git",
+                "reference": "4afe5f06bb4c3cf46d8b02328bcc34c0de652ad4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/enum/zipball/4afe5f06bb4c3cf46d8b02328bcc34c0de652ad4",
+                "reference": "4afe5f06bb4c3cf46d8b02328bcc34c0de652ad4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "fakerphp/faker": "^1.9.1",
+                "larapack/dd": "^1.1",
+                "phpunit/phpunit": "^9.0",
+                "vimeo/psalm": "^4.3"
+            },
+            "suggest": {
+                "fakerphp/faker": "To use the enum faker provider",
+                "phpunit/phpunit": "To use the enum assertions"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Enum\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brent Roose",
+                    "email": "brent@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Tom Witkowski",
+                    "email": "dev@gummibeer.de",
+                    "homepage": "https://gummibeer.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Enums",
+            "homepage": "https://github.com/spatie/enum",
+            "keywords": [
+                "enum",
+                "enumerable",
+                "spatie"
+            ],
+            "support": {
+                "docs": "https://docs.spatie.be/enum",
+                "issues": "https://github.com/spatie/enum/issues",
+                "source": "https://github.com/spatie/enum"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-11-25T11:30:17+00:00"
         },
         {
             "name": "statamic/cms",
@@ -10681,5 +10757,5 @@
         "php": "^7.4 || ^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/resources/js/components/Fieldtypes/ProductVariantFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariantFieldtype.vue
@@ -16,14 +16,14 @@
             >No product selected.</p>
 
             <select-field
-                v-if="productVariantsData && productVariantsData.purchasable_type === 'variants'"
+                v-if="productVariantsData && productVariantsData.purchasable_type === 'VARIANT'"
                 :options="productVariantOptions"
                 :disabled="readOnly"
                 v-model="variant.variant"
             ></select-field>
 
             <p
-                v-else-if="productVariantsData && productVariantsData.purchasable_type === 'product'"
+                v-else-if="productVariantsData && productVariantsData.purchasable_type === 'PRODUCT'"
                 class="text-sm p-1"
             >Product doesn't support variants.</p>
         </div>

--- a/src/Checkout/HandleStock.php
+++ b/src/Checkout/HandleStock.php
@@ -7,6 +7,7 @@ use DoubleThreeDigital\SimpleCommerce\Events\StockRunningLow;
 use DoubleThreeDigital\SimpleCommerce\Events\StockRunOut;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\CheckoutProductHasNoStockException;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
 
 trait HandleStock
 {
@@ -16,7 +17,7 @@ trait HandleStock
             ->each(function ($item) {
                 $product = Product::find($item['product']);
 
-                if ($product->purchasableType() === 'product') {
+                if ($product->purchasableType() === ProductType::PRODUCT()) {
                     if ($product->has('stock') && $product->get('stock') !== null) {
                         $stockCount = $product->get('stock') - $item['quantity'];
 
@@ -38,7 +39,7 @@ trait HandleStock
                     }
                 }
 
-                if ($product->purchasableType() === 'variants') {
+                if ($product->purchasableType() === ProductType::VARIANT()) {
                     $variant = $product->variant($item['variant']['variant'] ?? $item['variant']);
 
                     if ($variant !== null && $variant->stockCount() !== null) {

--- a/src/Contracts/Product.php
+++ b/src/Contracts/Product.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Contracts;
 
+use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
 use DoubleThreeDigital\SimpleCommerce\Products\ProductVariant;
 use DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxCategory;
 use Illuminate\Support\Collection;
@@ -46,7 +47,7 @@ interface Product
 
     public function stockCount();
 
-    public function purchasableType(): string;
+    public function purchasableType(): ProductType;
 
     public function variants(): Collection;
 

--- a/src/Exceptions/CheckoutProductHasNoStockException.php
+++ b/src/Exceptions/CheckoutProductHasNoStockException.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
 
 use DoubleThreeDigital\SimpleCommerce\Contracts\Product;
+use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
 
 class CheckoutProductHasNoStockException extends \Exception
 {
@@ -14,11 +15,11 @@ class CheckoutProductHasNoStockException extends \Exception
         $this->product = $product;
         $this->variant = $variant;
 
-        if ($product->purchasableType() === 'product') {
+        if ($product->purchasableType() === ProductType::PRODUCT()) {
             $message = "Product [{$product->id()}] does not have any available stock.";
         }
 
-        if ($product->purchasableType() === 'variants') {
+        if ($product->purchasableType() === ProductType::VARIANT()) {
             $message = "Variant [{$variant->key()}] on [{$product->id()}] does not have any available stock.";
         }
 

--- a/src/Fieldtypes/ProductVariantFieldtype.php
+++ b/src/Fieldtypes/ProductVariantFieldtype.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
 
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
 use Statamic\Fields\Fieldtype;
 
 class ProductVariantFieldtype extends Fieldtype
@@ -43,7 +44,7 @@ class ProductVariantFieldtype extends Fieldtype
 
         $product = Product::find($value['product']);
 
-        if ($product->purchasableType() === 'product') {
+        if ($product->purchasableType() === ProductType::PRODUCT()) {
             return null;
         }
 

--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -9,6 +9,7 @@ use DoubleThreeDigital\SimpleCommerce\Http\Requests\CartItem\DestroyRequest;
 use DoubleThreeDigital\SimpleCommerce\Http\Requests\CartItem\StoreRequest;
 use DoubleThreeDigital\SimpleCommerce\Http\Requests\CartItem\UpdateRequest;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Statamic\Facades\Site;
@@ -71,11 +72,11 @@ class CartItemController extends BaseActionController
         }
 
         // Ensure there's enough stock to fulfill the customer's quantity
-        if ($product->purchasableType() === 'product') {
+        if ($product->purchasableType() === ProductType::PRODUCT()) {
             if ($product->has('stock') && $product->get('stock') !== null && $product->get('stock') < $request->quantity) {
                 return $this->withErrors($request, __("There's not enough stock to fulfil the quantity you selected. Please try again later."));
             }
-        } elseif ($product->purchasableType() === 'variants') {
+        } elseif ($product->purchasableType() === ProductType::VARIANT()) {
             $variant = $product->variant($request->get('variant'));
 
             if ($variant !== null && $variant->stockCount() !== null && $variant->stockCount() < $request->quantity) {

--- a/src/Orders/Calculator.php
+++ b/src/Orders/Calculator.php
@@ -6,6 +6,7 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Calculator as Contract;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product as ProductAPI;
 use DoubleThreeDigital\SimpleCommerce\Facades\Shipping;
+use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 
 class Calculator implements Contract
@@ -65,7 +66,7 @@ class Calculator implements Contract
     {
         $product = ProductAPI::find($lineItem['product']);
 
-        if ($product->purchasableType() === 'variants') {
+        if ($product->purchasableType() === ProductType::VARIANT()) {
             $variant = $product->variant(
                 isset($lineItem['variant']['variant']) ? $lineItem['variant']['variant'] : $lineItem['variant']
             );

--- a/src/Products/Product.php
+++ b/src/Products/Product.php
@@ -35,13 +35,13 @@ class Product implements Contract
         return (int) $this->get('stock');
     }
 
-    public function purchasableType(): string
+    public function purchasableType(): ProductType
     {
         if (isset($this->data()['product_variants']['variants'])) {
-            return 'variants';
+            return ProductType::VARIANT();
         }
 
-        return 'product';
+        return ProductType::PRODUCT();
     }
 
     public function variants(): Collection

--- a/src/Products/Product.php
+++ b/src/Products/Product.php
@@ -28,7 +28,7 @@ class Product implements Contract
 
     public function stockCount()
     {
-        if ($this->purchasableType() === 'variants' || ! $this->has('stock')) {
+        if ($this->purchasableType() === ProductType::VARIANT() || ! $this->has('stock')) {
             return null;
         }
 

--- a/src/Products/ProductType.php
+++ b/src/Products/ProductType.php
@@ -9,4 +9,5 @@ use Spatie\Enum\Enum;
  * @method static self VARIANT()
  */
 class ProductType extends Enum
-{}
+{
+}

--- a/src/Products/ProductType.php
+++ b/src/Products/ProductType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Products;
+
+use Spatie\Enum\Enum;
+
+/**
+ * @method static self PRODUCT()
+ * @method static self VARIANT()
+ */
+class ProductType extends Enum
+{}


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request introduces a mostly backend change to Simple Commerce. Essentially, it changes what is returned from the Product class's `purchasableType` method.

SC now makes use of [Spatie's Enum](https://github.com/spatie/enum) package to provide what are essentially enums (a variant product, or a standard product product).

We can't take advantage of PHP's new Enum functionality as we need to support versions below PHP 8.1.