### PR TITLE
Fix issues when appending to customer `orders` array

### DIFF
--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Customers;
 
 use DoubleThreeDigital\SimpleCommerce\Contracts\Customer as Contract;
 use DoubleThreeDigital\SimpleCommerce\Data\HasData;
+use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
 use DoubleThreeDigital\SimpleCommerce\Facades\Customer as CustomerFacade;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Http\Resources\BaseResource;
@@ -70,8 +71,12 @@ class Customer implements Contract
         $orders = $this->get('orders', []);
 
         return collect($orders)->map(function ($orderId) {
-            return Order::find($orderId);
-        });
+            try {
+                return Order::find($orderId);
+            } catch (OrderNotFound $e) {
+                return null;
+            }
+        })->filter()->values();
     }
 
     public function routeNotificationForMail($notification = null)

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -258,6 +258,7 @@ class CheckoutController extends BaseActionController
         if (! isset(SimpleCommerce::customerDriver()['model']) && $this->cart->customer()) {
             $this->cart->customer()->merge([
                 'orders' => $this->cart->customer()->orders()
+                    ->pluck('id')
                     ->push($this->cart->id())
                     ->toArray(),
             ]);

--- a/tests/Http/Controllers/CheckoutControllerTest.php
+++ b/tests/Http/Controllers/CheckoutControllerTest.php
@@ -524,6 +524,88 @@ class CheckoutControllerTest extends TestCase
         $this->assertFalse(session()->has('simple-commerce-cart'));
     }
 
+    /**
+     * @test
+     * https://github.com/doublethreedigital/simple-commerce/issues/629
+     */
+    public function can_post_checkout_with_customer_where_customer_has_invalid_orders()
+    {
+        Event::fake();
+
+        $product = Product::make()
+            ->price(5000)
+            ->data([
+                'title' => 'Bacon',
+            ]);
+
+        $product->save();
+
+        $previousOrder = Order::make();
+        $previousOrder->save();
+
+        $customer = Customer::make()
+            ->email('stanley.hudson@example.com')
+            ->data([
+                'name' => 'Stanley Hudson',
+                'orders' => [
+                    'abc',
+                    '123',
+                    $previousOrder->id(),
+                ],
+            ]);
+
+        $customer->save();
+
+        $order = Order::make()->lineItems([
+            [
+                'id'       => Stache::generateId(),
+                'product'  => $product->id,
+                'quantity' => 1,
+                'total'    => 5000,
+            ],
+        ])->grandTotal(5000);
+
+        $order->save();
+
+        $this
+            ->withSession(['simple-commerce-cart' => $order->id])
+            ->post(route('statamic.simple-commerce.checkout.store'), [
+                'customer'     => $customer->id,
+                'gateway'      => DummyGateway::class,
+                'card_number'  => '4242424242424242',
+                'expiry_month' => '01',
+                'expiry_year'  => '2025',
+                'cvc'          => '123',
+            ]);
+
+        $order = $order->fresh();
+
+        // Assert events have been dispatched
+        Event::assertDispatched(PreCheckout::class);
+        Event::assertDispatched(PostCheckout::class);
+
+        // Assert order has been marked as paid
+        $this->assertTrue($order->get('published'));
+
+        $this->assertTrue($order->isPaid());
+        $this->assertNotNull($order->get('paid_date'));
+
+        // Assert customer has been updated
+        $this->assertNotNull($order->customer());
+        $this->assertSame($order->customer()->id(), $customer->id);
+
+        $this->assertSame($order->customer()->name(), 'Stanley Hudson');
+        $this->assertSame($order->customer()->email(), 'stanley.hudson@example.com');
+
+        $this->assertSame($order->customer()->orders()->pluck('id')->unique()->toArray(), [
+            $previousOrder->id(),
+            $order->id(),
+        ]);
+
+        // Finally, assert order is no longer attached to the users' session
+        $this->assertFalse(session()->has('simple-commerce-cart'));
+    }
+
     /** @test */
     public function can_post_checkout_with_coupon()
     {


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request fixes two issues when appending to the `orders` array that exists on customer entries:

* The IDs of orders in the array are plucked during checkout, instead of doing a lookup of the `Customer` class (which doesn't work)
* Fixed the issue causing #629 - where a customer's `orders` array contains order IDs that no longer exist, in which case Simple Commerce will now filter those orders out upon save

## To Do

* [x] Fixed #629 - orders which no longer exist will be filtered out of the array
* [x] Added a test to ensure #629 doesn't happen again
* [x] Fixed another issue I ran into during testing where a lookup of an `Order` instance would happen - even though it should just get an order ID (if that even makes sense 😅 )
