### PR TITLE
Only redeem coupon after order has been marked as paid

### DIFF
--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -39,10 +39,10 @@ class CheckoutController extends BaseActionController
                 ->preCheckout()
                 ->handleValidation()
                 ->handleCustomerDetails()
-                ->handleCoupon()
                 ->handleStock($this->cart)
                 ->handleRemainingData()
                 ->handlePayment()
+                ->handleCoupon()
                 ->postCheckout();
         } catch (CheckoutProductHasNoStockException $e) {
             $lineItem = $this->cart->lineItems()->filter(function ($lineItem) use ($e) {
@@ -147,21 +147,6 @@ class CheckoutController extends BaseActionController
         return $this;
     }
 
-    protected function handleCoupon()
-    {
-        if ($coupon = $this->request->get('coupon')) {
-            $this->cart->set('coupon', Coupon::findByCode($coupon)->id())->save();
-
-            $this->excludedKeys[] = 'coupon';
-        }
-
-        if (isset($this->cart->data['coupon'])) {
-            $this->cart->coupon()->redeem();
-        }
-
-        return $this;
-    }
-
     protected function handleRemainingData()
     {
         $data = [];
@@ -203,6 +188,21 @@ class CheckoutController extends BaseActionController
 
         foreach (Gateway::use($this->request->gateway)->purchaseRules() as $key => $rule) {
             $this->excludedKeys[] = $key;
+        }
+
+        return $this;
+    }
+
+    protected function handleCoupon()
+    {
+        if ($coupon = $this->request->get('coupon')) {
+            $this->cart->set('coupon', Coupon::findByCode($coupon)->id())->save();
+
+            $this->excludedKeys[] = 'coupon';
+        }
+
+        if (isset($this->cart->data['coupon'])) {
+            $this->cart->coupon()->redeem();
         }
 
         return $this;

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -39,10 +39,10 @@ class CheckoutController extends BaseActionController
                 ->preCheckout()
                 ->handleValidation()
                 ->handleCustomerDetails()
+                ->handleCoupon()
                 ->handleStock($this->cart)
                 ->handleRemainingData()
                 ->handlePayment()
-                ->handleCoupon()
                 ->postCheckout();
         } catch (CheckoutProductHasNoStockException $e) {
             $lineItem = $this->cart->lineItems()->filter(function ($lineItem) use ($e) {
@@ -147,6 +147,21 @@ class CheckoutController extends BaseActionController
         return $this;
     }
 
+    protected function handleCoupon()
+    {
+        if ($coupon = $this->request->get('coupon')) {
+            $this->cart->set('coupon', Coupon::findByCode($coupon)->id())->save();
+
+            $this->excludedKeys[] = 'coupon';
+        }
+
+        if (isset($this->cart->data['coupon'])) {
+            $this->cart->coupon()->redeem();
+        }
+
+        return $this;
+    }
+
     protected function handleRemainingData()
     {
         $data = [];
@@ -188,21 +203,6 @@ class CheckoutController extends BaseActionController
 
         foreach (Gateway::use($this->request->gateway)->purchaseRules() as $key => $rule) {
             $this->excludedKeys[] = $key;
-        }
-
-        return $this;
-    }
-
-    protected function handleCoupon()
-    {
-        if ($coupon = $this->request->get('coupon')) {
-            $this->cart->set('coupon', Coupon::findByCode($coupon)->id())->save();
-
-            $this->excludedKeys[] = 'coupon';
-        }
-
-        if (isset($this->cart->data['coupon'])) {
-            $this->cart->coupon()->redeem();
         }
 
         return $this;

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -155,10 +155,6 @@ class CheckoutController extends BaseActionController
             $this->excludedKeys[] = 'coupon';
         }
 
-        if (isset($this->cart->data['coupon'])) {
-            $this->cart->coupon()->redeem();
-        }
-
         return $this;
     }
 
@@ -216,6 +212,10 @@ class CheckoutController extends BaseActionController
 
         if (! $this->request->has('gateway') && $this->cart->get('is_paid') === false && $this->cart->get('grand_total') === 0) {
             $this->cart->markAsPaid();
+        }
+
+        if (isset($this->cart->data['coupon'])) {
+            $this->cart->coupon()->redeem();
         }
 
         $this->forgetCart();


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request fixes an issue where if you reach 'maximum_uses' during checkout, you either wouldn't be able to complete the checkout process or your customer would get charged the full amount (eg. discount didn't take affect).

The calculations is where it would do a 'isValid' check on the coupon but by that time it would already be considered invalid.

This PR moves the logic which redeems the coupon to **after** the order has been marked as paid.

Regarding tests: I've not written any for v2.4 but I will write some for v3.0 shortly (#623) as the 2.4 test for checking out with coupons is currently skipped.