### PR TITLE
v3.0: Order Confirmation page will now retain information after a page reload

### DIFF
--- a/docs/tags/checkout.md
+++ b/docs/tags/checkout.md
@@ -30,3 +30,18 @@ Like with the update cart tag, you can also pass information to the customer ent
 ```
 
 If you're using an off-site gateway, like Mollie, you can learn about the checkout process, [over here](/gateways#offsite-gateways).
+
+## Successful Redirect
+
+If you specify a `redirect` parameter on your Checkout form, Simple Commerce will retain the previous cart (eg. the one just checked out) when you use the `{{ sc:cart }}` tag.
+
+This means, in the Checkout Success/Thanks page, you can use the cart tags like normal.
+
+```
+<h2>Thanks!</h2>
+<p>Thanks for your order - {{ sc:cart:title }}.</p>
+```
+
+It's worth noting this same behavior works for off-site gateways as well.
+
+> **Note:** The cart information will only be available for 30 minutes after checking out. After which time, the page will start to use a fresh cart.

--- a/src/Http/Controllers/BaseActionController.php
+++ b/src/Http/Controllers/BaseActionController.php
@@ -18,6 +18,14 @@ class BaseActionController extends Controller
             return response()->json($data);
         }
 
+        if (isset($data['is_checkout_request'])) {
+            $request->session()->put('simple-commerce.checkout.success', [
+                'order_id' => $data['cart']['id'],
+                'expiry' => now()->addMinutes(30),
+                'url' => $request->_redirect,
+            ]);
+        }
+
         return $request->_redirect ?
             redirect($request->_redirect)->with($data)
             : back()->with($data);

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -62,6 +62,7 @@ class CheckoutController extends BaseActionController
             'cart'    => $request->wantsJson()
                 ? $this->cart->toResource()
                 : $this->cart->toAugmentedArray(),
+            'is_checkout_request' => true,
         ]);
     }
 

--- a/src/Http/Controllers/GatewayCallbackController.php
+++ b/src/Http/Controllers/GatewayCallbackController.php
@@ -46,6 +46,7 @@ class GatewayCallbackController extends BaseActionController
             'cart'    => $request->wantsJson()
                 ? $order->toResource()
                 : $order->toAugmentedArray(),
+            'is_checkout_request' => true,
         ]);
     }
 }

--- a/src/Orders/Cart/Drivers/CartDriver.php
+++ b/src/Orders/Cart/Drivers/CartDriver.php
@@ -50,7 +50,7 @@ trait CartDriver
 
     protected function resolve()
     {
-        if ($checkoutSuccess = request()->session()->get('simple-commerce.checkout.success')) {
+        if (request()->hasSession() && $checkoutSuccess = request()->session()->get('simple-commerce.checkout.success')) {
             // Has success expired? Use normal cart driver.
             if ($checkoutSuccess['expiry']->isPast()) {
                 return resolve(CartDriverContract::class);

--- a/src/Orders/Cart/Drivers/PostCheckoutDriver.php
+++ b/src/Orders/Cart/Drivers/PostCheckoutDriver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers;
+
+class PostCheckoutDriver extends SessionDriver
+{
+    protected $orderId;
+
+    public function __construct(array $checkoutSuccess)
+    {
+        $this->orderId = $checkoutSuccess['order_id'];
+    }
+
+    public function getCartKey(): string
+    {
+        return $this->orderId;
+    }
+
+    public function hasCart(): bool
+    {
+        return ! empty($this->orderId);
+    }
+}


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request makes it so the order confirmation page (where you go after the checkout page) retains information about the previous cart.

This allows developers to use the Simple Commerce tags instead of needing to grab the data via the session tag. It also means the order details are retained in case the page is refreshed for whatever reason.

The previous cart will only be available on the order confirmation page (as configured in the sc:checkout tag) and will only be available for up to 30 minutes after checking out.

## To Do

* [x] Ensure it works for off-site checkouts
* [x] Update documentation
* [x] Fix failing tests