### PR TITLE
Orders Tag

### DIFF
--- a/docs/tags.md
+++ b/docs/tags.md
@@ -6,22 +6,23 @@ title: Tags
 
 To help you integrate Simple Commerce into your Antlers templates, Simple Commerce provides various tags:
 
-* [Cart](/tags/cart)
-* [Checkout](/tags/checkout)
-* [Countries](/tags/countries)
-* [Coupon](/tags/coupon)
-* [Currencies](/tags/currencies)
-* [Customer](/tags/customer)
-* [Gateways](/tags/gateways)
-* [Shipping](/tags/shipping)
+- [Cart](/tags/cart)
+- [Checkout](/tags/checkout)
+- [Countries](/tags/countries)
+- [Coupon](/tags/coupon)
+- [Currencies](/tags/currencies)
+- [Customer](/tags/customer)
+- [Gateways](/tags/gateways)
+- [Orders](/tags/orders)
+- [Shipping](/tags/shipping)
 
 ## Form Tags
 
 Some Simple Commerce tags output `<form>` elements that submit to Simple Commerce endpoints. There's a couple of optional parameters you can add to form tags.
 
-* `redirect` - the URL where you'd like to redirect the user after a successful form submission.
-* `error_redirect` - the URL where you'd like to redirect the user after any validation errors are thrown by the form.
-* `request` - the name of the [Form Request](https://laravel.com/docs/master/validation#creating-form-requests) you wish to use for validation of the form.
+- `redirect` - the URL where you'd like to redirect the user after a successful form submission.
+- `error_redirect` - the URL where you'd like to redirect the user after any validation errors are thrown by the form.
+- `request` - the name of the [Form Request](https://laravel.com/docs/master/validation#creating-form-requests) you wish to use for validation of the form.
 
 ```antlers
 {{ sc:cart:addItem redirect="/cart" }}
@@ -45,11 +46,11 @@ Like noted above, you can use the `request` parameter when creating form tags to
 
 Although you can specify the `request` parameter on any form tag, not all of them will actually use it. Here's a list of the forms that do:
 
-* `{{ sc:cart:addItem }}`
-* `{{ sc:cart:updateItem }}`
-* `{{ sc:cart:update }}`
-* `{{ sc:customer:update }}`
-* `{{ sc:checkout }}`
+- `{{ sc:cart:addItem }}`
+- `{{ sc:cart:updateItem }}`
+- `{{ sc:cart:update }}`
+- `{{ sc:customer:update }}`
+- `{{ sc:checkout }}`
 
 ## Blade support
 

--- a/docs/tags/order.md
+++ b/docs/tags/order.md
@@ -1,0 +1,13 @@
+---
+title: Order Tag
+---
+
+## Receipt URL
+
+If you need to get the Receipt URL for a specific order, here's a real easy way of doing this:
+
+```antlers
+<a href="{{ sc:order:receiptUrl order="one-two-three" }}" target="_blank">Download receipt</a>
+```
+
+You're required to pass in the ID of the order as the `order` parameter. The tag will output a URL.

--- a/src/Tags/OrderTags.php
+++ b/src/Tags/OrderTags.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Tags;
+
+use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use Statamic\Tags\Tags;
+
+class OrderTags extends Tags
+{
+    public function receiptUrl()
+    {
+        $order = Order::find($this->params->get('order'));
+
+        return $order->receiptUrl();
+    }
+}

--- a/src/Tags/SimpleCommerceTag.php
+++ b/src/Tags/SimpleCommerceTag.php
@@ -18,6 +18,7 @@ class SimpleCommerceTag extends Tags
         'coupon'   => CouponTags::class,
         'customer' => CustomerTags::class,
         'gateways' => GatewayTags::class,
+        'order'    => OrderTags::class,
         'shipping' => ShippingTags::class,
     ];
 
@@ -43,11 +44,19 @@ class SimpleCommerceTag extends Tags
         }
 
         if (method_exists($class, $method)) {
-            return (new $class($this))->{$method}();
+            return (new $class($this))
+                ->setContent($this->content)
+                ->setContext($this->context)
+                ->setParameters($this->params)
+                ->{$method}();
         }
 
         if (method_exists($class, 'wildcard')) {
-            return (new $class($this))->wildcard($method);
+            return (new $class($this))
+                ->setContent($this->content)
+                ->setContext($this->context)
+                ->setParameters($this->params)
+                ->wildcard($method);
         }
 
         throw new TagNotFoundException("Tag [{$tag[0]}] could not be found.");


### PR DESCRIPTION
This pull request introduces a new `{{ sc:order }}` tag. The only method on this tag right now is to let users grab the receipt URL for a specific order.

```antlers
<a href="{{ sc:order:receiptUrl order="one-two-three" }}" target="_blank">Download receipt</a>
```

This PR also ensures that the tag content, context & parameters are passed into Simple Commerce's 'sub-tags'.