### PR TITLE
v3.0: Set title formats during install command

### DIFF
--- a/tests/Orders/EntryOrderRepositoryTest.php
+++ b/tests/Orders/EntryOrderRepositoryTest.php
@@ -7,6 +7,7 @@ use DoubleThreeDigital\SimpleCommerce\Tests\Invader;
 use DoubleThreeDigital\SimpleCommerce\Tests\RefreshContent;
 use DoubleThreeDigital\SimpleCommerce\Tests\SetupCollections;
 use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
+use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 
 class EntryOrderRepositoryTest extends TestCase
@@ -35,6 +36,8 @@ class EntryOrderRepositoryTest extends TestCase
     /** @test */
     public function can_generate_order_number_from_previous_order_titles()
     {
+        Collection::find('orders')->titleFormats([])->save();
+
         Entry::make()
             ->collection('orders')
             ->data(['title' => '#1234'])
@@ -58,6 +61,10 @@ class EntryOrderRepositoryTest extends TestCase
     /** @test */
     public function can_generate_order_number_from_previous_order_number()
     {
+        Collection::find('orders')->titleFormats([
+            'default' => '#{order_number}',
+        ])->save();
+
         Entry::make()
             ->collection('orders')
             ->data(['order_number' => 6001])

--- a/tests/SetupCollections.php
+++ b/tests/SetupCollections.php
@@ -30,6 +30,9 @@ trait SetupCollections
         return Collection::make('customers')
             ->title('Customers')
             ->sites(['default'])
+            ->titleFormats([
+                'default' => '{name} <{email}>',
+            ])
             ->save();
     }
 
@@ -38,6 +41,9 @@ trait SetupCollections
         return Collection::make('orders')
             ->title('Orders')
             ->sites(['default'])
+            ->titleFormats([
+                'default' => '#{order_number}',
+            ])
             ->save();
     }
 


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

We're currently only configuring the title formats during the upgrade process but this PR implements the change in the install command so new sites will contain the title format stuff too.
