### PR TITLE
v3.0: Allow gateways to define their own validation messages

### DIFF
--- a/docs/extending/custom-gateways.md
+++ b/docs/extending/custom-gateways.md
@@ -26,21 +26,22 @@ Once created, you'll find the newly generated gateway in your `app/Gateways` fol
 
 The boilerplate gateway has quite a few methods. Here's a quick overview of what each gateway method does and what you should return.
 
-* `name()` - should return the name of your gateway
-* `prepare()` - should be used to either: generate tokens used later on for displaying the payment form or generating an off-site checkout link.
-* `purchase()` - should be used to do the actual purchase (aka. taking the money from the customer)
-* `purchaseRules` - should return an array of [Laravel Validation Rules](https://laravel.com/docs/master/validation#available-validation-rules) for the checkout request.
-* `getCharge()` - should get information about a specific order's charge/transaction.
-* `refundCharge()` - should refund an order
-* `webhook()` - should accept incoming webhook payloads, used for off-site payment gateways.
+- `name()` - should return the name of your gateway
+- `prepare()` - should be used to either: generate tokens used later on for displaying the payment form or generating an off-site checkout link.
+- `purchase()` - should be used to do the actual purchase (aka. taking the money from the customer)
+- `purchaseRules` - should return an array of [Laravel Validation Rules](https://laravel.com/docs/master/validation#available-validation-rules) for the checkout request.
+- `purchaseMessages` (optional) - should return an array of validation messages for the checkout request, just like in a [Laravel Validation Request](https://laravel.com/docs/master/validation#using-rule-objects).
+- `getCharge()` - should get information about a specific order's charge/transaction.
+- `refundCharge()` - should refund an order
+- `webhook()` - should accept incoming webhook payloads, used for off-site payment gateways.
 
 ## DTOs
 
 DTOs (also known as Data Transfer Objects) are used to return information back from your gateway to Simple Commerce so it can process it. There's a couple gateway related ones you'll need to know about:
 
-* [`Prepare`](https://github.com/doublethreedigital/simple-commerce/blob/master/src/Gateways/Prepare.php)
-* [`Purchase`](https://github.com/doublethreedigital/simple-commerce/blob/master/src/Gateways/Purchase.php)
-* [`Response`](https://github.com/doublethreedigital/simple-commerce/blob/master/src/Gateways/Response.php)
+- [`Prepare`](https://github.com/doublethreedigital/simple-commerce/blob/master/src/Gateways/Prepare.php)
+- [`Purchase`](https://github.com/doublethreedigital/simple-commerce/blob/master/src/Gateways/Purchase.php)
+- [`Response`](https://github.com/doublethreedigital/simple-commerce/blob/master/src/Gateways/Response.php)
 
 Each of these DTOs will have slightly different uses. You can view some examples of usage on some of the [built-in gateways](https://github.com/doublethreedigital/simple-commerce/tree/master/src/Gateways/Builtin).
 

--- a/docs/tags/gateways.md
+++ b/docs/tags/gateways.md
@@ -9,6 +9,7 @@ This page has documentation on the tag itself but if you're looking for docs on 
 ## Tags
 
 ### All gateways
+
 This tag returns a loop of the gateways setup for your store.
 
 ```antlers
@@ -22,6 +23,7 @@ This tag returns a loop of the gateways setup for your store.
 ```
 
 ### Get a gateway
+
 This tag lets you get a particular gateway and its information, where `stripe` is the handle of the gateway.
 
 ```antlers
@@ -35,11 +37,12 @@ This tag lets you get a particular gateway and its information, where `stripe` i
 
 You might have noticed in the above examples, it uses things like `{{ display }}` and `{{ class }}`. These are variables exposed by Simple Commerce. Here's a full list of the variables you can use inside the `{{ sc:gateways }}` tag.
 
-* `name` - Name of the gateway
-* `handle` - Camel cased version of the gateway name
-* `class` - Class name of the gateway
-* `formatted_class` - Formatted version of the gateway's class name
-* `display` - Display name
-* `purchaseRules` - Validation rules used on the submission of `{{ sc:checkout }}` form
-* `gateway-config` - Everything from the gateways's config
-* `webhook_url` - Gateway's Webhook URL
+- `name` - Name of the gateway
+- `handle` - Camel cased version of the gateway name
+- `class` - Class name of the gateway
+- `formatted_class` - Formatted version of the gateway's class name
+- `display` - Display name
+- `purchaseRules` - Validation rules used on the submission of `{{ sc:checkout }}` form
+- `purchaseMessages` - Validation messages used for errors after the submission of the `{{ sc:checkout`}}` form.
+- `gateway-config` - Everything from the gateways's config
+- `webhook_url` - Gateway's Webhook URL

--- a/src/Console/Commands/stubs/gateway-onsite.php.stub
+++ b/src/Console/Commands/stubs/gateway-onsite.php.stub
@@ -27,6 +27,11 @@ class DummyClass extends BaseGateway implements Gateway
         return [];
     }
 
+    public function purchaseMessages(): array
+    {
+        return [];
+    }
+
     public function getCharge(Order $order): Response
     {
         return new Response();

--- a/src/Contracts/Gateway.php
+++ b/src/Contracts/Gateway.php
@@ -17,6 +17,8 @@ interface Gateway
 
     public function purchaseRules(): array;
 
+    public function purchaseMessages(): array;
+
     public function getCharge(Order $order): Response;
 
     public function refundCharge(Order $order): Response;

--- a/src/Contracts/GatewayManager.php
+++ b/src/Contracts/GatewayManager.php
@@ -18,6 +18,8 @@ interface GatewayManager
 
     public function purchaseRules();
 
+    public function purchaseMessages();
+
     public function getCharge($order);
 
     public function refundCharge($order);

--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -56,7 +56,7 @@ class BaseGateway
             '_error_redirect' => $this->errorRedirectUrl,
         ]);
 
-        return config('app.url').route('statamic.simple-commerce.gateways.callback', $data, false);
+        return config('app.url') . route('statamic.simple-commerce.gateways.callback', $data, false);
     }
 
     public function webhookUrl()
@@ -109,6 +109,16 @@ class BaseGateway
      * @return array
      */
     public function purchaseRules(): array
+    {
+        return [];
+    }
+
+    /**
+     * Should return any validation messages required for the gateway when submitting on-site purchases.
+     *
+     * @return array
+     */
+    public function purchaseMessages(): array
     {
         return [];
     }

--- a/src/Gateways/Manager.php
+++ b/src/Gateways/Manager.php
@@ -64,6 +64,11 @@ class Manager implements Contract
         return $this->resolve()->purchaseRules();
     }
 
+    public function purchaseMessages()
+    {
+        return $this->resolve()->purchaseMessages();
+    }
+
     public function getCharge($order)
     {
         return $this->resolve()->getCharge($order);

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -95,7 +95,9 @@ class CheckoutController extends BaseActionController
             $this->request->has('_request')
                 ? $this->buildFormRequest($this->request->get('_request'), $this->request)->messages()
                 : [],
-            // TODO: gateway custom validation messages?
+            $this->request->has('gateway')
+                ? Gateway::use($this->request->get('gateway'))->purchaseMessages()
+                : [],
             [],
         );
 


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request adds a `purchaseMessages` methods to gateways, allowing gateway to define the messages shown alongside any validation rules they set.

## To Do

* [X] Made the changes
* [X] Added a test
* [x] Updated the documentation
