### PR TITLE
v3.0: Shipping Method configs

### DIFF
--- a/config/simple-commerce.php
+++ b/config/simple-commerce.php
@@ -20,7 +20,7 @@ return [
 
             'shipping' => [
                 'methods' => [
-                    \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class,
+                    \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class => [],
                 ],
             ],
         ],

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -17,14 +17,14 @@ Shipping Methods can be configured on a site-by-site basis, helpful for if you h
 
         'shipping' => [
             'methods' => [
-                \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class,
+                \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class => [],
             ],
         ],
     ],
 ],
 ```
 
-The `methods` array should contain an array of Shipping Method classes, with the `::class` syntax.
+The `methods` array should contain an array of Shipping Method classes, with the `::class` syntax. You may also specify a configuration array as the second parameter.
 
 ### Default shipping method
 
@@ -43,7 +43,7 @@ In these cases, you may configure a default Shipping Method which will be used w
             'default_method' => \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class,
 
             'methods' => [
-                \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class,
+                \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class => [],
             ],
         ],
     ],

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -103,6 +103,16 @@ Here's a quick explanation of what each method does.
 - **calculateCost:** This method should be where you return the cost of the shipping, based on the order's entry data.
 - **checkAvailability:** This method is where an Address object is passed in and you should return a boolean of whether or not you ship to that location.
 
+### Using config settings
+
+As mentioned earlier, you may let users of your shipping method specify a configuration array which is accessible inside the Shipping Method itself. If you'd like to do this, you may access the config like so:
+
+```php
+// app/ShippingMethods/FirstClass.php
+
+$this->config()->get('api_key');
+```
+
 ## Templating
 
 During the cart/checkout flow, you'll want to do 2 things: first, let the customer enter their shipping address for the order and secondly, let the customer select the shipping method you want to use for the order.

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -70,8 +70,9 @@ namespace App\ShippingMethods;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\Data\Address;
+use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
 
-class FirstClass implements ShippingMethod
+class FirstClass extends BaseShippingMethod implements ShippingMethod
 {
     public function name(): string
     {

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -146,6 +146,45 @@ Simple Commerce has **partially automated** this upgrade step for you. Upon upgr
 
 It will have pulled in any fields from your orders that aren't 'reserved' (eg. SC presumes you probably don't want the `is_paid` field to be fillable).
 
+### High: Updates to Shipping Methods
+
+Simple Commerce now allows for passing configuration arrays for shipping methods. However, for this to work, shipping methods must be updated to extend upon the `BaseShippingMethod` class provided by Simple Commerce.
+
+```php
+<?php
+
+namespace App\ShippingMethods;
+
+use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
+use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
+
+class FirstClass extends BaseShippingMethod implements ShippingMethod
+{
+    //
+}
+```
+
+If you wish to start passing in config variables to your shipping methods, you may do it like so:
+
+```php
+'sites' => [
+    'default' => [
+        ...
+
+        'shipping' => [
+            'methods' => [
+                \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class => [
+                    'config' => 'setting',
+                    'foo' => 'bar',
+                ],
+            ],
+        ],
+    ],
+],
+```
+
+And inside the shipping method, you may do `$this->config()->get('key')` to get a specific config value.
+
 ### Medium: Order Emails
 
 Previously, Simple Commerce would send a fairly basic email with a PDF receipt attached.

--- a/src/Console/Commands/stubs/shipping.php.stub
+++ b/src/Console/Commands/stubs/shipping.php.stub
@@ -5,8 +5,9 @@ namespace DummyNamespace;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\Orders\Address;
+use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
 
-class DummyClass implements ShippingMethod
+class DummyClass extends BaseShippingMethod implements ShippingMethod
 {
     public function name(): string
     {

--- a/src/Orders/Calculator.php
+++ b/src/Orders/Calculator.php
@@ -144,7 +144,9 @@ class Calculator implements Contract
             ];
         }
 
-        $data['shipping_total'] = Shipping::use($shippingMethod ?? $defaultShippingMethod)->calculateCost($this->order);
+        $data['shipping_total'] = Shipping::site(Site::current()->handle())
+            ->use($shippingMethod ?? $defaultShippingMethod)
+            ->calculateCost($this->order);
 
         return [
             'data' => $data,

--- a/src/Shipping/BaseShippingMethod.php
+++ b/src/Shipping/BaseShippingMethod.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Shipping;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class BaseShippingMethod
+{
+    protected array $config = [];
+
+    public function __construct(array $config = [])
+    {
+        $this->config = $config;
+    }
+
+    public function config(): Collection
+    {
+        return collect($this->config);
+    }
+
+    public function setConfig(array $config)
+    {
+        $this->config = $config;
+
+        return $this;
+    }
+
+    public function name(): string
+    {
+        return Str::title(class_basename($this));
+    }
+}

--- a/src/Shipping/StandardPost.php
+++ b/src/Shipping/StandardPost.php
@@ -6,7 +6,7 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\Orders\Address;
 
-class StandardPost implements ShippingMethod
+class StandardPost extends BaseShippingMethod implements ShippingMethod
 {
     public function name(): string
     {
@@ -20,7 +20,7 @@ class StandardPost implements ShippingMethod
 
     public function calculateCost(Order $order): int
     {
-        return 120;
+        return 100;
     }
 
     public function checkAvailability(Order $order, Address $address): bool

--- a/src/Tags/ShippingTags.php
+++ b/src/Tags/ShippingTags.php
@@ -17,8 +17,8 @@ class ShippingTags extends SubTag
         $order = $this->getCart();
 
         return SimpleCommerce::shippingMethods(Site::current()->handle())
-            ->map(function ($method) use ($order) {
-                $instance = Shipping::use($method);
+            ->map(function ($shippingMethod) use ($order) {
+                $instance = Shipping::use($shippingMethod['class']);
 
                 if (! $shipingAddress = $order->shippingAddress()) {
                     return null;
@@ -31,7 +31,7 @@ class ShippingTags extends SubTag
                 $cost = $instance->calculateCost($order);
 
                 return [
-                    'handle'      => $method,
+                    'handle'      => $shippingMethod['class'],
                     'name'        => $instance->name(),
                     'description' => $instance->description(),
                     'cost'        => Currency::parse($cost, Site::current()),

--- a/src/Tags/ShippingTags.php
+++ b/src/Tags/ShippingTags.php
@@ -18,7 +18,8 @@ class ShippingTags extends SubTag
 
         return SimpleCommerce::shippingMethods(Site::current()->handle())
             ->map(function ($shippingMethod) use ($order) {
-                $instance = Shipping::use($shippingMethod['class']);
+                $instance = Shipping::site(Site::current()->handle())
+                    ->use($shippingMethod['class']);
 
                 if (! $shipingAddress = $order->shippingAddress()) {
                     return null;
@@ -38,6 +39,7 @@ class ShippingTags extends SubTag
                 ];
             })
             ->whereNotNull()
+            ->values()
             ->toArray();
     }
 }

--- a/tests/Orders/CalculatorTest.php
+++ b/tests/Orders/CalculatorTest.php
@@ -9,10 +9,12 @@ use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\Address;
 use DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
+use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use DoubleThreeDigital\SimpleCommerce\Tests\SetupCollections;
 use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
+use Statamic\Facades\Site;
 
 class CalculatorTest extends TestCase
 {
@@ -243,9 +245,7 @@ class CalculatorTest extends TestCase
     {
         Config::set('simple-commerce.tax_engine_config.rate', 20);
 
-        Config::set('simple-commerce.sites.default.shipping.methods', [
-            Postage::class,
-        ]);
+        SimpleCommerce::registerShippingMethod(Site::current()->handle(), Postage::class);
 
         $product = Product::make()->price(1000);
         $product->save();
@@ -280,9 +280,7 @@ class CalculatorTest extends TestCase
     {
         Config::set('simple-commerce.tax_engine_config.rate', 20);
 
-        Config::set('simple-commerce.sites.default.shipping.methods', [
-            Postage::class,
-        ]);
+        SimpleCommerce::registerShippingMethod(Site::current()->handle(), Postage::class);
 
         $product = Product::make()->price(1000);
         $product->save();
@@ -567,7 +565,7 @@ class CalculatorTest extends TestCase
     }
 }
 
-class Postage implements ShippingMethod
+class Postage extends BaseShippingMethod implements ShippingMethod
 {
     public function name(): string
     {

--- a/tests/Tags/ShippingTagsTest.php
+++ b/tests/Tags/ShippingTagsTest.php
@@ -8,6 +8,7 @@ use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Orders\Address;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use DoubleThreeDigital\SimpleCommerce\Tags\ShippingTags;
+use DoubleThreeDigital\SimpleCommerce\Tests\SetupCollections;
 use DoubleThreeDigital\SimpleCommerce\Tests\StaticCartDriver;
 use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
@@ -15,6 +16,8 @@ use Statamic\Facades\Antlers;
 
 class ShippingTagsTest extends TestCase
 {
+    use SetupCollections;
+
     protected $tag;
 
     public function setUp(): void
@@ -26,9 +29,7 @@ class ShippingTagsTest extends TestCase
             ->setContext([]);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function can_get_available_shipping_method()
     {
         // This will add onto the existing one we have from the default config

--- a/tests/Tags/ShippingTagsTest.php
+++ b/tests/Tags/ShippingTagsTest.php
@@ -6,6 +6,7 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
 use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Orders\Address;
+use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use DoubleThreeDigital\SimpleCommerce\Tags\ShippingTags;
 use DoubleThreeDigital\SimpleCommerce\Tests\SetupCollections;
@@ -60,7 +61,7 @@ class ShippingTagsTest extends TestCase
     }
 }
 
-class RoyalMail implements ShippingMethod
+class RoyalMail extends BaseShippingMethod implements ShippingMethod
 {
     public function name(): string
     {
@@ -83,7 +84,7 @@ class RoyalMail implements ShippingMethod
     }
 }
 
-class DPD implements ShippingMethod
+class DPD extends BaseShippingMethod implements ShippingMethod
 {
     public function name(): string
     {


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request allows for shipping methods to have their own config arrays, much like how you can do it with gateways. 

## Usage

In your `config/simple-commerce.php` file, you'd just need to add an array value for the shipping method:

```php
'sites' => [
    'default' => [
        ...

        'shipping' => [
            'default_method' => \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class,

            'methods' => [
                \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class => [
                  'api_key' => 'foobar123',
                ],
            ],
        ],
    ],
],
```

Then, inside a Shipping Method (after extending upon the new `BaseShippingMethod` class) you can do this to get a config value:

```php
$this->config()->get('api_key');
```

## Breaking change

When upgrading to v3.0, developers will now need to extend a `BaseShippingMethod` class which will make available the config methods needed for accessing the new config array.

```php
<?php

namespace App\ShippingMethods;

use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;

class FirstClass extends BaseShippingMethod implements ShippingMethod
{
    //
}
```

## To Do

* [x] Upgrade guide - document need for shipping methods to implement `BaseShippingMethod`
* [x] Document added method to shipping methods docs
* [x] Add tests?