### PR TITLE
v3.0: Shipping Method Fieldtype

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -229,6 +229,17 @@ Now, when you view orders, you'll see information around the particular payment.
 
 > **Note:** When using the Stripe Gateway, only new orders will show any payment information, due to some required data we were not previously storing.
 
+### Medium: Shipping Method fieldtype
+
+In addition to the Gateway fieldtype, Simple Commerce also comes with a 'Shipping Method fieldtype' so CP users can see which shipping method has been selected for the current orders.
+
+New sites will get the Shipping Method fieldtype by default but it's recommended you also add it to your existing order blueprint.
+
+1. Go into the Control Panel, click into 'Blueprints'
+2. Edit your order blueprint, add the 'Shipping Method' fieldtype. Remember to use the handle of `shipping_method`, otherwise it won't work.
+
+Now, when you view orders, you'll be able to see the selected shipping method.
+
 ### Low: Higher System Requirements
 
 Simple Commerce v3 requires you to be using PHP 8.0 (and above), along with Laravel 8 (and above) and Statamic 3.3. Adjusting the system requirements encourages developers to stay up to date and means Simple Commerce can take advantage of new features.

--- a/resources/blueprints/collections/orders/orders.yaml
+++ b/resources/blueprints/collections/orders/orders.yaml
@@ -5,32 +5,21 @@ sections:
     fields:
       - handle: title
         field:
-          type: hidden
+          type: text
           required: false
-      - handle: is_paid
-        field:
-          type: toggle
-          listable: false
-          display: "Is Paid?"
+          input_type: text
+          antlers: false
+          display: Title
+          icon: text
           width: 75
-          read_only: true
+          listable: hidden
+          instructions_position: above
       - handle: is_paid
         field:
           type: toggle
           listable: false
           display: "Is Paid?"
           width: 25
-      - handle: customer
-        field:
-          max_items: 1
-          mode: default
-          collections:
-            - customers
-          type: entries
-          listable: hidden
-          display: Customer
-          width: 50
-          read_only: true
       - handle: coupon
         field:
           max_items: 1
@@ -42,11 +31,32 @@ sections:
           display: Coupon
           width: 50
           read_only: true
+      - handle: customer
+        field:
+          max_items: 1
+          mode: default
+          collections:
+            - customers
+          type: entries
+          listable: hidden
+          display: Customer
+          width: 50
+          read_only: true
       - handle: gateway
         field:
           display: Gateway
           type: gateway
           icon: gateway
+          width: 50
+          listable: hidden
+          instructions_position: above
+      - handle: shipping_method
+        field:
+          max_items: 1
+          mode: select
+          display: "Shipping Method"
+          type: shipping_method
+          icon: shipping_method
           width: 50
           listable: hidden
           instructions_position: above

