### PR TITLE
v3.0: Setup 'title format' for order & customer collections

### DIFF
--- a/resources/blueprints/collections/customers/customers.yaml
+++ b/resources/blueprints/collections/customers/customers.yaml
@@ -5,11 +5,8 @@ sections:
     fields:
       - handle: title
         field:
-          input_type: text
-          type: text
-          localizable: false
-          listable: hidden
-          display: Title
+          type: hidden
+          required: false
       - handle: name
         field:
           input_type: text
@@ -28,6 +25,15 @@ sections:
           listable: hidden
           display: Email
           validate: required
+      - handle: orders
+        field:
+          mode: default
+          collections:
+            - orders
+          display: Orders
+          type: entries
+          icon: entries
+          listable: hidden
   sidebar:
     display: Sidebar
     fields:

--- a/resources/blueprints/collections/orders/orders.yaml
+++ b/resources/blueprints/collections/orders/orders.yaml
@@ -5,15 +5,8 @@ sections:
     fields:
       - handle: title
         field:
-          type: text
-          required: true
-          validate:
-            - required
-          display: "Order Number"
-          listable: hidden
-          input_type: text
-          antlers: false
-          read_only: true
+          type: hidden
+          required: false
       - handle: is_paid
         field:
           type: toggle
@@ -332,3 +325,6 @@ sections:
           validate: required
           width: 33
           listable: hidden
+      - handle: order_number
+        field:
+          type: hidden

--- a/src/Orders/EntryOrderRepository.php
+++ b/src/Orders/EntryOrderRepository.php
@@ -160,14 +160,12 @@ class EntryOrderRepository implements RepositoryContract
         $orderNumberQuery = Collection::find($this->collection)
             ->queryEntries()
             ->where('order_number', '!=', null)
-            ->orderBy('order_number', 'DESC')
             ->get();
 
         // Fallback to get order number from title (otherwise: start from the start..)
         if ($orderNumberQuery->isEmpty()) {
             $orderNumberQuery = Collection::find($this->collection)
                 ->queryEntries()
-                ->orderBy('title', 'ASC')
                 ->where('title', '!=', null)
                 ->get();
 
@@ -176,7 +174,7 @@ class EntryOrderRepository implements RepositoryContract
                 return config('simple-commerce.minimum_order_number', 1000);
             }
 
-            $lastOrderNumber = (int) Str::of($orderNumberQuery->first()->get('title'))
+            $lastOrderNumber = (int) Str::of($orderNumberQuery->last()->get('title'))
                 ->replace('Order ', '')
                 ->replace('#', '')
                 ->__toString();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -102,6 +102,7 @@ class ServiceProvider extends AddonServiceProvider
         UpdateScripts\v2_4\MigrateSingleCartConfig::class,
         UpdateScripts\v2_4\MigrateTaxConfiguration::class,
 
+        UpdateScripts\v3_0\ConfigureTitleFormats::class,
         UpdateScripts\v3_0\UpdateContentRepositoryReferences::class,
     ];
 

