### PR TITLE
Database orders: Fix issue where multiple orders would be created instead of just the one

### DIFF
--- a/src/Orders/EloquentOrderRepository.php
+++ b/src/Orders/EloquentOrderRepository.php
@@ -156,6 +156,8 @@ class EloquentOrderRepository implements RepositoryContract
             'use_shipping_address_for_billing' => $model->use_shipping_address_for_billing,
             'paid_date' => $model->paid_date,
         ]);
+
+        $order->resource = $model;
     }
 
     public function delete($order): void


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request fixes an issue where multiple order records would be created, instead of just the one. When you say, added a product to the cart, 3 carts may be created, even though only one will ever be used.