### PR TITLE
Validate against spaces in email addresses

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -47,6 +47,7 @@ return [
         'country_exists' => 'The selected country is not recognised.',
         'is_a_gateway' => ':value is not a gateway',
         'valid_coupon' => 'Sorry, this coupon is not valid for your order.',
+        'email_address_contains_spaces' => 'Your email may not contain any spaces.',
     ],
 
     'customer_title'            => ':name <:email>',

--- a/src/Http/Requests/Cart/UpdateRequest.php
+++ b/src/Http/Requests/Cart/UpdateRequest.php
@@ -22,8 +22,21 @@ class UpdateRequest extends FormRequest
             return $this->buildFormRequest($formRequest, $this)->rules();
         }
 
+        $rules = array_merge($this->getCart()->rules(), [
+            'email' => ['nullable', 'email', function ($attribute, $value, $fail) {
+                if (preg_match('/^\S*$/u', $value) === 0) {
+                    return $fail(__('Your email may not contain any spaces.'));
+                }
+            }],
+            'customer.email' => ['nullable', 'email', function ($attribute, $value, $fail) {
+                if (preg_match('/^\S*$/u', $value) === 0) {
+                    return $fail(__('Your email may not contain any spaces.'));
+                }
+            }],
+        ]);
+
         // v2.4 TODO: Don't validate against blueprints anymore, use an empty array here
