### PR TITLE
Database Orders: Allow for adding custom columns

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "stripe/stripe-php": "^7.7"
     },
     "require-dev": {
+        "doctrine/dbal": "^3.3",
         "nunomaduro/collision": "^5.0 || ^6.1",
         "orchestra/testbench": "^6.0 || ^7.0",
         "spatie/ray": "^1.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "408c5719bfadc21c4f493e40eb5c0375",
+    "content-hash": "709e7335ed21dc64fe4de37fcc37b336",
     "packages": [
         {
             "name": "ajthinking/archetype",
@@ -7838,6 +7838,347 @@
     ],
     "packages-dev": [
         {
+            "name": "doctrine/cache",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/1ca8f21980e770095a31456042471a57bc4c68fb",
+                "reference": "1ca8f21980e770095a31456042471a57bc4c68fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/coding-standard": "^9",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "symfony/cache": "^4.4 || ^5.4 || ^6",
+                "symfony/var-exporter": "^4.4 || ^5.4 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
+            "homepage": "https://www.doctrine-project.org/projects/cache.html",
+            "keywords": [
+                "abstraction",
+                "apcu",
+                "cache",
+                "caching",
+                "couchdb",
+                "memcached",
+                "php",
+                "redis",
+                "xcache"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/cache/issues",
+                "source": "https://github.com/doctrine/cache/tree/2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-20T20:07:39+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "3.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "9e7f76dd1cde81c62574fdffa5a9c655c847ad21"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/9e7f76dd1cde81c62574fdffa5a9c655c847ad21",
+                "reference": "9e7f76dd1cde81c62574fdffa5a9c655c847ad21",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2",
+                "doctrine/cache": "^1.11|^2.0",
+                "doctrine/deprecations": "^0.5.3|^1",
+                "doctrine/event-manager": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "9.0.0",
+                "jetbrains/phpstorm-stubs": "2022.1",
+                "phpstan/phpstan": "1.6.3",
+                "phpstan/phpstan-strict-rules": "^1.2",
+                "phpunit/phpunit": "9.5.20",
+                "psalm/plugin-phpunit": "0.16.1",
+                "squizlabs/php_codesniffer": "3.6.2",
+                "symfony/cache": "^5.2|^6.0",
+                "symfony/console": "^2.7|^3.0|^4.0|^5.0|^6.0",
+                "vimeo/psalm": "4.23.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/3.3.6"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-02T17:21:01+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9",
+                "phpunit/phpunit": "^7.5|^8.5|^9.5",
+                "psr/log": "^1|^2|^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
+            },
+            "time": "2022-05-02T15:47:09+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/41370af6a30faa9dc0368c4a6814d596e81aba7f",
+                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/1.1.x"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-29T18:28:51+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.1",
             "source": {
@@ -9286,6 +9627,55 @@
                 "source": "https://github.com/silexphp/Pimple/tree/v3.5.0"
             },
             "time": "2021-10-28T11:13:42+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -10995,5 +11385,5 @@
         "php": "^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/docs/database-orders.md
+++ b/docs/database-orders.md
@@ -74,9 +74,39 @@ When you make the switch, Simple Commerce will install [Runway](https://statamic
 
 Runway has it's own documentation site - you may [read it if you please](https://runway.duncanmcclean.com/control-panel).
 
-## Overriding
+## Custom Columns
 
-If you need to add a column or do something special, you can override the Eloquent Model or the Repository used by Simple Commerce.
+There are cases where you may wish to add columns to either of the provided tables: `orders`/`customers`. You may do this by simply writing a migration to add a column to the table:
+
+```
+php artisan make:migration AddPickupPointColumnToOrdersTable
+```
+
+```php
+/**
+ * Run the migrations.
+ *
+ * @return void
+ */
+public function up()
+{
+    Schema::table('orders', function (Blueprint $table) {
+        $table->string('pickup_point')->after('gateway');
+    });
+}
+```
+
+You should then run your migrations:
+
+```
+php artisan migrate
+```
+
+Once migrated, Simple Commerce will get/set any order or customer data to your custom column, rather than relying on it being saved to the `data` column.
+
+## Customization
+
+If you need to, there's way to customise/override the Eloquent model used, along with the 'repository'.
 
 ### The Model
 

--- a/src/Console/Commands/SwitchToDatabase.php
+++ b/src/Console/Commands/SwitchToDatabase.php
@@ -37,7 +37,8 @@ class SwitchToDatabase extends Command
             ->copyMigrationStubs()
             ->switchRepositories()
             ->copyBlueprintStubs()
-            ->installRunway();
+            ->installRunway()
+            ->installDbal();
 
         $this->line('');
         $this->info('Next steps:');
@@ -104,6 +105,21 @@ class SwitchToDatabase extends Command
 
         if (! Composer::create()->isInstalled('doublethreedigital/runway')) {
             Composer::create()->require('doublethreedigital/runway');
+        }
+
+        if (! File::exists(config_path('runway.php'))) {
+            File::copy($this->stubsPath . '/runway_config.php', config_path('runway.php'));
+        }
+
+        return $this;
+    }
+
+    protected function installDbal(): self
+    {
+        $this->info('Installing Doctrine DBAL...');
+
+        if (! Composer::create()->isInstalled('doctrine/dbal')) {
+            Composer::create()->require('doctrine/dbal');
         }
 
         if (! File::exists(config_path('runway.php'))) {

--- a/src/Customers/CustomerModel.php
+++ b/src/Customers/CustomerModel.php
@@ -13,9 +13,7 @@ class CustomerModel extends Model
 
     protected $table = 'customers';
 
-    protected $fillable = [
-        'name', 'email', 'data',
-    ];
+    protected $guarded = [];
 
     protected $casts = [
         'data' => 'json',

--- a/src/Customers/EloquentCustomerRepository.php
+++ b/src/Customers/EloquentCustomerRepository.php
@@ -103,7 +103,17 @@ class EloquentCustomerRepository implements RepositoryContract
         $customer->id = $model->id;
         $customer->email = $model->email;
 
-        // TODO: name & data should be fed back in
+        $customer->data = collect($model->data)
+            ->merge([
+                'name' => $model->name,
+            ])
+            ->merge(
+                collect($this->getCustomColumns())
+                    ->mapWithKeys(function ($columnName) use ($model) {
+                        return [$columnName => $model->{$columnName}];
+                    })
+                    ->toArray()
+            );
 
         $customer->resource = $model;
     }

--- a/src/Customers/EloquentCustomerRepository.php
+++ b/src/Customers/EloquentCustomerRepository.php
@@ -2,15 +2,20 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Customers;
 
+use Doctrine\DBAL\Schema\Column;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Customer;
 use DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository as RepositoryContract;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Schema;
 
 class EloquentCustomerRepository implements RepositoryContract
 {
     protected $model;
+
+    protected $knownColumns = [
+        'name',
+    ];
 
     public function __construct()
     {
@@ -34,9 +39,19 @@ class EloquentCustomerRepository implements RepositoryContract
             ->resource($model)
             ->id($model->id)
             ->email($model->email)
-            ->data(array_merge($model->data, [
-                'name' => $model->name,
-            ]));
+            ->data(
+                collect($model->data)
+                    ->merge([
+                        'name' => $model->name,
+                    ])
+                    ->merge(
+                        collect($this->getCustomColumns())
+                            ->mapWithKeys(function ($columnName) use ($model) {
+                                return [$columnName => $model->{$columnName}];
+                            })
+                            ->toArray()
+                    )
+            );
     }
 
     public function findByEmail(string $email): ?Customer
@@ -64,22 +79,58 @@ class EloquentCustomerRepository implements RepositoryContract
         }
 
         $model->email = $customer->email();
-        $model->data = Arr::except($customer->data()->toArray(), ['name']);
 
         if ($name = $customer->get('name')) {
             $model->name = $name;
         }
 
+        // If anything in the order data has it's own column, save it
+        // there, rather than in the data column.
+        collect($this->getCustomColumns())
+            ->filter(function ($columnName) use ($customer) {
+                return $customer->has($columnName);
+            })
+            ->each(function ($columnName) use (&$model, $customer) {
+                $model->{$columnName} = $customer->get($columnName);
+            });
+
+        $model->data = $customer->data()
+            ->except($this->knownColumns)
+            ->except($this->getCustomColumns());
+
         $model->save();
 
         $customer->id = $model->id;
         $customer->email = $model->email;
+
+        // TODO: name & data should be fed back in
+
         $customer->resource = $model;
     }
 
     public function delete(Customer $customer): void
     {
         $customer->resource()->delete();
+    }
+
+    /**
+     * Returns an array of custom columns the developer
+     * has added to the 'customers' table.
+     *
+     * @return array
+     */
+    protected function getCustomColumns(): array
+    {
+        $tableColumns = Schema::getConnection()
+            ->getDoctrineSchemaManager()
+            ->listTableColumns((new $this->model)->getTable());
+
+        return collect($tableColumns)
+            ->reject(function (Column $column) {
+                return in_array($column->getName(), $this->knownColumns);
+            })
+            ->map->getName()
+            ->toArray();
     }
 
     public static function bindings(): array

--- a/src/Orders/OrderModel.php
+++ b/src/Orders/OrderModel.php
@@ -13,14 +13,7 @@ class OrderModel extends Model
 
     protected $table = 'orders';
 
-    protected $fillable = [
-        'is_paid', 'is_shipped', 'is_refunded', 'items', 'grand_total', 'items_total', 'tax_total',
-        'shipping_total', 'coupon_total', 'shipping_name', 'shipping_address', 'shipping_address_line2',
-        'shipping_city', 'shipping_postal_code', 'shipping_region', 'shipping_country', 'billing_name',
-        'billing_address', 'billing_address_line2', 'billing_city', 'billing_postal_code', 'billing_region',
-        'billing_country', 'use_shipping_address_for_billing', 'customer_id', 'coupon', 'gateway', 'data',
-        'paid_date',
-    ];
+    protected $guarded = [];
 
     protected $casts = [
         'is_paid' => 'boolean',
@@ -36,6 +29,9 @@ class OrderModel extends Model
         'gateway' => 'json',
         'data' => 'json',
         'paid_date' => 'datetime',
+
+        // Ignore this. Needed for SC's test suite.
+        'ordered_on_tuesday' => 'boolean',
     ];
 
     protected $appends = [

--- a/src/Orders/OrderModel.php
+++ b/src/Orders/OrderModel.php
@@ -29,9 +29,6 @@ class OrderModel extends Model
         'gateway' => 'json',
         'data' => 'json',
         'paid_date' => 'datetime',
-
-        // Ignore this. Needed for SC's test suite.
-        'ordered_on_tuesday' => 'boolean',
     ];
 
     protected $appends = [

--- a/tests/Customers/EloquentCustomerTest.php
+++ b/tests/Customers/EloquentCustomerTest.php
@@ -58,6 +58,27 @@ class EloquentCustomerTest extends TestCase
     }
 
     /** @test */
+    public function can_find_customer_with_custom_column()
+    {
+        $customer = CustomerModel::create([
+            'name' => 'CJ Cregg',
+            'email' => 'cj@whitehouse.gov',
+            'data' => [
+                'role' => 'Press Secretary',
+            ],
+            'favourite_colour' => 'Orange',
+        ]);
+
+        $find = Customer::find($customer->id);
+
+        $this->assertSame($find->id(), $customer->id);
+        $this->assertSame($find->name(), $customer->name);
+        $this->assertSame($find->email(), $customer->email);
+        $this->assertSame($find->get('role'), 'Press Secretary');
+        $this->assertSame($find->get('favourite_colour'), 'Orange');
+    }
+
+    /** @test */
     public function can_find_customer_by_email()
     {
         $customer = CustomerModel::create([
@@ -111,6 +132,27 @@ class EloquentCustomerTest extends TestCase
 
         $this->assertSame($customer->id(), $customerRecord->id);
         $this->assertSame($customer->get('is_senior_advisor'), true);
+    }
+
+    /** @test */
+    public function can_save_with_custom_column()
+    {
+        $customerRecord = CustomerModel::create([
+            'name' => 'CJ Cregg',
+            'email' => 'cj@whitehouse.gov',
+            'data' => [
+                'role' => 'Press Secretary',
+            ],
+        ]);
+
+        $customer = Customer::find($customerRecord->id);
+
+        $customer->set('favourite_colour', 'Yellow');
+
+        $customer->save();
+
+        $this->assertSame($customer->id(), $customerRecord->id);
+        $this->assertSame($customer->get('favourite_colour'), 'Yellow');
     }
 
     /** @test */

--- a/tests/Orders/EloquentOrderTest.php
+++ b/tests/Orders/EloquentOrderTest.php
@@ -99,7 +99,7 @@ class EloquentOrderTest extends TestCase
             'data' => [
                 'foo' => 'bar',
             ],
-            'ordered_on_tuesday' => true,
+            'ordered_on_tuesday' => 'Yes',
         ]);
 
         $find = Order::find($order->id);
@@ -107,7 +107,7 @@ class EloquentOrderTest extends TestCase
         $this->assertSame($find->id(), $order->id);
         $this->assertSame($find->lineItems()->count(), 1);
         $this->assertSame($find->get('foo'), 'bar');
-        $this->assertSame($find->get('ordered_on_tuesday'), true);
+        $this->assertSame($find->get('ordered_on_tuesday'), 'Yes');
     }
 
     /** @test */
@@ -171,16 +171,16 @@ class EloquentOrderTest extends TestCase
 
         $order = Order::find($orderRecord->id);
 
-        $order->set('ordered_on_tuesday', true);
+        $order->set('ordered_on_tuesday', 'Yes');
 
         $order->save();
 
         $this->assertSame($order->id(), $orderRecord->id);
-        $this->assertSame($order->get('ordered_on_tuesday'), true);
+        $this->assertSame($order->get('ordered_on_tuesday'), 'Yes');
 
         $this->assertDatabaseHas('orders', [
             'id' => $orderRecord->id,
-            'ordered_on_tuesday' => true,
+            'ordered_on_tuesday' => 'Yes',
         ]);
     }
 

--- a/tests/Orders/EloquentOrderTest.php
+++ b/tests/Orders/EloquentOrderTest.php
@@ -5,6 +5,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Tests\Orders;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
+use DoubleThreeDigital\SimpleCommerce\Tests\SetupCollections;
 use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
 use DoubleThreeDigital\SimpleCommerce\Tests\UseDatabaseContentDrivers;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -12,7 +13,7 @@ use Illuminate\Support\Collection;
 
 class EloquentOrderTest extends TestCase
 {
-    use RefreshDatabase, UseDatabaseContentDrivers;
+    use SetupCollections, RefreshDatabase, UseDatabaseContentDrivers;
 
     /** @test */
     public function can_get_all_orders()
@@ -82,6 +83,34 @@ class EloquentOrderTest extends TestCase
     }
 
     /** @test */
+    public function can_find_order_with_custom_column()
+    {
+        $product = Product::make()->price(1000);
+        $product->save();
+
+        $order = OrderModel::create([
+            'items' => [
+                [
+                    'product' => $product->id(),
+                    'quantity' => 1,
+                    'total' => 1000,
+                ],
+            ],
+            'data' => [
+                'foo' => 'bar',
+            ],
+            'ordered_on_tuesday' => true,
+        ]);
+
+        $find = Order::find($order->id);
+
+        $this->assertSame($find->id(), $order->id);
+        $this->assertSame($find->lineItems()->count(), 1);
+        $this->assertSame($find->get('foo'), 'bar');
+        $this->assertSame($find->get('ordered_on_tuesday'), true);
+    }
+
+    /** @test */
     public function can_create()
     {
         $create = Order::make()
@@ -122,6 +151,37 @@ class EloquentOrderTest extends TestCase
 
         $this->assertSame($order->id(), $orderRecord->id);
         $this->assertSame($order->get('is_special_order'), true);
+    }
+
+    /** @test */
+    public function can_save_when_bit_of_data_has_its_own_column()
+    {
+        $product = Product::make()->price(1000);
+        $product->save();
+
+        $orderRecord = OrderModel::create([
+            'items' => [
+                [
+                    'product' => $product->id(),
+                    'quantity' => 1,
+                    'total' => 1000,
+                ],
+            ],
+        ]);
+
+        $order = Order::find($orderRecord->id);
+
+        $order->set('ordered_on_tuesday', true);
+
+        $order->save();
+
+        $this->assertSame($order->id(), $orderRecord->id);
+        $this->assertSame($order->get('ordered_on_tuesday'), true);
+
+        $this->assertDatabaseHas('orders', [
+            'id' => $orderRecord->id,
+            'ordered_on_tuesday' => true,
+        ]);
     }
 
     /** @test */

--- a/tests/UseDatabaseContentDrivers.php
+++ b/tests/UseDatabaseContentDrivers.php
@@ -8,7 +8,7 @@ trait UseDatabaseContentDrivers
 {
     public function setUpDatabaseContentDrivers()
     {
-        $this->stubsPath = __DIR__ . '/../src/Console/Commands/stubs';
+        $this->stubsPath = __DIR__ . '/__fixtures__/database/migrations';
 
         if (count(File::glob(database_path('migrations') . '/*_create_customers_table.php')) < 1) {
             File::copy($this->stubsPath . '/create_customers_table.php', database_path('migrations/' . date('Y_m_d_His') . '_create_customers_table.php'));

--- a/tests/__fixtures__/database/migrations/create_customers_table.php
+++ b/tests/__fixtures__/database/migrations/create_customers_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCustomersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('customers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->string('email')->unique();
+            $table->json('data')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('customers');
+    }
+}

--- a/tests/__fixtures__/database/migrations/create_customers_table.php
+++ b/tests/__fixtures__/database/migrations/create_customers_table.php
@@ -18,6 +18,10 @@ class CreateCustomersTable extends Migration
             $table->string('name')->nullable();
             $table->string('email')->unique();
             $table->json('data')->nullable();
+
+            // Some custom stuff for testing...
+            $table->string('favourite_colour')->nullable();
+
             $table->timestamps();
         });
     }

--- a/tests/__fixtures__/database/migrations/create_orders_table.php
+++ b/tests/__fixtures__/database/migrations/create_orders_table.php
@@ -46,7 +46,7 @@ class CreateOrdersTable extends Migration
             $table->dateTime('paid_date')->nullable();
 
             // Some custom stuff for testing...
-            $table->boolean('ordered_on_tuesday')->nullable();
+            $table->string('ordered_on_tuesday')->nullable();
 
             $table->timestamps();
         });

