### PR TITLE
Allow customising Stripe Payment Intent data

### DIFF
--- a/docs/gateways/stripe.md
+++ b/docs/gateways/stripe.md
@@ -72,7 +72,7 @@ Bearing in mind, you will need to use that inside of a `{{ sc:gateways }}` tag i
 
 ## Payment Intent
 
-During the 'prepare' stage, Simple Commerce creates a Stripe Payment Intent. The Payment Intent generates a 'client secret' which is later given to Stripe Elements to render the payment fields.
+During the 'prepare' stage, Simple Commerce creates a [Stripe Payment Intent](https://stripe.com/docs/payments/payment-intents#creating-a-paymentintent). The Payment Intent generates a 'client secret' which is later given to Stripe Elements to render the payment fields.
 
 Simple Commerce will automatically set the amount, currency, description and order ID (as metadata) on the Payment Intent. However, there can be times where you may need to add to the array that's sent.
 
@@ -95,3 +95,5 @@ You may do this easily by providing a closure in the Stripe gateway config:
 ```
 
 The closure should accept an `$order` parameter and should then return an array which will be merged with the defaults.
+
+It's worth nothing that Laravel doesn't support using closures in config files alongside config caching.

--- a/docs/gateways/stripe.md
+++ b/docs/gateways/stripe.md
@@ -60,7 +60,7 @@ A rough example of a Stripe Elements implementation is provided below.
             }
         })
     }
-    
+
     document.getElementById('checkout-form').addEventListener('submit', (e) => {
         e.preventDefault()
 	confirmPayment()
@@ -69,3 +69,29 @@ A rough example of a Stripe Elements implementation is provided below.
 ```
 
 Bearing in mind, you will need to use that inside of a `{{ sc:gateways }}` tag in order to use any values from your gateway config.
+
+## Payment Intent
+
+During the 'prepare' stage, Simple Commerce creates a Stripe Payment Intent. The Payment Intent generates a 'client secret' which is later given to Stripe Elements to render the payment fields.
+
+Simple Commerce will automatically set the amount, currency, description and order ID (as metadata) on the Payment Intent. However, there can be times where you may need to add to the array that's sent.
+
+You may do this easily by providing a closure in the Stripe gateway config:
+
+```php
+'gateways' => [
+	\DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway::class => [
+    	'key' => env('STRIPE_KEY'),
+        'secret' => env('STRIPE_SECRET'),
+        'payment_intent_data' => function ($order) {
+            return [
+                'metadata' => [
+                    'product_ids' => $order->lineItems()->pluck('product')->join(', '),
+                ],
+            ];
+        },
+    ],
+],
+```
+
+The closure should accept an `$order` parameter and should then return an array which will be merged with the defaults.

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -66,6 +66,13 @@ class StripeGateway extends BaseGateway implements Gateway
             $intentData['receipt_email'] = $customer->email();
         }
 
+        if ($this->config()->has('payment_intent_data')) {
+            $intentData = array_merge_recursive(
+                $intentData,
+                $this->config()->get('payment_intent_data')($order)
+            );
+        }
+
         $intent = PaymentIntent::create($intentData);
 
         return new GatewayResponse(true, [

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -45,9 +45,6 @@ class StripeGateway extends BaseGateway implements Gateway
             'metadata'           => [
                 'order_id' => $order->id,
             ],
-            // 'automatic_payment_methods' => [
-            //     'enabled' => 'true',
-            // ],
         ];
 
         $customer = $order->customer();

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -42,9 +42,6 @@ class StripeGateway extends BaseGateway implements Gateway
             'currency'           => Currency::get(Site::current())['code'],
             'description'        => "Order: {$order->title()}",
             'setup_future_usage' => 'off_session',
-            'metadata'           => [
-                'order_id' => $order->id,
-            ],
         ];
 
         $customer = $order->customer();
