### PR TITLE
v2.4: Tidy up temporary gateway data

### DIFF
--- a/src/Listeners/TidyTemporaryGatewayData.php
+++ b/src/Listeners/TidyTemporaryGatewayData.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Listeners;
+
+use DoubleThreeDigital\SimpleCommerce\Events\PostCheckout;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+
+class TidyTemporaryGatewayData
+{
+    public function handle(PostCheckout $event)
+    {
+        $order = $event->order;
+
+        collect(SimpleCommerce::gateways())->pluck('handle')->each(function ($gatewayHandle) use ($order) {
+            $order->set($gatewayHandle, null);
+        });
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -42,6 +42,9 @@ class ServiceProvider extends AddonServiceProvider
         Events\OrderPaid::class => [
             Listeners\SendConfiguredNotifications::class,
         ],
+        Events\PostCheckout::class => [
+            Listeners\TidyTemporaryGatewayData::class,
+        ],
         Events\StockRunningLow::class => [
             Listeners\SendConfiguredNotifications::class,
         ],


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request introduces a change in v2.4 which will automatically tidy up the temporary data left around on order entries.

You'll often see things like these lying around in your order entries:

```yaml
stripe:
  intent: pi_whatever
  client_secret: pi_whateveragain_secret_something
```

^ That's the kind of temporary data we're talking about. It'll be tidied up after the order has been marked as paid.

Kind of related to #498 which simplified the gateway data system.