### PR TITLE
Customer entry slug should be the email, not a slugified version of the email

### DIFF
--- a/resources/blueprints/collections/customers/customers.yaml
+++ b/resources/blueprints/collections/customers/customers.yaml
@@ -3,16 +3,14 @@ sections:
   main:
     display: Main
     fields:
-      -
-        handle: title
+      - handle: title
         field:
           input_type: text
           type: text
           localizable: false
           listable: hidden
           display: Title
-      -
-        handle: name
+      - handle: name
         field:
           input_type: text
           type: text
@@ -21,8 +19,7 @@ sections:
           listable: hidden
           display: Name
           validate: required
-      -
-        handle: email
+      - handle: email
         field:
           input_type: email
           type: text
@@ -34,11 +31,11 @@ sections:
   sidebar:
     display: Sidebar
     fields:
-      -
-        handle: slug
+      - handle: slug
         field:
           input_type: text
           type: text
           localizable: false
           listable: hidden
           display: Slug
+          read_only: true

--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -73,12 +73,10 @@ class Customer implements Contract
             'email' => $email,
         ]);
 
-        $slug = $email;
-
         $this->title = $title;
         $this->data['title'] = $title;
 
-        $this->slug = $slug;
+        $this->slug = $email;
 
         return $this;
     }

--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -33,7 +33,7 @@ class Customer implements Contract
     {
         $entry = Entry::query()
             ->where('collection', $this->collection())
-            ->where('slug', Str::slug($email))
+            ->whereIn('slug', [$email, Str::slug($email)])
             ->first();
 
         if (! $entry) {
@@ -73,7 +73,7 @@ class Customer implements Contract
             'email' => $email,
         ]);
 
-        $slug = Str::slug($email);
+        $slug = $email;
 
         $this->title = $title;
         $this->data['title'] = $title;


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request changes the slug (& by extension, the filename) of customer entries. Instead of being a slugified version of an email, like `duncan-at-doublethree-digital`, it will now be `duncan@doublethree.digital`.

Fixed the remainder of #564.

## To Do

* [X] New customer entries will use email address for slug/filename
* [X] `findByEmail` will now check either combinations: email string or slugified email string
* [ ] Add some tests to ensure old entries are found correctly & new entries just use the email