### PR TITLE
Use the default error bag, rather than our own

### DIFF
--- a/src/Http/Controllers/BaseActionController.php
+++ b/src/Http/Controllers/BaseActionController.php
@@ -33,7 +33,7 @@ class BaseActionController extends Controller
         }
 
         return $request->_error_redirect
-            ? redirect($request->_error_redirect)->withErrors($errorMessage, 'simple-commerce')
-            : back()->withErrors($errorMessage, 'simple-commerce');
+            ? redirect($request->_error_redirect)->withErrors($errorMessage)
+            : back()->withErrors($errorMessage);
     }
 }

--- a/src/Tags/Concerns/FormBuilder.php
+++ b/src/Tags/Concerns/FormBuilder.php
@@ -40,12 +40,12 @@ trait FormBuilder
 
     private function redirectField()
     {
-        return '<input type="hidden" name="_redirect" value="'.$this->params->get('redirect').'" />';
+        return '<input type="hidden" name="_redirect" value="' . $this->params->get('redirect') . '" />';
     }
 
     private function requestField()
     {
-        return '<input type="hidden" name="_request" value="'.$this->params->get('request').'" />';
+        return '<input type="hidden" name="_request" value="' . $this->params->get('request') . '" />';
     }
 
     private function params(): array
@@ -70,7 +70,7 @@ trait FormBuilder
 
         $errors = [];
 
-        foreach (session('errors')->getBag('simple-commerce')->all() as $error) {
+        foreach (session('errors')->getBag('default')->all() as $error) {
             $errors[]['value'] = $error;
         }
 
@@ -85,7 +85,7 @@ trait FormBuilder
     private function hasErrors(): bool
     {
         return (session()->has('errors'))
-            ? session('errors')->hasBag('simple-commerce')
+            ? session('errors')->hasBag('default')
             : false;
     }
 
@@ -97,7 +97,7 @@ trait FormBuilder
     private function getErrorBag()
     {
         if ($this->hasErrors()) {
-            return session('errors')->getBag('simple-commerce');
+            return session('errors')->getBag('default');
         }
     }
 }

--- a/src/Tags/SimpleCommerceTag.php
+++ b/src/Tags/SimpleCommerceTag.php
@@ -112,7 +112,7 @@ class SimpleCommerceTag extends Tags
 
         $errors = [];
 
-        foreach (session('errors')->getBag('simple-commerce')->all() as $error) {
+        foreach (session('errors')->getBag('default')->all() as $error) {
             $errors[]['value'] = $error;
         }
 


### PR DESCRIPTION
This pull request fixes issues where the error tags in Simple Commerce wouldn't work properly because they'd be looking for errors in a `simple-commerce` error bag but our controllers would be returning those errors in the `default` error bag.

To stay inline with how Statamic does it's error handling, we'll just use the `default` error bag. 

Closes #581. Relates to #582 (which does the same but for v2.4)