### PR TITLE
Support underscore wildcard params in Cart tag

### DIFF
--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -250,6 +250,7 @@ class CartTags extends SubTag
         }
 
         $camelCaseMethod = Str::camel($method);
+
         if ($camelCaseMethod != $method && method_exists($this, $camelCaseMethod)) {
             return $this->{$camelCaseMethod}();
         }

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -247,7 +247,7 @@ class CartTags extends SubTag
         if (method_exists($this, $method)) {
             return $this->{$method}();
         }
-        
+
         $camelCaseMethod = Str::camel($method);
         if ($camelCaseMethod != $method && method_exists($this, $camelCaseMethod)) {
             return $this->{$camelCaseMethod}();

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Tags;
 
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use Illuminate\Support\Str;
 
 class CartTags extends SubTag
 {

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -247,6 +247,11 @@ class CartTags extends SubTag
         if (method_exists($this, $method)) {
             return $this->{$method}();
         }
+        
+        $camelCaseMethod = Str::camel($method);
+        if ($camelCaseMethod != $method && method_exists($this, $camelCaseMethod)) {
+            return $this->{$camelCaseMethod}();
+        }
 
         if (property_exists($cart, $method)) {
             return $cart->{$method};

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -609,6 +609,29 @@ class CartTagTest extends TestCase
         $this->assertSame($usage instanceof \Statamic\Fields\Value ? $usage->value() : $usage, 'Deliver by front door.');
     }
 
+    /**
+     * @test
+     * https://github.com/doublethreedigital/simple-commerce/pull/650
+     */
+    public function can_get_data_from_cart_when_method_should_be_converted_to_studly_case()
+    {
+        $cart = Order::make()->merge([
+            'title' => '#0001',
+            'note'  => 'Deliver by front door.',
+        ])->grandTotal(1590);
+
+        $cart->save();
+
+        $this->session(['simple-commerce-cart' => $cart->id]);
+        $this->tag->setParameters([]);
+
+        $usage = $this->tag->wildcard('raw_grand_total');
+
+        // Statamic 3.3: From 3.3, this will return a Value instance
+        $this->assertTrue($usage instanceof \Statamic\Fields\Value || is_int($usage));
+        $this->assertSame($usage instanceof \Statamic\Fields\Value ? $usage->value() : $usage, 1590);
+    }
+
     /** @test */
     public function cant_get_data_from_cart_if_there_is_no_cart()
     {


### PR DESCRIPTION
The documentation says you can access the raw grand total with `{{ sc:cart:raw_grand_total }}`, however this returns null (the wildcard method conditions don’t pick it up).

This revision makes the camel case version of the param, and if different from the provided method (and exists), tries to call it.

So ‘raw_grand_total’ converts to ‘rawGrandTotal’ for which there is a method that can be called.

You can then get the grand total with either:
- `{{ sc:cart:raw_grand_total }}` (as per the docs), or
- `{{ sc:cart:rawGrandTotal }}`

Wasn't sure if a PR to adjust the Tag was the best thing, or if the documentation needed updating. By changing the tag, then the documentation remains correct (with the underscores), and the SC Starter Kit too remains correct (with camel case).