### PR TITLE
v3.0: Remove `addOrder` method from Customer class

### DIFF
--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -65,17 +65,6 @@ class Customer implements Contract
             });
     }
 
-    public function addOrder($orderId): self
-    {
-        $orders = $this->has('orders') ? $this->get('orders') : [];
-        $orders[] = $orderId;
-
-        $this->set('orders', $orders);
-        $this->save();
-
-        return $this;
-    }
-
     public function routeNotificationForMail($notification = null)
     {
         return $this->email();

--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -59,10 +59,17 @@ class Customer implements Contract
 
     public function orders(): Collection
     {
-        return collect($this->has('orders') ? $this->get('orders') : [])
-            ->map(function ($orderId) {
-                return Order::find($orderId);
+        if ($this->resource instanceof Model) {
+            return $this->resource->orders->map(function ($order) {
+                return Order::find($order->id);
             });
+        }
+
+        $orders = $this->get('orders', []);
+
+        return collect($orders)->map(function ($orderId) {
+            return Order::find($orderId);
+        });
     }
 
     public function routeNotificationForMail($notification = null)

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -16,6 +16,7 @@ use DoubleThreeDigital\SimpleCommerce\Http\Requests\AcceptsFormRequests;
 use DoubleThreeDigital\SimpleCommerce\Http\Requests\Checkout\StoreRequest;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use DoubleThreeDigital\SimpleCommerce\Rules\ValidCoupon;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Statamic\Facades\Site;
@@ -258,8 +259,12 @@ class CheckoutController extends BaseActionController
 
     protected function postCheckout()
     {
-        if ($this->cart->customer()) {
-            $this->cart->customer()->addOrder($this->cart->id);
+        if (isset(SimpleCommerce::customerDriver()['collection']) && $this->cart->customer()) {
+            $this->cart->customer()->merge([
+                'orders' => $this->cart->customer()->orders()->push($this->cart->id())->toArray(),
+            ]);
+
+            $this->cart->customer()->save();
         }
 
         if (! $this->request->has('gateway') && $this->cart->isPaid() === false && $this->cart->grandTotal() === 0) {

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -259,9 +259,11 @@ class CheckoutController extends BaseActionController
 
     protected function postCheckout()
     {
-        if (isset(SimpleCommerce::customerDriver()['collection']) && $this->cart->customer()) {
+        if (! isset(SimpleCommerce::customerDriver()['model']) && $this->cart->customer()) {
             $this->cart->customer()->merge([
-                'orders' => $this->cart->customer()->orders()->push($this->cart->id())->toArray(),
+                'orders' => $this->cart->customer()->orders()
+                    ->push($this->cart->id())
+                    ->toArray(),
             ]);
 
             $this->cart->customer()->save();

--- a/tests/Customers/UserCustomerTest.php
+++ b/tests/Customers/UserCustomerTest.php
@@ -314,22 +314,6 @@ class UserCustomerTest extends TestCase
     }
 
     /** @test */
-    public function can_add_order()
-    {
-        $order = Order::make()->merge(['title' => 'Order #0002']);
-        $order->save();
-
-        $user = User::make()->id('sam')->email('sam@example.com')->set('name', 'Sam Example');
-        $user->save();
-
-        $customer = Customer::find('sam');
-        $customer->addOrder($order->id())->save();
-
-        $this->assertSame($customer->orders()->count(), 1);
-        $this->assertSame($customer->orders()->first()->get('title'), 'Order #0002');
-    }
-
-    /** @test */
     public function can_get_mail_notification_route()
     {
         $user = User::make()->id('sam')->email('sam@example.com')->set('name', 'Sam Example');


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request removes the `addOrder` method which exists on the `Customer` class as it's no longer necessary for all content drivers.

In the past, it would be responsible for adding an order ID to the `orders` array on a Customer entry / user. However, if you're using the Eloquent driver for example, this is no longer necessary as we can use Eloquent relationships for the same thing.