### PR TITLE
Stripe Gateway: Save payment intent to orders

### DIFF
--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -98,6 +98,7 @@ class StripeGateway extends BaseGateway implements Gateway
             'card'     => $paymentMethod->card->toArray(),
             'customer' => $paymentMethod->customer,
             'livemode' => $paymentMethod->livemode,
+            'payment_intent' => $paymentIntent->id,
         ]);
     }
 
@@ -129,9 +130,15 @@ class StripeGateway extends BaseGateway implements Gateway
     {
         $this->setUpWithStripe();
 
-        $paymentIntent = isset($order->get('stripe')['intent'])
-            ? $order->get('stripe')['intent']
-            : null;
+        $paymentIntent = null;
+
+        if (isset($order->get('gateway')['data']['payment_intent'])) {
+            $paymentIntent = $order->get('gateway')['data']['payment_intent'];
+        }
+
+        if (isset($order->get('stripe')['intent'])) {
+            $paymentIntent = $order->get('stripe')['intent'];
+        }
 
         if (! $paymentIntent) {
             throw new RefundFailed('Stripe: No Payment Intent was provided to action a refund.');

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -113,9 +113,15 @@ class StripeGateway extends BaseGateway implements Gateway
     {
         $this->setUpWithStripe();
 
-        $paymentIntent = isset($order->get('stripe')['intent'])
-            ? $order->get('stripe')['intent']
-            : null;
+        $paymentIntent = null;
+
+        if (isset($order->get('gateway')['data']['payment_intent'])) {
+            $paymentIntent = $order->get('gateway')['data']['payment_intent'];
+        }
+
+        if (isset($order->get('stripe')['intent'])) {
+            $paymentIntent = $order->get('stripe')['intent'];
+        }
 
         if (! $paymentIntent) {
             throw new StripePaymentIntentNotProvided('Stripe: No Payment Intent was provided to fetch.');

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -275,9 +275,6 @@ class StripeGatewayTest extends TestCase
                 'intent' => $paymentIntent = PaymentIntent::create([
                     'amount' => 1234,
                     'currency' => 'GBP',
-                    // 'automatic_payment_methods' => [
-                    //     'enabled' => 'true',
-                    // ],
                 ])->id,
             ],
         ]);
@@ -342,9 +339,6 @@ class StripeGatewayTest extends TestCase
                 'intent' => $paymentIntent = PaymentIntent::create([
                     'amount' => 1234,
                     'currency' => 'GBP',
-                    // 'automatic_payment_methods' => [
-                    //     'enabled' => 'true',
-                    // ],
                 ])->id,
             ],
             'grand_total' => 1234,
@@ -373,9 +367,6 @@ class StripeGatewayTest extends TestCase
                 'intent' => $paymentIntent = PaymentIntent::create([
                     'amount' => 1234,
                     'currency' => 'GBP',
-                    // 'automatic_payment_methods' => [
-                    //     'enabled' => 'true',
-                    // ],
                 ])->id,
             ],
             'grand_total' => 1234,

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -308,6 +308,7 @@ class StripeGatewayTest extends TestCase
         // $this->assertSame($purchase->data()['card'], $paymentMethod->card);
         $this->assertSame($purchase->data()['customer'], $paymentMethod->customer);
         $this->assertSame($purchase->data()['livemode'], $paymentMethod->livemode);
+        $this->assertSame($purchase->data()['payment_intent'], $paymentIntent);
 
         $order = $order->fresh();
 


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request saves the ID of the Stripe Payment Intent to the 'gateway data' of new orders as this was previously missing, due to it being cleaned up from the 'temporary gateway data' after checkout.

This has already been fixed in v3.0 but I've noticed I do need to refactor the v3 implementation for refunds etc so it grabs the Payment Intent ID from the right place.

**Note:** This pull request will only fix the refund problem for future orders, not past orders. If you need to refund a past order, I'd recommend doing so within the Stripe Dashboard.

Fixes #624 (for new orders only, though)

## To Do

* [X] Added 'payment_intent' to the gateway data saved to the order
* [X] Updated tests to assert Payment Intent is added to gateway data
* [x] Update tests around getting a charge from payment intent (in either two places)
* [x] Update tests around refunding a charge from payment intent (in either two places)