--- a/tests/__fixtures__/database/migrations/create_orders_table.php
+++ b/tests/__fixtures__/database/migrations/create_orders_table.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateOrdersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('orders', function (Blueprint $table) {
+            $table->id();
+            $table->boolean('is_paid')->default(false);
+            $table->boolean('is_shipped')->default(false);
+            $table->boolean('is_refunded')->default(false);
+            $table->json('items')->nullable();
+            $table->integer('grand_total')->default(0);
+            $table->integer('items_total')->default(0);
+            $table->integer('tax_total')->default(0);
+            $table->integer('shipping_total')->default(0);
+            $table->integer('coupon_total')->default(0);
+            $table->string('shipping_name')->nullable();
+            $table->text('shipping_address')->nullable();
+            $table->text('shipping_address_line2')->nullable();
+            $table->string('shipping_city')->nullable();
+            $table->string('shipping_postal_code')->nullable();
+            $table->string('shipping_region')->nullable();
+            $table->string('shipping_country')->nullable();
+            $table->string('billing_name')->nullable();
+            $table->text('billing_address')->nullable();
+            $table->text('billing_address_line2')->nullable();
+            $table->string('billing_city')->nullable();
+            $table->string('billing_postal_code')->nullable();
+            $table->string('billing_region')->nullable();
+            $table->string('billing_country')->nullable();
+            $table->boolean('use_shipping_address_for_billing')->default(false);
+            $table->foreignId('customer_id')->nullable();
+            $table->string('coupon')->nullable();
+            $table->json('gateway')->nullable();
+            $table->json('data')->nullable();
+            $table->dateTime('paid_date')->nullable();
+
+            // Some custom stuff for testing...
+            $table->boolean('ordered_on_tuesday')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('orders');
+    }
+}


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request adds support for developers adding custom columns to the `orders`/`customers` tables. 

**For example:** a store may wish to store data about a pickup point but they probably don't want that data to live inside a JSON column (like it would currently)

This also means developers can edit these columns inside Runway which they wouldn't be able to do if the data was stored inside the `data` column.

Closes #634

## Note for existing database users

If you've already setup a database prior to this change, you'll need to install the `doctrine/dbal` dependency. You can do this by running the following command:

```
composer require doctrine/dbal
```

## To Do

* [X] Orders: Reading from custom columns
* [X] Orders: Writing back to custom columns
* [X] Orders: Write tests for both read/write
* [x] Customers: Reading from custom columns
* [x] Customers: Writing back to custom columns
* [x] Customers: Write tests for both read/write
* [x] Update documentation to mention 'custom column' functionality
