### PR TITLE
v3.2: Make it easier to update/remove cart items, based on product

### DIFF
--- a/docs/tags/cart.md
+++ b/docs/tags/cart.md
@@ -94,12 +94,28 @@ The tag itself requires an `item` parameter which should be the ID of the specfi
 {{ /sc:cart:updateItem }}
 ```
 
+Alternatively, if you don't have easy access to the ID of the cart item, you can pass in the product ID instead:
+
+```antlers
+{{ sc:cart:updateItem :product="id" }}
+  <input type="number" name="quantity" value="2">
+{{ /sc:cart:updateItem }}
+```
+
 ## Remove Cart Item
 
 This tag allows you to remove an item from the cart. It's a [form tag](/tags#form-tags) and the only required parameter is on the tag itself: the `item` parameter should be the ID or the specific cart item you wish to remove from the cart.
 
 ```antlers
 {{ sc:cart:removeItem :item="id" }}
+  <button type="submit">Remove item from cart</button>
+{{ /sc:cart:removeItem }}
+```
+
+Alternatively, if you don't have easy access to the ID of the cart item, you can pass in the product ID instead:
+
+```antlers
+{{ sc:cart:removeItem :product="id" }}
   <button type="submit">Remove item from cart</button>
 {{ /sc:cart:removeItem }}
 ```

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -156,22 +156,50 @@ class CartTags extends SubTag
 
     public function updateItem()
     {
+        $lineItemId = $this->params->get('item');
+
+        if ($product = $this->params->get('product')) {
+            $lineItemId = collect($this->getCart()->lineItems()->map->toArray())
+                ->where('product', $product)
+                ->when($this->params->get('variant'), function ($query, $variant) {
+                    $query->where('variant', $variant);
+                })
+                ->pluck('id')
+                ->first();
+        }
+
+        $lineItem = $this->getCart()->lineItem($lineItemId);
+
         return $this->createForm(
             route('statamic.simple-commerce.cart-items.update', [
-                'item' => $this->params->get('item'),
+                'item' => $lineItemId,
             ]),
-            [],
+            optional($lineItem)->toArray() ?? [],
             'POST'
         );
     }
 
     public function removeItem()
     {
+        $lineItemId = $this->params->get('item');
+
+        if ($product = $this->params->get('product')) {
+            $lineItemId = collect($this->getCart()->lineItems()->map->toArray())
+                ->where('product', $product)
+                ->when($this->params->get('variant'), function ($query, $variant) {
+                    $query->where('variant', $variant);
+                })
+                ->pluck('id')
+                ->first();
+        }
+
+        $lineItem = $this->getCart()->lineItem($lineItemId);
+
         return $this->createForm(
             route('statamic.simple-commerce.cart-items.destroy', [
-                'item' => $this->params->get('item'),
+                'item' => $lineItemId,
             ]),
-            [],
+            optional($lineItem)->toArray() ?? [],
             'DELETE'
         );
     }


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request solves a little pain point. 

Before now, if you wanted to update an existing line item (to change the quantity for example), you would have had to _somehow_ get the ID of the line item you wanted to update. Maybe you would have had to loop through all the line items, check the product ID and a bunch of other malarkey. 

Now, you can just provide the ID of the product in the cart you want to update and Simple Commerce will figure out the rest.

```antlers
{{ sc:cart:updateItem :product="id" }}
  <input type="number" name="quantity" value="2">
{{ /sc:cart:updateItem }}
```

If you need to, you may also provide an additional `variant` parameter to scope down the items.

Related: #501

## To Do

* [x] Added support on the `{{ sc:cart:updateItem }}` tag
* [x] Added support on the `{{ sc:cart:removeItem }}` tag
* [x] Added tests to cover both tags
* [x] Updated the documentation to mention the new parameter