### PR TITLE
Attach receipt to back-office email

### DIFF
--- a/src/Notifications/BackOfficeOrderPaid.php
+++ b/src/Notifications/BackOfficeOrderPaid.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Notifications;
 
+use Barryvdh\DomPDF\Facade as PDF;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Currency;
 use Illuminate\Bus\Queueable;
@@ -46,14 +47,21 @@ class BackOfficeOrderPaid extends Notification
      */
     public function toMail($notifiable)
     {
+        $pdf = PDF::loadView('simple-commerce::receipt', $this->order->toAugmentedArray());
+
         return (new MailMessage)
             ->subject("New Order: {$this->order->title()}")
             ->line("Order **{$this->order->title()}** has just been paid and is ready for fulfilment.")
             ->line('# Order Details')
-            ->line('Grand Total: '.Currency::parse($this->order->get('grand_total'), Site::current()))
-            ->line('Items Total: '.Currency::parse($this->order->get('items_total'), Site::current()))
-            ->line('Shipping Total: '.Currency::parse($this->order->get('shipping_total'), Site::current()))
-            ->line('Customer: '.optional($this->order->customer())->email() ?? 'Guest')
-            ->line('Payment Gateway: '.optional($this->order->gateway())['display'] ?? 'N/A');
+            ->line('Grand Total: ' . Currency::parse($this->order->get('grand_total'), Site::current()))
+            ->line('Items Total: ' . Currency::parse($this->order->get('items_total'), Site::current()))
+            ->line('Shipping Total: ' . Currency::parse($this->order->get('shipping_total'), Site::current()))
+            ->line('Customer: ' . optional($this->order->customer())->email() ?? 'Guest')
+            ->line('Payment Gateway: ' . optional($this->order->gateway())['display'] ?? 'N/A')
+            ->attachData(
+                $pdf->output(),
+                'receipt.pdf',
+                ['mime' => 'application/pdf']
+            );
     }
 }


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request adds the receipt as an attachment to the out-of-the-box back-office email sent after an order has been marked as paid.

Fixes #569.