--- a/src/UpdateScripts/v3_0/ConfigureTitleFormats.php
+++ b/src/UpdateScripts/v3_0/ConfigureTitleFormats.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v3_0;
+
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Site;
+use Statamic\Fields\Blueprint;
+use Statamic\UpdateScripts\UpdateScript;
+
+class ConfigureTitleFormats extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('3.0.0-beta.1');
+    }
+
+    public function update()
+    {
+        if (! isset(SimpleCommerce::orderDriver()['collection']) || ! isset(SimpleCommerce::productDriver()['collection'])) {
+            return;
+        }
+
+        $this
+            ->setupTitleFormatForOrders()
+            ->setupTitleFormatForCustomers();
+    }
+
+    protected function setupTitleFormatForOrders(): self
+    {
+        Collection::find(SimpleCommerce::orderDriver()['collection'])
+            ->titleFormats(
+                collect(Site::all())
+                    ->mapWithKeys(function ($site) {
+                        return [
+                            $site->handle() => '#{order_number}',
+                        ];
+                    })
+                    ->toArray()
+            )
+            ->save();
+
+        Collection::find(SimpleCommerce::orderDriver()['collection'])
+            ->entryBlueprints()
+            ->each(function (Blueprint $blueprint) {
+                $blueprint->removeField('title', 'main');
+
+                $blueprint->ensureFieldInSection('order_number', [
+                    'type' => 'hidden',
+                ], $blueprint->sections()->last()->handle());
+
+                $blueprint->save();
+            });
+
+        return $this;
+    }
+
+    protected function setupTitleFormatForCustomers(): self
+    {
+        Collection::find(SimpleCommerce::customerDriver()['collection'])
+            ->titleFormats(
+                collect(Site::all())
+                    ->mapWithKeys(function ($site) {
+                        return [
+                            $site->handle() => '{name} <{email}>',
+                        ];
+                    })
+                    ->toArray()
+            )
+            ->save();
+
+        Collection::find(SimpleCommerce::customerDriver()['collection'])
+            ->entryBlueprints()
+            ->each(function (Blueprint $blueprint) {
+                $blueprint->removeField('title', 'main');
+                $blueprint->save();
+            });
+
+        return $this;
+    }
+}

--- a/tests/Orders/EntryOrderRepositoryTest.php
+++ b/tests/Orders/EntryOrderRepositoryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Tests\Orders;
+
+use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
+use DoubleThreeDigital\SimpleCommerce\Tests\Invader;
+use DoubleThreeDigital\SimpleCommerce\Tests\RefreshContent;
+use DoubleThreeDigital\SimpleCommerce\Tests\SetupCollections;
+use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
+use Statamic\Facades\Entry;
+
+class EntryOrderRepositoryTest extends TestCase
+{
+    use SetupCollections, RefreshContent;
+
+    protected $repository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = new EntryOrderRepository;
+    }
+
+    /** @test */
+    public function can_generate_order_number_from_minimum_order_number()
+    {
+        $this->app['config']->set('simple-commerce.minimum_order_number', 1000);
+
+        $generateOrderNumber = (new Invader($this->repository))->generateOrderNumber();
+
+        $this->assertSame($generateOrderNumber, 1000);
+    }
+
+    /** @test */
+    public function can_generate_order_number_from_previous_order_titles()
+    {
+        Entry::make()
+            ->collection('orders')
+            ->data(['title' => '#1234'])
+            ->save();
+
+        Entry::make()
+            ->collection('orders')
+            ->data(['title' => '#1235'])
+            ->save();
+
+        Entry::make()
+            ->collection('orders')
+            ->data(['title' => '#1236'])
+            ->save();
+
+        $generateOrderNumber = (new Invader($this->repository))->generateOrderNumber();
+
+        $this->assertSame($generateOrderNumber, 1237);
+    }
+
+    /** @test */
+    public function can_generate_order_number_from_previous_order_number()
+    {
+        Entry::make()
+            ->collection('orders')
+            ->data(['order_number' => 6001])
+            ->save();
+
+        Entry::make()
+            ->collection('orders')
+            ->data(['order_number' => 6002])
+            ->save();
+
+        Entry::make()
+            ->collection('orders')
+            ->data(['order_number' => 6003])
+            ->save();
+
+        $generateOrderNumber = (new Invader($this->repository))->generateOrderNumber();
+
+        $this->assertSame($generateOrderNumber, 6004);
+    }
+}


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request changes the way titles are generated for orders & customers. Until now, Simple Commerce would generate them on save. Now, Statamic has a 'title' features format which means we can hand off the functionality to it. 

This PR also adds a new 'order_number' field to order entries (which is incidentally used in the order format for orders). You're absolutely free to change the title formats in any way you want - SC is just setting them up for you.

## To Do

* [X] Implemented 'title format's for order & customer collections
* [X] Refactor the order number generation code
* [x] Maybe add some tests for the code which generates the order numbers?
* [x] Update the blueprint stubs to remove title field
* [x] Maybe update the starter kit with the title formats? 