### PR TITLE
v3.2: Change name of 'value' field on coupons

### DIFF
--- a/resources/blueprints/collections/coupons/coupons.yaml
+++ b/resources/blueprints/collections/coupons/coupons.yaml
@@ -28,7 +28,7 @@ sections:
           display: Type
           validate: required
           width: 50
-      - handle: value
+      - handle: coupon_value
         field:
           input_type: text
           type: text

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -172,7 +172,7 @@ class Coupon implements Contract
     public function toAugmentedArray($keys = null)
     {
         $blueprintFields = $this->resource()->blueprint()->fields()->items()->reject(function ($field) {
-            return isset($field['import']) || $field['handle'] === 'value';
+            return isset($field['import']) || $field['handle'] === 'value'; // TODO 4.0: Don't need this as coupon_value is 'the way' now
         })->pluck('handle')->toArray();
 
         $augmentedData = $this->resource()->toAugmentedArray($blueprintFields);

--- a/src/Coupons/EntryCouponRepository.php
+++ b/src/Coupons/EntryCouponRepository.php
@@ -36,10 +36,10 @@ class EntryCouponRepository implements RepositoryContract
             ->resource($entry)
             ->id($entry->id())
             ->code($entry->slug())
-            ->value($entry->get('value'))
+            ->value($entry->get('coupon_value') ?? $entry->get('value')) // TODO 4.0: Only coupon_value should be supported
             ->type($entry->get('type'))
             ->data(array_merge(
-                $entry->data()->except(['value', 'type'])->toArray(),
+                $entry->data()->except(['coupon_value', 'value', 'type'])->toArray(),
                 [
                     'site' => optional($entry->site())->handle(),
                     'slug' => $entry->slug(),
@@ -91,7 +91,7 @@ class EntryCouponRepository implements RepositoryContract
             array_merge(
                 Arr::except($coupon->data()->toArray(), ['id', 'site', 'slug', 'published']),
                 [
-                    'value' => $coupon->value(),
+                    'coupon_value' => $coupon->value(),
                     'type' => $coupon->type(),
                 ]
             )
@@ -101,7 +101,7 @@ class EntryCouponRepository implements RepositoryContract
 
         $coupon->id = $entry->id();
         $coupon->code = $entry->slug();
-        $coupon->value = $entry->get('value');
+        $coupon->value = $entry->get('coupon_value');
         $coupon->type = $entry->get('type');
         $coupon->resource = $entry;
 

--- a/src/UpdateScripts/v3_2/RenameCouponValueField.php
+++ b/src/UpdateScripts/v3_2/RenameCouponValueField.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v3_2;
+
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Illuminate\Support\Facades\File;
+use Statamic\Contracts\Entries\Entry;
+use Statamic\Facades\Collection;
+use Statamic\Fields\Blueprint;
+use Statamic\UpdateScripts\UpdateScript;
+
+class RenameCouponValueField extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('3.2.0');
+    }
+
+    public function update()
+    {
+        if (! isset(SimpleCommerce::couponDriver()['collection'])) {
+            return;
+        }
+
+        // Rename field in blueprint
+        Collection::find(SimpleCommerce::couponDriver()['collection'])
+            ->entryBlueprints()
+            ->filter(function (Blueprint $blueprint) {
+                return $blueprint->hasField('value');
+            })
+            ->each(function (Blueprint $blueprint) {
+                $blueprintContents = File::get($blueprint->path());
+
+                $blueprintContents = str_replace('handle: value', 'handle: coupon_value', $blueprintContents);
+
+                File::put($blueprint->path(), $blueprintContents);
+            });
+
+        // Change field in coupon entries
+        Collection::find(SimpleCommerce::couponDriver()['collection'])
+            ->queryEntries()
+            ->get()
+            ->each(function (Entry $entry) {
+                $entry->set('coupon_value', $entry->get('value'));
+                $entry->set('value', null);
+
+                $entry->save();
+            });
+
+        $this->console()->info('Due to some conflicts with Statamic, Simple Commerce has renamed the `value` field to `coupon_value`.');
+    }
+}

--- a/tests/Http/Controllers/CouponControllerTest.php
+++ b/tests/Http/Controllers/CouponControllerTest.php
@@ -42,7 +42,7 @@ class CouponControllerTest extends TestCase
             ->data([
                 'title'              => 'Half Price',
                 'redeemed'           => 0,
-                'value'              => 50,
+                'coupon_value'       => 50,
                 'type'               => 'percentage',
                 'minimum_cart_value' => null,
             ]);
@@ -82,7 +82,7 @@ class CouponControllerTest extends TestCase
             ->data([
                 'title'              => 'Half Price',
                 'redeemed'           => 0,
-                'value'              => 50,
+                'coupon_value'       => 50,
                 'type'               => 'percentage',
                 'minimum_cart_value' => null,
             ]);
@@ -125,7 +125,7 @@ class CouponControllerTest extends TestCase
             ->data([
                 'title'              => 'Half Price',
                 'redeemed'           => 5,
-                'value'              => 50,
+                'coupon_value'       => 50,
                 'type'               => 'percentage',
                 'minimum_cart_value' => null,
                 'maximum_uses'       => 5, // We shouldn't be able to use because of this
@@ -188,7 +188,7 @@ class CouponControllerTest extends TestCase
             ->data([
                 'title'              => 'Half Price',
                 'redeemed'           => 0,
-                'value'              => 50,
+                'coupon_value'       => 50,
                 'type'               => 'percentage',
                 'minimum_cart_value' => null,
                 'products'           => [$this->product->id],
@@ -229,7 +229,7 @@ class CouponControllerTest extends TestCase
             ->data([
                 'title'              => 'Half Price',
                 'redeemed'           => 5,
-                'value'              => 50,
+                'coupon_value'       => 50,
                 'type'               => 'percentage',
                 'minimum_cart_value' => null,
                 'maximum_uses'       => 0,
@@ -282,7 +282,7 @@ class CouponControllerTest extends TestCase
             ->data([
                 'title'              => 'Hof Price',
                 'redeemed'           => 0,
-                'value'              => 50,
+                'coupon_value'       => 50,
                 'type'               => 'percentage',
                 'minimum_cart_value' => null,
                 'customers'          => [$customer->id],
@@ -334,7 +334,7 @@ class CouponControllerTest extends TestCase
             ->data([
                 'title'              => 'Halv Price',
                 'redeemed'           => 0,
-                'value'              => 50,
+                'coupon_value'       => 50,
                 'type'               => 'percentage',
                 'minimum_cart_value' => null,
                 'customers'          => [$customer->id],
@@ -373,7 +373,7 @@ class CouponControllerTest extends TestCase
             ->data([
                 'title'              => 'Half Price',
                 'redeemed'           => 0,
-                'value'              => 50,
+                'coupon_value'       => 50,
                 'type'               => 'percentage',
                 'minimum_cart_value' => null,
             ]);
@@ -409,7 +409,7 @@ class CouponControllerTest extends TestCase
             ->data([
                 'title'              => 'Half Price',
                 'redeemed'           => 0,
-                'value'              => 50,
+                'coupon_value'       => 50,
                 'type'               => 'percentage',
                 'minimum_cart_value' => null,
             ]);


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request changes the name of the 'value' field on coupons. Instead of the field being `value`, it's now `coupon_value`.

This is due to Statamic having issues if you have a field with the handle, `value` (statamic/cms#2495).

Related: #559

## To Do

* [x] Renamed the field
* [x] Updated the tests
* [x] Added to default blueprint (needs to be done in the starter kit too)
* [x] Created an upgrade script