-        return Arr::except($this->getCart()->rules(), [
+        return Arr::except($rules, [
             'title',
             'items',
             'slug',

--- a/src/Http/Requests/Cart/UpdateRequest.php
+++ b/src/Http/Requests/Cart/UpdateRequest.php
@@ -25,12 +25,12 @@ class UpdateRequest extends FormRequest
         $rules = array_merge($this->getCart()->rules(), [
             'email' => ['nullable', 'email', function ($attribute, $value, $fail) {
                 if (preg_match('/^\S*$/u', $value) === 0) {
-                    return $fail(__('Your email may not contain any spaces.'));
+                    return $fail(__('simple-commerce::validation.email_address_contains_spaces'));
                 }
             }],
             'customer.email' => ['nullable', 'email', function ($attribute, $value, $fail) {
                 if (preg_match('/^\S*$/u', $value) === 0) {
-                    return $fail(__('Your email may not contain any spaces.'));
+                    return $fail(__('simple-commerce::validation.email_address_contains_spaces'));
                 }
             }],
         ]);

--- a/src/Http/Requests/CartItem/StoreRequest.php
+++ b/src/Http/Requests/CartItem/StoreRequest.php
@@ -23,6 +23,17 @@ class StoreRequest extends FormRequest
             'product'  => ['required', 'string'],
             'variant'  => ['string'],
             'quantity' => ['required', 'numeric', 'gt:0'],
+
+            'email' => ['nullable', 'email', function ($attribute, $value, $fail) {
+                if (preg_match('/^\S*$/u', $value) === 0) {
+                    return $fail(__('Your email may not contain any spaces.'));
+                }
+            }],
+            'customer.email' => ['nullable', 'email', function ($attribute, $value, $fail) {
+                if (preg_match('/^\S*$/u', $value) === 0) {
+                    return $fail(__('Your email may not contain any spaces.'));
+                }
+            }],
         ];
 
         if ($formRequest = $this->get('_request')) {

--- a/src/Http/Requests/CartItem/StoreRequest.php
+++ b/src/Http/Requests/CartItem/StoreRequest.php
@@ -26,12 +26,12 @@ class StoreRequest extends FormRequest
 
             'email' => ['nullable', 'email', function ($attribute, $value, $fail) {
                 if (preg_match('/^\S*$/u', $value) === 0) {
-                    return $fail(__('Your email may not contain any spaces.'));
+                    return $fail(__('simple-commerce::validation.email_address_contains_spaces'));
                 }
             }],
             'customer.email' => ['nullable', 'email', function ($attribute, $value, $fail) {
                 if (preg_match('/^\S*$/u', $value) === 0) {
-                    return $fail(__('Your email may not contain any spaces.'));
+                    return $fail(__('simple-commerce::validation.email_address_contains_spaces'));
                 }
             }],
         ];

--- a/tests/Http/Controllers/CartControllerTest.php
+++ b/tests/Http/Controllers/CartControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Tests\Http\Controllers;
 
+use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
 use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
@@ -180,6 +181,35 @@ class CartControllerTest extends TestCase
     }
 
     /** @test */
+    public function cant_update_cart_and_create_new_customer_if_email_contains_spaces()
+    {
+        $cart = Order::create()->save();
+
+        $data = [
+            'name'  => 'Joe Mo',
+            'email' => 'joe mo@gmail.com',
+        ];
+
+        $response = $this
+            ->from('/cart')
+            ->withSession(['simple-commerce-cart' => $cart->id])
+            ->post(route('statamic.simple-commerce.cart.update'), $data)
+            ->assertSessionHasErrors('email');
+
+        $cart->find($cart->id);
+
+        $this->assertArrayNotHasKey('customer', $cart->data);
+
+        try {
+            Customer::findByEmail($data['email']);
+
+            $this->assertTrue(false);
+        } catch (CustomerNotFound $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    /** @test */
     public function can_update_cart_and_existing_customer_by_id()
     {
         $customer = Customer::create()->data([
@@ -266,6 +296,37 @@ class CartControllerTest extends TestCase
         $this->assertSame($customer->data['name'], 'Rebecca Logan');
         $this->assertSame($customer->title, 'Rebecca Logan <rebecca.logan@example.com>');
         $this->assertSame($customer->slug, 'rebeccalogan-at-examplecom');
+    }
+
+    /** @test */
+    public function cant_update_cart_and_create_new_customer_via_customer_array_if_email_contains_spaces()
+    {
+        $cart = Order::create()->save();
+
+        $data = [
+            'customer' => [
+                'name'  => 'CJ Cregg',
+                'email' => 'cj cregg@example.com',
+            ],
+        ];
+
+        $response = $this
+            ->from('/cart')
+            ->withSession(['simple-commerce-cart' => $cart->id])
+            ->post(route('statamic.simple-commerce.cart.update'), $data)
+            ->assertSessionHasErrors();
+
+        $cart->find($cart->id);
+
+        $this->assertNull($cart->get('customer'));
+
+        try {
+            Customer::findByEmail('cj cregg@example.com');
+
+            $this->assertTrue(false);
+        } catch (CustomerNotFound $e) {
+            $this->assertTrue(true);
+        }
     }
 
     /**

--- a/tests/Http/Controllers/CartItemControllerTest.php
+++ b/tests/Http/Controllers/CartItemControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Tests\Http\Controllers;
 
+use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
 use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
@@ -36,10 +37,10 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $cart = Order::find(session()->get('simple-commerce-cart'));
@@ -65,7 +66,7 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->postJson(route('statamic.simple-commerce.cart-items.store'), $data);
 
         $response->assertJsonStructure([
@@ -99,10 +100,10 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $cart = Order::find(session()->get('simple-commerce-cart'));
@@ -130,10 +131,10 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHasErrors('smth');
     }
 
@@ -174,10 +175,10 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $cart = Order::find(session()->get('simple-commerce-cart'));
@@ -224,10 +225,10 @@ class CartItemControllerTest extends TestCase
 
         $response = $this
             ->withSession(['simple-commerce-cart' => $cart->id])
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $cart = Order::find(session()->get('simple-commerce-cart'));
@@ -286,10 +287,10 @@ class CartItemControllerTest extends TestCase
 
         $response = $this
             ->withSession(['simple-commerce-cart' => $cart->id])
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $cart = Order::find(session()->get('simple-commerce-cart'));
@@ -323,11 +324,11 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->withSession(['simple-commerce-cart' => $cart->id])
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHas('simple-commerce-cart');
         $this->assertSame(1000, $cart->data['items_total']);
 
@@ -355,7 +356,7 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->withSession(['simple-commerce-cart' => $cart->id])
             ->post(route('statamic.simple-commerce.cart-items.store'), $data)
             ->assertSessionHasErrors();
@@ -401,7 +402,7 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->withSession(['simple-commerce-cart' => $cart->id])
             ->post(route('statamic.simple-commerce.cart-items.store'), $data)
             ->assertSessionHasErrors();
@@ -437,11 +438,11 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$productTwo->slug)
+            ->from('/products/' . $productTwo->slug)
             ->withSession(['simple-commerce-cart' => $cart->id])
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$productTwo->slug);
+        $response->assertRedirect('/products/' . $productTwo->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $cart = $cart->find($cart->id);
@@ -469,7 +470,7 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
         $response->assertRedirect('/checkout');
@@ -499,10 +500,10 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $cart = Order::find(session()->get('simple-commerce-cart'));
@@ -520,6 +521,36 @@ class CartItemControllerTest extends TestCase
     }
 
     /** @test */
+    public function cant_store_item_with_email_that_contains_spaces()
+    {
+        $product = Product::create([
+            'title' => 'Dog Food',
+            'price' => 1000,
+        ]);
+
+        $data = [
+            'product'  => $product->id,
+            'quantity' => 1,
+            'name' => 'Spud Man',
+            'email' => 'spud man@potato.net',
+        ];
+
+        $response = $this
+            ->from('/products/' . $product->slug)
+            ->post(route('statamic.simple-commerce.cart-items.store'), $data)
+            ->assertSessionHasErrors()
+            ->assertSessionMissing('simple-commerce-cart');
+
+        try {
+            Customer::findByEmail('spud man@potato.net');
+
+            $this->assertTrue(false);
+        } catch (CustomerNotFound $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    /** @test */
     public function can_store_item_with_only_email()
     {
         $product = Product::create([
@@ -534,10 +565,10 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $cart = Order::find(session()->get('simple-commerce-cart'));
@@ -578,10 +609,10 @@ class CartItemControllerTest extends TestCase
 
         $response = $this
             ->withSession(['simple-commerce-cart' => $order->id()])
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $cart = Order::find(session()->get('simple-commerce-cart'));
@@ -618,10 +649,10 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $cart = Order::find(session()->get('simple-commerce-cart'));
@@ -678,10 +709,10 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $cart = Order::find(session()->get('simple-commerce-cart'));
@@ -712,10 +743,10 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $response->assertSessionHasErrors();
@@ -754,10 +785,10 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHas('simple-commerce-cart');
 
         $response->assertSessionHasErrors();
@@ -802,7 +833,7 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$productTwo->slug)
+            ->from('/products/' . $productTwo->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
         $response->assertRedirect('/checkout');
@@ -998,10 +1029,10 @@ class CartItemControllerTest extends TestCase
         ];
 
         $response = $this
-            ->from('/products/'.$product->slug)
+            ->from('/products/' . $product->slug)
             ->post(route('statamic.simple-commerce.cart-items.store'), $data);
 
-        $response->assertRedirect('/products/'.$product->slug);
+        $response->assertRedirect('/products/' . $product->slug);
         $response->assertSessionHasErrors();
     }
 


### PR DESCRIPTION
This pull request adds validation against spaces being allowed in customer emails, submitted via the `{{ sc:cart }}` form tags.

This PR partially fixes #564.