@@ -64,11 +61,15 @@ class StripeGateway extends BaseGateway implements Gateway
         }
 
         if ($this->config()->has('payment_intent_data')) {
-            $intentData = array_merge_recursive(
+            $intentData = array_merge(
                 $intentData,
                 $this->config()->get('payment_intent_data')($order)
             );
         }
+
+        // We're setting this after the rest of the payment intent data,
+        // in case the developer adds their own stuff to 'metadata'.
+        $intentData['metadata']['order_id'] = $order->id;
 
         $intent = PaymentIntent::create($intentData);
 

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -10,10 +10,10 @@ use DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Prepare;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Purchase;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Response as GatewayResponse;
+use DoubleThreeDigital\SimpleCommerce\Tests\SetupCollections;
 use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Statamic\Facades\Collection;
 use Stripe\Customer as StripeCustomer;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
@@ -21,17 +21,19 @@ use Stripe\Stripe;
 
 class StripeGatewayTest extends TestCase
 {
+    use SetupCollections;
+
     public StripeGateway $gateway;
 
     public function setUp(): void
     {
         parent::setUp();
 
+        $this->setupCollections();
+
         $this->gateway = new StripeGateway([
             'secret' => env('STRIPE_SECRET'),
         ]);
-
-        Collection::make('orders')->title('Order')->save();
     }
 
     /** @test */

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -200,7 +200,7 @@ class StripeGatewayTest extends TestCase
             'secret' => env('STRIPE_SECRET'),
             'payment_intent_data' => function (ContractsOrder $order) {
                 return [
-                    'description' => 'Some custom description',
+                    // 'description' => 'Some custom description',
                     'metadata' => [
                         'foo' => 'bar',
                     ],
@@ -238,7 +238,6 @@ class StripeGatewayTest extends TestCase
 
         $this->assertSame($paymentIntent->id, $prepare->data()['intent']);
         $this->assertSame($paymentIntent->amount, $order->get('grand_total'));
-        $this->assertSame($paymentIntent->description, 'Some custom description');
         $this->assertSame($paymentIntent->metadata->foo, 'bar');
         $this->assertNull($paymentIntent->customer);
         $this->assertNull($paymentIntent->receipt_email);

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -211,18 +211,18 @@ class StripeGatewayTest extends TestCase
         $prepare = $this->gateway->prepare(new Prepare(
             new Request(),
             $order = Order::create([
-                 'items' => [
-                     [
-                         'id' => app('stache')->generateId(),
-                         'product' => $product->id,
-                         'quantity' => 1,
-                         'total' => 5500,
-                         'metadata' => [],
-                     ],
-                 ],
-                 'grand_total' => 5500,
-                 'title' => '#0001',
-             ])
+                'items' => [
+                    [
+                        'id' => app('stache')->generateId(),
+                        'product' => $product->id,
+                        'quantity' => 1,
+                        'total' => 5500,
+                        'metadata' => [],
+                    ],
+                ],
+                'grand_total' => 5500,
+                'title' => '#0001',
+            ])
         ));
 
         $this->assertIsObject($prepare);

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -200,7 +200,7 @@ class StripeGatewayTest extends TestCase
             'secret' => env('STRIPE_SECRET'),
             'payment_intent_data' => function (ContractsOrder $order) {
                 return [
-                    // 'description' => 'Some custom description',
+                    'description' => 'Some custom description',
                     'metadata' => [
                         'foo' => 'bar',
                     ],
@@ -213,18 +213,18 @@ class StripeGatewayTest extends TestCase
         $prepare = $this->gateway->prepare(new Prepare(
             new Request(),
             $order = Order::create([
-                'items' => [
-                    [
-                        'id' => app('stache')->generateId(),
-                        'product' => $product->id,
-                        'quantity' => 1,
-                        'total' => 5500,
-                        'metadata' => [],
-                    ],
-                ],
-                'grand_total' => 5500,
-                'title' => '#0001',
-            ])
+                 'items' => [
+                     [
+                         'id' => app('stache')->generateId(),
+                         'product' => $product->id,
+                         'quantity' => 1,
+                         'total' => 5500,
+                         'metadata' => [],
+                     ],
+                 ],
+                 'grand_total' => 5500,
+                 'title' => '#0001',
+             ])
         ));
 
         $this->assertIsObject($prepare);
@@ -238,6 +238,7 @@ class StripeGatewayTest extends TestCase
 
         $this->assertSame($paymentIntent->id, $prepare->data()['intent']);
         $this->assertSame($paymentIntent->amount, $order->get('grand_total'));
+        $this->assertSame($paymentIntent->description, 'Some custom description');
         $this->assertSame($paymentIntent->metadata->foo, 'bar');
         $this->assertNull($paymentIntent->customer);
         $this->assertNull($paymentIntent->receipt_email);

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -213,18 +213,18 @@ class StripeGatewayTest extends TestCase
         $prepare = $this->gateway->prepare(new Prepare(
             new Request(),
             $order = Order::create([
-                 'items' => [
-                     [
-                         'id' => app('stache')->generateId(),
-                         'product' => $product->id,
-                         'quantity' => 1,
-                         'total' => 5500,
-                         'metadata' => [],
-                     ],
-                 ],
-                 'grand_total' => 5500,
-                 'title' => '#0001',
-             ])
+                'items' => [
+                    [
+                        'id' => app('stache')->generateId(),
+                        'product' => $product->id,
+                        'quantity' => 1,
+                        'total' => 5500,
+                        'metadata' => [],
+                    ],
+                ],
+                'grand_total' => 5500,
+                'title' => '#0001',
+            ])
         ));
 
         $this->assertIsObject($prepare);

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Tests\Gateways\Builtin;
 
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order as ContractsOrder;
 use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
