### PR TITLE
v3.0: Only redeem coupon after order has been marked as paid

### DIFF
--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -191,10 +191,6 @@ class CheckoutController extends BaseActionController
             $this->excludedKeys[] = 'coupon';
         }
 
-        if ($this->cart->coupon()) {
-            $this->cart->coupon()->redeem();
-        }
-
         return $this;
     }
 
@@ -271,6 +267,10 @@ class CheckoutController extends BaseActionController
 
         if (! $this->request->has('gateway') && $this->cart->isPaid() === false && $this->cart->grandTotal() === 0) {
             $this->cart->markAsPaid();
+        }
+
+        if ($this->cart->coupon()) {
+            $this->cart->coupon()->redeem();
         }
 
         $this->forgetCart();


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

v3 implementation of #622, including tests.