--- a/src/Fieldtypes/ShippingMethodFieldtype.php
+++ b/src/Fieldtypes/ShippingMethodFieldtype.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Statamic\CP\Column;
+use Statamic\Facades\Site;
+use Statamic\Fieldtypes\Relationship;
+
+class ShippingMethodFieldtype extends Relationship
+{
+    protected $canCreate = false;
+
+    protected function configFieldItems(): array
+    {
+        return [
+            'max_items' => [
+                'display' => __('Max Items'),
+                'instructions' => __('statamic::messages.max_items_instructions'),
+                'type' => 'hidden',
+                'default' => 1,
+            ],
+            'mode' => [
+                'display' => __('Mode'),
+                'instructions' => __('statamic::fieldtypes.relationship.config.mode'),
+                'type' => 'hidden',
+                'default' => 'select',
+            ],
+        ];
+    }
+
+    public function getIndexItems($request)
+    {
+        $site = Site::selected();
+
+        return SimpleCommerce::shippingMethods($site->handle())
+            ->map(function ($shippingMethod) {
+                return [
+                    'id' => $shippingMethod['class'],
+                    'name' => $shippingMethod['name'],
+                    'title' => $shippingMethod['name'],
+                ];
+            })
+            ->values();
+    }
+
+    protected function getColumns()
+    {
+        return [
+            Column::make('name'),
+        ];
+    }
+
+    public function toItemArray($value)
+    {
+        $site = Site::selected();
+
+        $shippingMethod = SimpleCommerce::shippingMethods($site->handle())
+            ->where('class', $value)
+            ->first();
+
+        if (! $shippingMethod) {
+            return null;
+        }
+
+        return [
+            'id' => $shippingMethod['class'],
+            'title' => $shippingMethod['name'],
+        ];
+    }
+
+    public function preProcessIndex($data)
+    {
+        if (! $data) {
+            return;
+        }
+
+        return collect($data)->map(function ($item) {
+            $site = Site::selected();
+
+            $shippingMethod = SimpleCommerce::shippingMethods($site->handle())
+                ->where('class', $item)
+                ->first();
+
+            if (! $shippingMethod) {
+                return null;
+            }
+
+            return $shippingMethod['name'];
+        })->join(', ');
+    }
+
+    public function rules(): array
+    {
+        if ($this->config('max_items') === 1) {
+            return [
+                'string',
+                'in:' . implode(',', SimpleCommerce::shippingMethods(Site::selected()->handle())->pluck('class')->toArray()),
+            ];
+        }
+
+        return parent::rules();
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -37,6 +37,7 @@ class ServiceProvider extends AddonServiceProvider
         Fieldtypes\ProductVariantFieldtype::class,
         Fieldtypes\ProductVariantsFieldtype::class,
         Fieldtypes\RegionFieldtype::class,
+        Fieldtypes\ShippingMethodFieldtype::class,
         Fieldtypes\TaxCategoryFieldtype::class,
 
         Fieldtypes\Variables\LineItemTax::class,

--- a/tests/Fieldtypes/ShippingMethodFieldtypeTest.php
+++ b/tests/Fieldtypes/ShippingMethodFieldtypeTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Tests\Fieldtypes;
+
+use DoubleThreeDigital\SimpleCommerce\Fieldtypes\ShippingMethodFieldtype;
+use DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost;
+use DoubleThreeDigital\SimpleCommerce\Tests\Invader;
+use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Statamic\CP\Column;
+
+class ShippingMethodFieldtypeTest extends TestCase
+{
+    protected $fieldtype;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fieldtype = new ShippingMethodFieldtype;
+    }
+
+    /** @test */
+    public function can_get_config_field_items()
+    {
+        $configFieldItems = (new Invader($this->fieldtype))->configFieldItems();
+
+        $this->assertIsArray($configFieldItems);
+    }
+
+    /** @test */
+    public function can_get_index_items()
+    {
+        $getIndexItems = $this->fieldtype->getIndexItems(new Request());
+
+        $this->assertTrue($getIndexItems instanceof Collection);
+
+        $this->assertSame($getIndexItems->last(), [
+            'id' => StandardPost::class,
+            'name' => 'Standard Post',
+            'title' => 'Standard Post',
+        ]);
+    }
+
+    /** @test */
+    public function can_get_columns()
+    {
+        $getColumns = (new Invader($this->fieldtype))->getColumns();
+
+        $this->assertIsArray($getColumns);
+
+        $this->assertTrue($getColumns[0] instanceof Column);
+        $this->assertSame($getColumns[0]->field(), 'name');
+        $this->assertSame($getColumns[0]->label(), 'Name');
+    }
+
+    /** @test */
+    public function can_return_as_item_array()
+    {
+        $toItemArray = $this->fieldtype->toItemArray(StandardPost::class);
+
+        $this->assertIsArray($toItemArray);
+
+        $this->assertSame($toItemArray, [
+            'id' => StandardPost::class,
+            'title' => 'Standard Post',
+        ]);
+    }
+
+    /** @test */
+    public function can_preprocess_index()
+    {
+        $preProcessIndex = $this->fieldtype->preProcessIndex(StandardPost::class);
+
+        $this->assertIsString($preProcessIndex);
+        $this->assertSame($preProcessIndex, 'Standard Post');
+    }
+
+    /** @test */
+    public function can_preprocess_index_with_no_shipping_method()
+    {
+        $preProcessIndex = $this->fieldtype->preProcessIndex(null);
+
+        $this->assertNull($preProcessIndex);
+    }
+}


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request introduces a new shipping method fieldtype that lets Control Panel users view the name of the shipping method used for the current order.

We're not doing anything that special with this - just a 'normal' relationship fieldtype.

![image](https://user-images.githubusercontent.com/19637309/163671066-e14bc01d-e176-4edd-a125-7e2670a09ea1.png)

## To Do

* [X] Implemented a Shipping Method fieldtype
* [x] Added some tests
* [X] Added a note to the 'upgrade guide'
