### PR TITLE
Prevent debugbar from creating orders

### DIFF
--- a/src/DebugbarDataCollector.php
+++ b/src/DebugbarDataCollector.php
@@ -11,6 +11,12 @@ class DebugbarDataCollector extends \DebugBar\DataCollector\DataCollector implem
 
     public function collect()
     {
+        if (! $this->hasCart()) {
+            return [
+                'Cart ID' => 'No cart found.',
+            ];
+        }
+
         $cart = $this->getCart();
 
         return [


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request fixes an issue where Debugbar would create an empty cart for the user when they load a page.