### PR TITLE
Improvements to the 'Order Status' filter

### DIFF
--- a/src/Filters/OrderStatusFilter.php
+++ b/src/Filters/OrderStatusFilter.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Filters;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\Order;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Statamic\Query\Scopes\Filter;
 
@@ -18,7 +17,8 @@ class OrderStatusFilter extends Filter
                 'type' => 'radio',
                 'options' => [
                     'cart' => 'Cart',
-                    'order' => 'Order',
+                    'paid' => 'Paid',
+                    'shipped' => 'Shipped',
                 ],
             ],
         ];
@@ -27,14 +27,28 @@ class OrderStatusFilter extends Filter
     public function autoApply()
     {
         return [
-            'type' => 'order',
+            'type' => 'paid',
         ];
     }
 
     public function apply($query, $values)
     {
-        $query
-            ->where('is_paid', $values['type'] === 'order');
+        if ($values['type'] === 'cart') {
+            return $query
+                ->where('is_paid', false);
+        }
+
+        if ($values['type'] === 'paid') {
+            return $query
+                ->where('is_paid', true)
+                ->where('is_shipped', false);
+        }
+
+        if ($values['type'] === 'shipped') {
+            return $query
+                ->where('is_paid', true)
+                ->where('is_shipped', true);
+        }
     }
 
     public function badge($values)
@@ -47,7 +61,6 @@ class OrderStatusFilter extends Filter
     public function visibleTo($key)
     {
         return $key === 'entries'
-            // && SimpleCommerce::orderDriver()['driver'] === Order::class
             && isset(SimpleCommerce::orderDriver()['driver'])
             && $this->context['collection'] === SimpleCommerce::orderDriver()['collection'];
     }


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request makes some changes to the Order Status filter to allow for filtering by unpaid/cart orders, paid orders & shipped orders.

The default option here will be 'Paid', as it was previously.

![image](https://user-images.githubusercontent.com/19637309/160941571-9ecf940f-0f64-4d14-a650-dd3fbb012f86.png)
