### PR TITLE
Coupons limit to specific customers

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   php_tests:
     # runs-on: ubuntu-latest
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: buildjet-8vcpu-ubuntu-2004
 
     strategy:
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   php_tests:
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
+    runs-on: buildjet-2vcpu-ubuntu-2004
 
     strategy:
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,8 +6,7 @@ on:
 
 jobs:
   php_tests:
-    # runs-on: ubuntu-latest
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   php_tests:
     # runs-on: ubuntu-latest
-    runs-on: buildjet-2vcpu-ubuntu-2004
+    runs-on: buildjet-4vcpu-ubuntu-2004
 
     strategy:
       matrix:

--- a/resources/blueprints/collections/coupons/coupon.yaml
+++ b/resources/blueprints/collections/coupons/coupon.yaml
@@ -7,11 +7,12 @@ sections:
         handle: title
         field:
           type: textarea
+          required: true
           instructions: 'Give yourself a reminder of what this coupon is for.'
-          localizable: false
           listable: hidden
           display: Description
-          validate: required
+          validate:
+            - required
       -
         handle: type
         field:
@@ -25,7 +26,6 @@ sections:
           push_tags: false
           cast_booleans: false
           type: select
-          localizable: false
           listable: hidden
           display: Type
           validate: required
@@ -35,7 +35,6 @@ sections:
         field:
           input_type: text
           type: text
-          localizable: false
           listable: hidden
           display: Value
           validate: required
@@ -44,7 +43,6 @@ sections:
         handle: optional_settings
         field:
           type: section
-          localizable: false
           listable: hidden
           display: 'Optional Settings'
       -
@@ -53,7 +51,6 @@ sections:
           input_type: text
           type: text
           instructions: 'If set, this coupon will only be able to be used a certain amount of times.'
-          localizable: false
           width: 50
           listable: hidden
           display: 'Maximum Uses'
@@ -63,7 +60,6 @@ sections:
           read_only: false
           type: money
           instructions: 'What''s the minimum items total a cart should have before this coupon can be redeemed?'
-          localizable: false
           width: 50
           listable: hidden
           display: 'Minimum Cart Value'
@@ -77,24 +73,40 @@ sections:
           type: entries
           icon: entries
           listable: hidden
+          width: 50
+          instructions: 'If selected, this coupon will only be valid when any of the products are present.'
+      -
+        handle: customers
+        field:
+          mode: default
+          collections:
+            - customers
+          display: Customers
+          type: entries
+          icon: entries
+          instructions: 'If selected, this coupon will only be valid for selected customers.'
+          width: 50
+          listable: hidden
   sidebar:
     display: Sidebar
     fields:
       -
         handle: slug
         field:
-          generate: true
           type: slug
-          localizable: false
+          required: true
+          localizable: true
+          generate: true
           listable: hidden
           display: 'Coupon Code'
+          validate:
+            - required
       -
         handle: redeemed
         field:
           input_type: number
           type: text
           instructions: 'Amount of times this coupon has been redeemed.'
-          localizable: false
           listable: hidden
           display: Redeemed
           read_only: true

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -5,7 +5,6 @@ namespace DoubleThreeDigital\SimpleCommerce\Coupons;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Coupon as Contract;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\CouponNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderFacade;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use DoubleThreeDigital\SimpleCommerce\Support\Traits\HasData;

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -5,6 +5,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Coupons;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Coupon as Contract;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\CouponNotFound;
+use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderFacade;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use DoubleThreeDigital\SimpleCommerce\Support\Traits\HasData;
@@ -71,6 +72,14 @@ class Coupon implements Contract
             }
         }
 
+        if ($this->isCustomerSpecific()) {
+            $isCustomerAllowed = collect($this->get('customers'))->contains($order->get('customer'));
+
+            if (! $isCustomerAllowed) {
+                return false;
+            }
+        }
+
         return true;
     }
 
@@ -87,6 +96,12 @@ class Coupon implements Contract
     {
         return $this->has('products')
             && collect($this->get('products'))->count() >= 1;
+    }
+
+    protected function isCustomerSpecific()
+    {
+        return $this->has('customers')
+            && collect($this->get('customers'))->count() >= 1;
     }
 
     public function collection(): string

--- a/tests/Http/Controllers/CouponControllerTest.php
+++ b/tests/Http/Controllers/CouponControllerTest.php
@@ -269,7 +269,7 @@ class CouponControllerTest extends TestCase
         $customer = Customer::create([
             'name' => 'John Doe',
             'email' => 'john@doe.com',
-        ])->save();
+        ]);
 
         $this->cart->set('customer', $customer->id);
 
@@ -317,7 +317,7 @@ class CouponControllerTest extends TestCase
         $customer = Customer::create([
             'name' => 'John Doe',
             'email' => 'john@doe.com',
-        ])->save();
+        ]);
 
         $this->cart->set('customer', null);
 


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request introduces the ability to limit coupons to only be used by specific customers.

When configuring your coupon, in addition to limiting the products, you may now also limit the customers:

![image](https://user-images.githubusercontent.com/19637309/148644698-a9d2c9ee-67d9-4707-a49d-bc46f60a1956.png)

This new feature will work if you store customers as entries and if you store customers as normal Statamic users.