### PR TITLE
v3.0: Gateway Fieldtype

### DIFF
--- a/docs/extending/custom-gateways.md
+++ b/docs/extending/custom-gateways.md
@@ -34,6 +34,7 @@ The boilerplate gateway has quite a few methods. Here's a quick overview of what
 - `getCharge()` - should get information about a specific order's charge/transaction.
 - `refundCharge()` - should refund an order
 - `webhook()` - should accept incoming webhook payloads, used for off-site payment gateways.
+- `paymentDisplay()` - should return an array with `text` and a `url` which will be returned by the 'Gateway Fieldtype'
 
 ## DTOs
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -20,11 +20,6 @@ composer update doublethreedigital/simple-commerce --with-dependencies
 
 ## Changes
 
-- Data Refactor TODO: #556
-- new minimum system reqs
-- no more receipt pdfs
-- mention upgrade script tasks
-
 ### High: Changes around the Data APIs (Partially automated)
 
 This is probably **the largest change** around how Simple Commerce works. If you've written any kind of custom code that deals with an `Order`, `Product`, etc, I'd recommend you test your code to ensure it's compatible with v3.0.
@@ -183,6 +178,17 @@ On the 'Order Confirmation' page (the one after checking out), you'd previously 
     Thanks for your order ({{ title }}), {{ customer:title }}
 {{ /sc:cart }}
 ```
+
+### Medium: Gateway fieldtype
+
+Included in Simple Commerce v3 is a 'Gateway Fieldtype' which allows you to view the gateway used for a specific order, along with information around the payment itself. New sites will get the Gateway fieldtype by default but it's recommended you also add it to your existing order blueprint.
+
+1. Go into the Control Panel, click into 'Blueprints'
+2. Edit your order blueprint, add the 'Gateway' fieldtype. Remember to use the handle of `gateway`, otherwise it won't work.
+
+Now, when you view orders, you'll see information around the particular payment.
+
+> **Note:** When using the Stripe Gateway, only new orders will show any payment information, due to some required data we were not previously storing.
 
 ### Low: Higher System Requirements
 

--- a/resources/blueprints/collections/orders/orders.yaml
+++ b/resources/blueprints/collections/orders/orders.yaml
@@ -12,8 +12,14 @@ sections:
           type: toggle
           listable: false
           display: "Is Paid?"
-          width: 50
+          width: 75
           read_only: true
+      - handle: is_paid
+        field:
+          type: toggle
+          listable: false
+          display: "Is Paid?"
+          width: 25
       - handle: customer
         field:
           max_items: 1
@@ -36,6 +42,14 @@ sections:
           display: Coupon
           width: 50
           read_only: true
+      - handle: gateway
+        field:
+          display: Gateway
+          type: gateway
+          icon: gateway
+          width: 50
+          listable: hidden
+          instructions_position: above
       - handle: items
         field:
           fields:

--- a/resources/js/components/Fieldtypes/GatewayFieldtype.vue
+++ b/resources/js/components/Fieldtypes/GatewayFieldtype.vue
@@ -1,0 +1,92 @@
+<template>
+    <div class="relationship-input">
+        <p
+            v-if="value == null"
+            class="text-sm py-1"
+        >No Gateway</p>
+
+        <div v-else class="relationship-input-items space-y-1 outline-none" tabindex="0">
+            <div class="item select-none item outline-none" tabindex="0">
+                <div class="item-inner">
+                    <a 
+                        :href="paymentDisplay.url" 
+                        target="_blank"
+                    >
+                        {{ paymentDisplay.text }}
+                    </a>
+                </div>
+
+                <div class="text-4xs text-grey-60 uppercase whitespace-no-wrap mr-1">
+                    {{ gatewayName }}
+                </div>
+
+                <div class="pr-1 flex items-center" v-if="!readOnly">
+                    <dropdown-list>
+                        <data-list-inline-actions
+                            :item="entry"
+                            :url="actionUrl"
+                            :actions="actions"
+                            @started="actionStarted"
+                            @completed="actionCompleted"
+                        />
+                    </dropdown-list>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+// import HasActions from '../../../../vendor/statamic/cms/resources/js/components/data-list/HasActions';
+
+export default {
+    name: 'gateway-fieldtype',
+    
+    mixins: [
+        Fieldtype, 
+        // HasActions
+    ],
+
+    props: ['meta'],
+
+    data() {
+        return {
+            gatewayData: this.value.data,
+            entry: this.value.entry,
+            actions: this.value.actions,
+            actionUrl: this.value.action_url,
+            gatewayClass: this.value.gateway_class,
+            paymentDisplay: this.value.payment_display,
+        }
+    },
+
+    computed: {
+        paymentDisplay() {
+            return this.value.payment_display
+        },
+
+        gatewayName() {
+            const gatewayClass = this.value.gateway_class
+
+            const gateway = this.meta.gateways.find((gateway) => {
+                return gateway.class === gatewayClass
+            })
+
+            return gateway.name
+        },
+    },
+
+    methods: {
+        actionStarted() {
+            //
+        },
+
+        actionCompleted() {
+            this.$events.$emit('clear-selections');
+            this.$events.$emit('reset-action-modals');
+
+            this.$toast.success(__('Action completed'));
+        },
+    },
+}
+</script>

--- a/resources/js/cp.js
+++ b/resources/js/cp.js
@@ -1,9 +1,11 @@
 // Fieldtypes
 
+import GatewayFieldtype from './components/Fieldtypes/GatewayFieldtype.vue';
 import MoneyFieldtype from './components/Fieldtypes/MoneyFieldtype.vue'
 import ProductVariantFieldtype from './components/Fieldtypes/ProductVariantFieldtype.vue'
 import ProductVariantsFildtype from './components/Fieldtypes/ProductVariantsFieldtype.vue'
 
+Statamic.$components.register('gateway-fieldtype', GatewayFieldtype)
 Statamic.$components.register('money-fieldtype', MoneyFieldtype)
 Statamic.$components.register('product-variant-fieldtype', ProductVariantFieldtype)
 Statamic.$components.register('product-variants-fieldtype', ProductVariantsFildtype)

--- a/src/Console/Commands/stubs/runway_order_blueprint.yaml
+++ b/src/Console/Commands/stubs/runway_order_blueprint.yaml
@@ -13,11 +13,12 @@ sections:
           input_type: text
           antlers: false
           read_only: true
+          width: 75
       - handle: is_paid
         field:
           type: toggle
           display: "Is Paid?"
-          width: 50
+          width: 25
           read_only: true
       - handle: customer_id
         field:
@@ -41,6 +42,14 @@ sections:
           display: Coupon
           width: 50
           read_only: true
+      - handle: gateway
+        field:
+          display: Gateway
+          type: gateway
+          icon: gateway
+          width: 50
+          listable: hidden
+          instructions_position: above
       - handle: items
         field:
           fields:

--- a/src/Contracts/Gateway.php
+++ b/src/Contracts/Gateway.php
@@ -28,4 +28,6 @@ interface Gateway
     public function webhook(Request $request);
 
     public function isOffsiteGateway(): bool;
+
+    public function paymentDisplay($value): array;
 }

--- a/src/Fieldtypes/GatewayFieldtype.php
+++ b/src/Fieldtypes/GatewayFieldtype.php
@@ -61,8 +61,8 @@ class GatewayFieldtype extends Fieldtype
 
     public function process($value)
     {
-        if (isset($value['actual'])) {
-            return $value['actual'];
+        if (isset($value['data'])) {
+            return $value['data'];
         }
 
         return $value;

--- a/src/Fieldtypes/GatewayFieldtype.php
+++ b/src/Fieldtypes/GatewayFieldtype.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+
+use DoubleThreeDigital\SimpleCommerce\Actions\RefundAction;
+use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Statamic\Facades\Action;
+use Statamic\Fields\Fieldtype;
+
+class GatewayFieldtype extends Fieldtype
+{
+    public static function title()
+    {
+        return 'Gateway';
+    }
+
+    public function preload()
+    {
+        return [
+            'gateways' => SimpleCommerce::gateways(),
+        ];
+    }
+
+    public function preProcess($value)
+    {
+        if (! $value) {
+            return null;
+        }
+
+        $gateway = collect(SimpleCommerce::gateways())
+            ->where('class', isset($value['use']) ? $value['use'] : $value)
+            ->first();
+
+        if (! $gateway) {
+            return null;
+        }
+
+        $actions = Action::for($this->field->parent())
+            ->filter(function ($action) {
+                return in_array(get_class($action), [
+                    RefundAction::class,
+                ]);
+            })
+            ->values();
+
+        return [
+            'data' => $value,
+            'entry' => optional($this->field->parent())->id(),
+
+            'gateway_class' => $gateway['class'],
+            'payment_display' => Gateway::use($gateway['class'])->paymentDisplay($value),
+
+            'actions' => $actions,
+            'action_url' => cp_route(
+                'collections.entries.actions.run',
+                $this->field->parent()->collection->handle()
+            ),
+        ];
+    }
+
+    public function process($value)
+    {
+        if (isset($value['actual'])) {
+            return $value['actual'];
+        }
+
+        return $value;
+    }
+
+    public function augment($value)
+    {
+        // TODO
+
+        return [];
+    }
+}

--- a/src/Fieldtypes/GatewayFieldtype.php
+++ b/src/Fieldtypes/GatewayFieldtype.php
@@ -82,4 +82,21 @@ class GatewayFieldtype extends Fieldtype
             'data' => array_pull($value, 'data', []),
         ]);
     }
+
+    public function preProcessIndex($value)
+    {
+        if (! $value) {
+            return;
+        }
+
+        $gateway = collect(SimpleCommerce::gateways())
+            ->where('class', isset($value['use']) ? $value['use'] : $value)
+            ->first();
+
+        if (! $gateway) {
+            return null;
+        }
+
+        return $gateway['name'];
+    }
 }

--- a/src/Fieldtypes/GatewayFieldtype.php
+++ b/src/Fieldtypes/GatewayFieldtype.php
@@ -70,8 +70,16 @@ class GatewayFieldtype extends Fieldtype
 
     public function augment($value)
     {
-        // TODO
+        $gateway = collect(SimpleCommerce::gateways())
+            ->where('class', isset($value['use']) ? $value['use'] : $value)
+            ->first();
 
-        return [];
+        if (! $gateway) {
+            return null;
+        }
+
+        return array_merge($gateway, [
+            'data' => array_pull($value, 'data', []),
+        ]);
     }
 }

--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -123,6 +123,19 @@ class BaseGateway
         return [];
     }
 
+    /**
+     * Should return an array with text & a URL which will be displayed by the Gateway fieldtype in the CP.
+     *
+     * @return array
+     */
+    public function paymentDisplay($value): array
+    {
+        return [
+            'text' => isset($value['data']) ? $value['data']['id'] : $value['id'],
+            'url' => '#',
+        ];
+    }
+
     public function markOrderAsPaid(Order $order): bool
     {
         if ($this->isOffsiteGateway()) {

--- a/src/Gateways/Builtin/DummyGateway.php
+++ b/src/Gateways/Builtin/DummyGateway.php
@@ -63,4 +63,12 @@ class DummyGateway extends BaseGateway implements Gateway
     {
         return null;
     }
+
+    public function paymentDisplay($value): array
+    {
+        return [
+            'text' => $value['data']['id'],
+            'url' => null,
+        ];
+    }
 }

--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -235,6 +235,20 @@ class PayPalGateway extends BaseGateway implements Gateway
         return new HttpResponse();
     }
 
+    public function paymentDisplay($value): array
+    {
+        if (! isset($value['data']['result']['id'])) {
+            return ['text' => 'Unknown', 'url' => null];
+        }
+
+        $payment = $value['data']['result']['id'];
+
+        return [
+            'text' => $payment,
+            'url' => null,
+        ];
+    }
+
     protected function setupPayPal()
     {
         if ($this->config()->get('environment') === 'sandbox') {

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -98,6 +98,7 @@ class StripeGateway extends BaseGateway implements Gateway
             'card'     => $paymentMethod->card->toArray(),
             'customer' => $paymentMethod->customer,
             'livemode' => $paymentMethod->livemode,
+            'payment_intent' => $paymentIntent->id,
         ]);
     }
 
@@ -180,6 +181,20 @@ class StripeGateway extends BaseGateway implements Gateway
         // TODO: implement refund handling
 
         return new Response();
+    }
+
+    public function paymentDisplay($value): array
+    {
+        if (! isset($value['data']['payment_intent'])) {
+            return ['text' => 'Unknown', 'url' => null];
+        }
+
+        $stripePaymentIntent = $value['data']['payment_intent'];
+
+        return [
+            'text' => $stripePaymentIntent,
+            'url' => "https://dashboard.stripe.com/test/payments/{$stripePaymentIntent}",
+        ];
     }
 
     protected function setUpWithStripe()

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -193,7 +193,7 @@ class StripeGateway extends BaseGateway implements Gateway
 
         return [
             'text' => $stripePaymentIntent,
-            'url' => "https://dashboard.stripe.com/test/payments/{$stripePaymentIntent}",
+            'url' => "https://dashboard.stripe.com/payments/{$stripePaymentIntent}",
         ];
     }
 

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -28,6 +28,8 @@ use Stripe\Stripe;
 
 class StripeGateway extends BaseGateway implements Gateway
 {
+    protected bool $isUsingTestMode = false;
+
     public function name(): string
     {
         return 'Stripe';
@@ -189,11 +191,15 @@ class StripeGateway extends BaseGateway implements Gateway
             return ['text' => 'Unknown', 'url' => null];
         }
 
+        $this->setUpWithStripe();
+
         $stripePaymentIntent = $value['data']['payment_intent'];
 
         return [
             'text' => $stripePaymentIntent,
-            'url' => "https://dashboard.stripe.com/payments/{$stripePaymentIntent}",
+            'url' => $this->isUsingTestMode
+                ? "https://dashboard.stripe.com/test/payments/{$stripePaymentIntent}"
+                : "https://dashboard.stripe.com/payments/{$stripePaymentIntent}",
         ];
     }
 
@@ -215,5 +221,7 @@ class StripeGateway extends BaseGateway implements Gateway
         if ($version = $this->config()->has('version')) {
             Stripe::setApiVersion($version);
         }
+
+        $this->isUsingTestMode = str_contains($this->config()->get('secret'), 'sk_test_');
     }
 }

--- a/src/Gateways/Manager.php
+++ b/src/Gateways/Manager.php
@@ -108,6 +108,11 @@ class Manager implements Contract
         return $this->resolve()->isOffsiteGateway();
     }
 
+    public function paymentDisplay($value)
+    {
+        return $this->resolve()->paymentDisplay($value);
+    }
+
     public function withRedirectUrl(string $redirectUrl): self
     {
         $this->redirectUrl = $redirectUrl;

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -251,6 +251,8 @@ class CheckoutController extends BaseActionController
             $this->excludedKeys[] = $key;
         }
 
+        $this->cart->fresh();
+
         return $this;
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -32,6 +32,7 @@ class ServiceProvider extends AddonServiceProvider
 
     protected $fieldtypes = [
         Fieldtypes\CountryFieldtype::class,
+        Fieldtypes\GatewayFieldtype::class,
         Fieldtypes\MoneyFieldtype::class,
         Fieldtypes\ProductVariantFieldtype::class,
         Fieldtypes\ProductVariantsFieldtype::class,

--- a/tests/Fieldtypes/GatewayFieldtypeTest.php
+++ b/tests/Fieldtypes/GatewayFieldtypeTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Tests\Fieldtypes;
+
+use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DoubleThreeDigital\SimpleCommerce\Fieldtypes\GatewayFieldtype;
+use DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\DummyGateway;
+use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
+use Illuminate\Support\Facades\Auth;
+use Statamic\Facades\User;
+use Statamic\Fields\Field;
+
+class GatewayFieldtypeTest extends TestCase
+{
+    /** @test */
+    public function can_get_title()
+    {
+        $title = GatewayFieldtype::title();
+
+        $this->assertSame('Gateway', $title);
+    }
+
+    /** @test */
+    public function can_preload()
+    {
+        $preload = (new GatewayFieldtype)->preload();
+
+        $this->assertIsArray($preload);
+        $this->assertArrayHasKey('gateways', $preload);
+    }
+
+    /** @test */
+    public function can_preprocess()
+    {
+        $order = Order::make();
+        $order->save();
+
+        $user = User::make()->email('test@test.com');
+        $user->save();
+
+        $field = new Field('gateway', [
+            'type' => 'gateway',
+        ]);
+
+        $field->setParent($order->resource());
+
+        Auth::setUser($user);
+
+        $preProcess = (new GatewayFieldtype)->setField($field)->preProcess([
+            'use' => DummyGateway::class,
+            'data' => [
+                'id' => 'abc123',
+                'smth' => 'cool',
+            ],
+        ]);
+
+        $this->assertIsArray($preProcess);
+
+        $this->assertArrayHasKey('data', $preProcess);
+        $this->assertSame([
+            'use' => DummyGateway::class,
+            'data' => [
+                'id' => 'abc123',
+                'smth' => 'cool',
+            ],
+        ], $preProcess['data']);
+
+        $this->assertArrayHasKey('entry', $preProcess);
+        $this->assertArrayHasKey('gateway_class', $preProcess);
+        $this->assertArrayHasKey('payment_display', $preProcess);
+        $this->assertArrayHasKey('actions', $preProcess);
+        $this->assertArrayHasKey('action_url', $preProcess);
+    }
+
+    /** @test */
+    public function can_process()
+    {
+        $process = (new GatewayFieldtype)->process([
+            'data' => [
+                'use' => DummyGateway::class,
+                'data' => ['smth' => 'cool'],
+            ],
+            'actions' => [],
+        ]);
+
+        $this->assertIsArray($process);
+
+        $this->assertSame([
+            'use' => DummyGateway::class,
+            'data' => ['smth' => 'cool'],
+        ], $process);
+    }
+
+    /** @test */
+    public function can_augment()
+    {
+        $augment = (new GatewayFieldtype)->augment([
+            'use' => DummyGateway::class,
+            'data' => ['smth' => 'cool'],
+        ]);
+
+        $this->assertIsArray($augment);
+
+        $this->assertArrayHasKey('name', $augment);
+        $this->assertArrayHasKey('handle', $augment);
+        $this->assertArrayHasKey('class', $augment);
+        $this->assertArrayHasKey('formatted_class', $augment);
+        $this->assertArrayHasKey('display', $augment);
+        $this->assertArrayHasKey('purchaseRules', $augment);
+        $this->assertArrayHasKey('gateway-config', $augment);
+        $this->assertArrayHasKey('webhook_url', $augment);
+        $this->assertArrayHasKey('data', $augment);
+    }
+
+    /** @test */
+    public function can_preprocess_index()
+    {
+        $preProcessIndex = (new GatewayFieldtype)->preProcessIndex([
+            'use' => DummyGateway::class,
+            'data' => ['smth' => 'cool'],
+        ]);
+
+        $this->assertSame('Dummy', $preProcessIndex);
+    }
+}

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -499,7 +499,7 @@ class StripeGatewayTest extends TestCase
 
         $this->assertSame([
             'text' => $paymentIntent,
-            'url' => 'https://dashboard.stripe.com/payments/' . $paymentIntent,
+            'url' => 'https://dashboard.stripe.com/test/payments/' . $paymentIntent,
         ], $paymentDisplay);
     }
 

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -479,21 +479,15 @@ class StripeGatewayTest extends TestCase
 
         Stripe::setApiKey(env('STRIPE_SECRET'));
 
-        $order = Order::make()->grandTotal(1234)->merge([
-            'gateway' => [
-                'use' => StripeGateway::class,
-                'data' => [
-                    'payment_intent' => $paymentIntent = PaymentIntent::create([
-                        'amount' => 1234,
-                        'currency' => 'GBP',
-                    ])->id,
-                ],
+        $paymentDisplay = $this->gateway->paymentDisplay([
+            'use' => StripeGateway::class,
+            'data' => [
+                'payment_intent' => $paymentIntent = PaymentIntent::create([
+                    'amount' => 1234,
+                    'currency' => 'GBP',
+                ])->id,
             ],
         ]);
-
-        $order->save();
-
-        $paymentDisplay = $this->gateway->paymentDisplay($order->fresh()->get('gateway'));
 
         $this->assertIsArray($paymentDisplay);
 
@@ -506,16 +500,10 @@ class StripeGatewayTest extends TestCase
     /** @test */
     public function does_not_return_array_from_payment_display_if_no_payment_intent_is_set()
     {
-        $order = Order::make()->grandTotal(1234)->merge([
-            'gateway' => [
-                'use' => StripeGateway::class,
-                'data' => [],
-            ],
+        $paymentDisplay = $this->gateway->paymentDisplay([
+            'use' => StripeGateway::class,
+            'data' => [],
         ]);
-
-        $order->save();
-
-        $paymentDisplay = $this->gateway->paymentDisplay($order->fresh()->get('gateway'));
 
         $this->assertIsArray($paymentDisplay);
 

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -469,4 +469,59 @@ class StripeGatewayTest extends TestCase
 
         $this->assertTrue($webhook instanceof Response);
     }
+
+    /** @test */
+    public function returns_array_from_payment_display()
+    {
+        if (! env('STRIPE_SECRET')) {
+            $this->markTestSkipped('Skipping, no Stripe Secret has been defined for this environment.');
+        }
+
+        Stripe::setApiKey(env('STRIPE_SECRET'));
+
+        $order = Order::make()->grandTotal(1234)->merge([
+            'gateway' => [
+                'use' => StripeGateway::class,
+                'data' => [
+                    'payment_intent' => $paymentIntent = PaymentIntent::create([
+                        'amount' => 1234,
+                        'currency' => 'GBP',
+                    ])->id,
+                ],
+            ],
+        ]);
+
+        $order->save();
+
+        $paymentDisplay = $this->gateway->paymentDisplay($order->fresh()->get('gateway'));
+
+        $this->assertIsArray($paymentDisplay);
+
+        $this->assertSame([
+            'text' => $paymentIntent,
+            'url' => 'https://dashboard.stripe.com/payments/' . $paymentIntent,
+        ], $paymentDisplay);
+    }
+
+    /** @test */
+    public function does_not_return_array_from_payment_display_if_no_payment_intent_is_set()
+    {
+        $order = Order::make()->grandTotal(1234)->merge([
+            'gateway' => [
+                'use' => StripeGateway::class,
+                'data' => [],
+            ],
+        ]);
+
+        $order->save();
+
+        $paymentDisplay = $this->gateway->paymentDisplay($order->fresh()->get('gateway'));
+
+        $this->assertIsArray($paymentDisplay);
+
+        $this->assertSame([
+            'text' => 'Unknown',
+            'url' => null,
+        ], $paymentDisplay);
+    }
 }


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request introduces a brand new Gateway fieldtype to allow CP users to click into their gateway directly from the order & to easily issue refunds.

<img width="383" alt="image" src="https://user-images.githubusercontent.com/19637309/162998684-5d12c1a7-448c-4687-81b8-c0acb3ac7514.png">

## Notes

* **Stripe:** Only new orders will appear with their payment ID/link due to some missing information in previous orders.

## To Do

* [x] Update documentation (gateway implementation, etc)
* [x] Add some tests for gateway method and fieldtype
* [x] Fieldtype augmentation?