### PR TITLE
Add 'Simple Commerce' tab to Laravel Debugbar

### DIFF
--- a/src/DebugbarDataCollector.php
+++ b/src/DebugbarDataCollector.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce;
+
+use DoubleThreeDigital\SimpleCommerce\Facades\Currency;
+use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use Statamic\Facades\Site;
+
+class DebugbarDataCollector extends \DebugBar\DataCollector\DataCollector implements \DebugBar\DataCollector\Renderable
+{
+    use CartDriver;
+
+    public function collect()
+    {
+        $cart = $this->getCart();
+
+        return [
+            'Cart ID' => $cart->id,
+            'Line Items' => $cart->lineItems()->map(function ($lineItem) {
+                $product = Product::find($lineItem['product']);
+
+                $formattedTaxAmount = Currency::parse($lineItem['tax']['amount'], Site::current());
+                $formattedItemAmount = Currency::parse($lineItem['total'], Site::current());
+
+                return "{$lineItem['quantity']} X {$product->get('title')} (Tax: {$formattedTaxAmount}, Total: {$formattedItemAmount})";
+            })->join(', '),
+            'Items Total' => Currency::parse($cart->get('items_total'), Site::current()),
+            'Tax Total' => Currency::parse($cart->get('tax_total'), Site::current()),
+            'Shipping Total' => Currency::parse($cart->get('shipping_total'), Site::current()),
+            'Coupon Total' => Currency::parse($cart->get('coupon_total'), Site::current()),
+            'Grand Total' => Currency::parse($cart->get('grand_total'), Site::current()),
+            'Site Currency' => Currency::get(Site::current())['symbol'] . ' ' . Currency::get(Site::current())['name'],
+            'Enabled Gateways' => collect(SimpleCommerce::gateways())->pluck('name')->join(', '),
+        ];
+    }
+
+    public function getName()
+    {
+        return 'simple-commerce';
+    }
+
+    public function getWidgets()
+    {
+        return [
+            'simple-commerce' => [
+                'icon' => 'shopping-cart',
+                'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
+                'map' => 'simple-commerce',
+                'default' => '{}',
+            ],
+        ];
+    }
+}

--- a/src/DebugbarDataCollector.php
+++ b/src/DebugbarDataCollector.php
@@ -37,16 +37,16 @@ class DebugbarDataCollector extends \DebugBar\DataCollector\DataCollector implem
 
     public function getName()
     {
-        return 'simple-commerce';
+        return 'Simple Commerce';
     }
 
     public function getWidgets()
     {
         return [
-            'simple-commerce' => [
+            'Simple Commerce' => [
                 'icon' => 'shopping-cart',
                 'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
-                'map' => 'simple-commerce',
+                'map' => 'Simple Commerce',
                 'default' => '{}',
             ],
         ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\SimpleCommerce;
 
+use Barryvdh\Debugbar\Facade as Debugbar;
 use Statamic\Events\EntryBlueprintFound;
 use Statamic\Facades\CP\Nav;
 use Statamic\Facades\Permission;
@@ -125,7 +126,7 @@ class ServiceProvider extends AddonServiceProvider
         Filters\OrderStatusFilter::register();
 
         if (class_exists('Barryvdh\Debugbar\ServiceProvider') && config('debugbar.enabled', false) === true) {
-            \Barryvdh\Debugbar\Facade::addCollector(new DebugbarDataCollector('simple-commerce'));
+            Debugbar::addCollector(new DebugbarDataCollector('simple-commerce'));
         }
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -123,6 +123,10 @@ class ServiceProvider extends AddonServiceProvider
         });
 
         Filters\OrderStatusFilter::register();
+
+        if (class_exists('Barryvdh\Debugbar\ServiceProvider') && config('debugbar.enabled', false) === true) {
+            \Barryvdh\Debugbar\Facade::addCollector(new DebugbarDataCollector('simple-commerce'));
+        }
     }
 
     protected function bootVendorAssets()


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request adds a new 'Simple Commerce' tab to the Laravel Debugbar (if installed). It lets you view things like the current cart ID, line items, total, enabled gateways etc.

![image](https://user-images.githubusercontent.com/19637309/159357566-14dcea9c-514c-433d-aa9b-0c6d6ff81dba.png)