### PR TITLE
Fix issue with coupons not being augmented properly

### DIFF
--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -10,7 +10,6 @@ use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use DoubleThreeDigital\SimpleCommerce\Support\Traits\HasData;
 use DoubleThreeDigital\SimpleCommerce\Support\Traits\IsEntry;
 use Statamic\Facades\Entry;
-use Statamic\Fields\Field;
 
 class Coupon implements Contract
 {
@@ -34,7 +33,7 @@ class Coupon implements Contract
             ->where('slug', $code)
             ->first();
 
-        if (!$entry) {
+        if (! $entry) {
             throw new CouponNotFound("Coupon [{$code}] could not be found.");
         }
 

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -10,6 +10,7 @@ use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use DoubleThreeDigital\SimpleCommerce\Support\Traits\HasData;
 use DoubleThreeDigital\SimpleCommerce\Support\Traits\IsEntry;
 use Statamic\Facades\Entry;
+use Statamic\Fields\Field;
 
 class Coupon implements Contract
 {
@@ -33,7 +34,7 @@ class Coupon implements Contract
             ->where('slug', $code)
             ->first();
 
-        if (! $entry) {
+        if (!$entry) {
             throw new CouponNotFound("Coupon [{$code}] could not be found.");
         }
 
@@ -87,6 +88,20 @@ class Coupon implements Contract
     {
         return $this->has('products')
             && collect($this->get('products'))->count() >= 1;
+    }
+
+    public function toAugmentedArray($keys = null)
+    {
+        $blueprintFields = $this->blueprint()->fields()->items()->reject(function ($field) {
+            return $field['handle'] === 'value';
+        })->pluck('handle')->toArray();
+
+        $augmentedData = $this->entry()->toAugmentedArray($blueprintFields);
+
+        return array_merge(
+            $this->toArray(),
+            $augmentedData,
+        );
     }
 
     public function collection(): string

--- a/tests/Http/Controllers/CheckoutControllerTest.php
+++ b/tests/Http/Controllers/CheckoutControllerTest.php
@@ -384,7 +384,7 @@ class CheckoutControllerTest extends TestCase
     /** @test */
     public function can_post_checkout_with_coupon()
     {
-        $this->markTestSkipped('Breaks every so often, needs fixed.');
+        // $this->markTestSkipped('Breaks every so often, needs fixed.');
 
         Config::set('simple-commerce.sites.default.tax.rate', 0);
         Config::set('simple-commerce.sites.default.shipping.methods', []);


### PR DESCRIPTION
This pull request fixes an issue where coupons weren't aren't being augmented properly.

Basically, augmentation for coupons is currently broken as the percent/amount field is called `handle` (due to statamic/cms#2495). This pull request doesn't really fix it but workaround it for now when using the coupon in Simple Commerce.

In the long term, Statamic will fix the issue with fields with the handle `value` or we will change it to something like `amount` which would need to be done as a breaking change. 

Fixes #558