@@ -184,6 +185,65 @@ class StripeGatewayTest extends TestCase
         $this->assertSame($stripeCustomer->id, $paymentIntent->customer);
         $this->assertSame($stripeCustomer->name, 'George');
         $this->assertSame($stripeCustomer->email, 'george@example.com');
+    }
+
+    /** @test */
+    public function can_prepare_with_payment_intent_data_closure()
+    {
+        if (! env('STRIPE_SECRET')) {
+            $this->markTestSkipped('Skipping, no Stripe Secret has been defined for this environment.');
+        }
+
+        $this->gateway->setConfig([
+            'secret' => env('STRIPE_SECRET'),
+            'payment_intent_data' => function (ContractsOrder $order) {
+                return [
+                    'description' => 'Some custom description',
+                    'metadata' => [
+                        'foo' => 'bar',
+                    ],
+                ];
+            },
+        ]);
+
+        $product = Product::create(['title' => 'Concert Ticket', 'price' => 5500]);
+
+        $prepare = $this->gateway->prepare(new Prepare(
+            new Request(),
+            $order = Order::create([
+                 'items' => [
+                     [
+                         'id' => app('stache')->generateId(),
+                         'product' => $product->id,
+                         'quantity' => 1,
+                         'total' => 5500,
+                         'metadata' => [],
+                     ],
+                 ],
+                 'grand_total' => 5500,
+                 'title' => '#0001',
+             ])
+        ));
+
+        $this->assertIsObject($prepare);
+        $this->assertTrue($prepare instanceof GatewayResponse);
+
+        $this->assertTrue($prepare->success());
+        $this->assertArrayHasKey('intent', $prepare->data());
+        $this->assertArrayHasKey('client_secret', $prepare->data());
+
+        $paymentIntent = PaymentIntent::retrieve($prepare->data()['intent']);
+
+        $this->assertSame($paymentIntent->id, $prepare->data()['intent']);
+        $this->assertSame($paymentIntent->amount, $order->get('grand_total'));
+        $this->assertSame($paymentIntent->description, 'Some custom description');
+        $this->assertSame($paymentIntent->metadata->foo, 'bar');
+        $this->assertNull($paymentIntent->customer);
+        $this->assertNull($paymentIntent->receipt_email);
+
+        $this->gateway->setConfig([
+            'secret' => env('STRIPE_SECRET'),
+        ]);
     }
 
     /** @test */


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request introduces a tiny new feature to Simple Commerce. Essentially, if you're using the Stripe Payment Gateway and you want to customise the array that's sent to Stripe to create a Payment Intent, you can now do it by providing a `payment_intent_data` closure as part of the gateway config.

```php
'gateways' => [
    \DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway::class => [
    	'key' => env('STRIPE_KEY'),
        'secret' => env('STRIPE_SECRET'),
        'payment_intent_data' => function ($order) {
            return [
                'metadata' => [
                    'product_ids' => $order->lineItems()->pluck('product')->join(', '),
                ],
            ];
        },
    ],
],
```

## To Do

* [X] Added the `payment_intent_data` closure
* [X] Added a test
* [X] Updated the documentation
* [x] Add note about config caching to docs
