### PR TITLE
v3.0: Add Gateway & Shipping Methods to Order blueprint upon upgrade to v3

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -218,27 +218,13 @@ On the 'Order Confirmation' page (the one after checking out), you'd previously 
 {{ /sc:cart }}
 ```
 
-### Medium: Gateway fieldtype
+### Low: Gateway & Shipping Method fields (Automated)
 
-Included in Simple Commerce v3 is a 'Gateway Fieldtype' which allows you to view the gateway used for a specific order, along with information around the payment itself. New sites will get the Gateway fieldtype by default but it's recommended you also add it to your existing order blueprint.
+During the upgrade process, Simple Commerce added two new fields to your Order blueprint. A **Gateway** field and a **Shipping Method** field. These fields should hopefully be useful for your CP users to be able to see the gateway/shipping method that's being used for an order.
 
-1. Go into the Control Panel, click into 'Blueprints'
-2. Edit your order blueprint, add the 'Gateway' fieldtype. Remember to use the handle of `gateway`, otherwise it won't work.
+The fields will automatically be pushed into the Sidebar of the Order blueprint, you may move it as you wish.
 
-Now, when you view orders, you'll see information around the particular payment.
-
-> **Note:** When using the Stripe Gateway, only new orders will show any payment information, due to some required data we were not previously storing.
-
-### Medium: Shipping Method fieldtype
-
-In addition to the Gateway fieldtype, Simple Commerce also comes with a 'Shipping Method fieldtype' so CP users can see which shipping method has been selected for the current orders.
-
-New sites will get the Shipping Method fieldtype by default but it's recommended you also add it to your existing order blueprint.
-
-1. Go into the Control Panel, click into 'Blueprints'
-2. Edit your order blueprint, add the 'Shipping Method' fieldtype. Remember to use the handle of `shipping_method`, otherwise it won't work.
-
-Now, when you view orders, you'll be able to see the selected shipping method.
+> **Note:** When using the Stripe Gateway, past orders will show 'Unknown' as the payment ID. Future orders will show the payment ID as expected.
 
 ### Low: Higher System Requirements
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -104,6 +104,7 @@ class ServiceProvider extends AddonServiceProvider
         UpdateScripts\v2_4\MigrateSingleCartConfig::class,
         UpdateScripts\v2_4\MigrateTaxConfiguration::class,
 
+        UpdateScripts\v3_0\AddNewFieldsToOrderBlueprint::class,
         UpdateScripts\v3_0\ConfigureTitleFormats::class,
         UpdateScripts\v3_0\ConfigureWhitelistedFields::class,
         UpdateScripts\v3_0\UpdateContentRepositoryReferences::class,

--- a/src/UpdateScripts/v3_0/AddNewFieldsToOrderBlueprint.php
+++ b/src/UpdateScripts/v3_0/AddNewFieldsToOrderBlueprint.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v3_0;
+
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Statamic\Facades\Collection;
+use Statamic\Fields\Blueprint;
+use Statamic\UpdateScripts\UpdateScript;
+
+class AddNewFieldsToOrderBlueprint extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('3.0.0-beta.1');
+    }
+
+    public function update()
+    {
+        if (! isset(SimpleCommerce::orderDriver()['collection']) || ! isset(SimpleCommerce::customerDriver()['collection'])) {
+            return;
+        }
+
+        Collection::find(SimpleCommerce::orderDriver()['collection'])
+            ->entryBlueprints()
+            ->each(function (Blueprint $blueprint) {
+                $blueprint->ensureFieldInSection('gateway', [
+                    'display' => 'Gateway',
+                    'type' => 'gateway',
+                ], 'sidebar');
+
+                $blueprint->ensureFieldInSection('shipping_method', [
+                    'display' => 'Shipping Method',
+                    'type' => 'shipping_method',
+                ], 'sidebar');
+
+                $blueprint->save();
+            });
+
+        $this->console()->info('Simple Commerce has added two new fields to your Order blueprint: `gateway` and `shipping_method`.');
+    }
+}

--- a/src/UpdateScripts/v3_0/ConfigureTitleFormats.php
+++ b/src/UpdateScripts/v3_0/ConfigureTitleFormats.php
@@ -24,6 +24,8 @@ class ConfigureTitleFormats extends UpdateScript
         $this
             ->setupTitleFormatForOrders()
             ->setupTitleFormatForCustomers();
+
+        $this->console()->info("Simple Commerce has configured 'title formats' for your Order and Customer collections.");
     }
 
     protected function setupTitleFormatForOrders(): self

--- a/src/UpdateScripts/v3_0/ConfigureWhitelistedFields.php
+++ b/src/UpdateScripts/v3_0/ConfigureWhitelistedFields.php
@@ -39,5 +39,7 @@ class ConfigureWhitelistedFields extends UpdateScript
                 'line_items' => [],
             ])
             ->save();
+
+        $this->console()->info("Simple Commerce has added the 'field_whitelist' config setting to your config file. You should update the list as needed.");
     }
 }


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request implements an upgrade script to automatically add the new Gateway & Shipping Method fields to order blueprints upon upgrade to v3.
