### PR TITLE
Fix incorrect coupon calculations

### DIFF
--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -51,11 +51,7 @@ class Coupon implements Contract
         return $this
             ->fluentlyGetOrSet('value')
             ->setter(function ($value) {
-                if (is_string($value)) {
-                    if (! str_contains($value, '.')) {
-                        $value = $value * 100;
-                    }
-
+                if (is_string($value) && str_contains($value, '.')) {
                     return (int) str_replace('.', '', $value);
                 }
 

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -39,6 +39,13 @@ class Coupon implements Contract
             ->args(func_get_args());
     }
 
+    public function type($type = null)
+    {
+        return $this
+            ->fluentlyGetOrSet('type')
+            ->args(func_get_args());
+    }
+
     public function value($value = null)
     {
         return $this
@@ -54,13 +61,6 @@ class Coupon implements Contract
 
                 return $value;
             })
-            ->args(func_get_args());
-    }
-
-    public function type($type = null)
-    {
-        return $this
-            ->fluentlyGetOrSet('type')
             ->args(func_get_args());
     }
 

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -43,6 +43,17 @@ class Coupon implements Contract
     {
         return $this
             ->fluentlyGetOrSet('value')
+            ->setter(function ($value) {
+                if (is_string($value)) {
+                    if (! str_contains($value, '.')) {
+                        $value = $value * 100;
+                    }
+
+                    return (int) str_replace('.', '', $value);
+                }
+
+                return $value;
+            })
             ->args(func_get_args());
     }
 

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -52,7 +52,11 @@ class Coupon implements Contract
             ->fluentlyGetOrSet('value')
             ->setter(function ($value) {
                 if (is_string($value) && str_contains($value, '.')) {
-                    return (int) str_replace('.', '', $value);
+                    $value = (int) str_replace('.', '', $value);
+                }
+
+                if ($this->type === 'percentage' && $value > 100) {
+                    $value = $value / 100;
                 }
 
                 return $value;

--- a/src/Coupons/EntryCouponRepository.php
+++ b/src/Coupons/EntryCouponRepository.php
@@ -36,8 +36,8 @@ class EntryCouponRepository implements RepositoryContract
             ->resource($entry)
             ->id($entry->id())
             ->code($entry->slug())
-            ->value($entry->get('coupon_value') ?? $entry->get('value')) // TODO 4.0: Only coupon_value should be supported
             ->type($entry->get('type'))
+            ->value($entry->get('coupon_value') ?? $entry->get('value')) // TODO 4.0: Only coupon_value should be supported
             ->data(array_merge(
                 $entry->data()->except(['coupon_value', 'value', 'type'])->toArray(),
                 [
@@ -91,8 +91,8 @@ class EntryCouponRepository implements RepositoryContract
             array_merge(
                 Arr::except($coupon->data()->toArray(), ['id', 'site', 'slug', 'published']),
                 [
-                    'coupon_value' => $coupon->value(),
                     'type' => $coupon->type(),
+                    'coupon_value' => $coupon->value(),
                 ]
             )
         );
@@ -101,8 +101,8 @@ class EntryCouponRepository implements RepositoryContract
 
         $coupon->id = $entry->id();
         $coupon->code = $entry->slug();
-        $coupon->value = $entry->get('coupon_value');
         $coupon->type = $entry->get('type');
+        $coupon->value = $entry->get('coupon_value');
         $coupon->resource = $entry;
 
         $coupon->merge([

--- a/tests/Orders/CalculatorTest.php
+++ b/tests/Orders/CalculatorTest.php
@@ -366,6 +366,53 @@ class CalculatorTest extends TestCase
         $this->assertSame($calculate['items'][0]['total'], 10000);
     }
 
+    /**
+     * @test
+     * https://github.com/doublethreedigital/simple-commerce/issues/651
+     */
+    public function ensure_percentage_coupon_is_calculated_correctly_on_items_total_when_value_is_a_decimal_number()
+    {
+        Config::set('simple-commerce.tax_engine_config.rate', 0);
+        Config::set('simple-commerce.sites.default.shipping.methods', []);
+
+        $product = Product::make()->price(5000);
+        $product->save();
+
+        $coupon = Coupon::make()
+            ->code('fifty-friday')
+            ->value('10.00')
+            ->type('percentage')
+            ->data([
+                'title'              => 'Fifty Friday',
+                'redeemed'           => 0,
+                'minimum_cart_value' => null,
+            ]);
+
+        $coupon->save();
+
+        $cart = Order::make()->isPaid(false)->lineItems([
+            [
+                'product'  => $product->id,
+                'quantity' => 2,
+                'total'    => 10000,
+            ],
+        ])->coupon($coupon->id);
+
+        $cart->save();
+
+        $calculate = (new Calculator())->calculate($cart);
+
+        $this->assertIsArray($calculate);
+
+        $this->assertSame($calculate['grand_total'], 9000);
+        $this->assertSame($calculate['items_total'], 10000);
+        $this->assertSame($calculate['shipping_total'], 0);
+        $this->assertSame($calculate['tax_total'], 0);
+        $this->assertSame($calculate['coupon_total'], 1000);
+
+        $this->assertSame($calculate['items'][0]['total'], 10000);
+    }
+
     /** @test */
     public function ensure_fixed_coupon_is_calculated_correctly_on_items_total()
     {

--- a/tests/Orders/CalculatorTest.php
+++ b/tests/Orders/CalculatorTest.php
@@ -410,6 +410,55 @@ class CalculatorTest extends TestCase
         $this->assertSame($calculate['items'][0]['total'], 10000);
     }
 
+    /**
+     * @test
+     * https://github.com/doublethreedigital/simple-commerce/issues/651
+     */
+    public function ensure_fixed_coupon_is_calculated_correctly_on_items_total_when_value_is_a_decimal_number()
+    {
+        Config::set('simple-commerce.tax_engine_config.rate', 0);
+        Config::set('simple-commerce.sites.default.shipping.methods', []);
+
+        $product = Product::make()->price(5000);
+        $product->save();
+
+        $coupon = Coupon::make()
+            ->code('one-hundred-pence-off')
+            ->value('10.00')
+            ->type('fixed')
+            ->data([
+                'title'              => 'One Hundred Pence Off (£1)',
+                'redeemed'           => 0,
+                'minimum_cart_value' => null,
+            ]);
+
+        $coupon->save();
+
+        $cart = Order::make()->isPaid(false)->lineItems([
+            [
+                'product'  => $product->id,
+                'quantity' => 2,
+                'total'    => 10000,
+            ],
+        ])->coupon($coupon->id);
+
+        $cart->save();
+
+        $calculate = (new Calculator())->calculate($cart);
+
+        $this->assertIsArray($calculate);
+
+        $this->assertSame($calculate['grand_total'], 9000);
+        $this->assertSame($calculate['items_total'], 10000);
+        $this->assertSame($calculate['shipping_total'], 0);
+        $this->assertSame($calculate['tax_total'], 0);
+        $this->assertSame($calculate['coupon_total'], 1000);
+
+        $this->assertSame($calculate['items'][0]['total'], 10000);
+
+        $this->assertSame($coupon->value(), 1000);
+    }
+
     /** @test */
     public function ensure_tax_is_included_when_using_coupon()
     {


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request fixes two issues with coupon calculation that were mentioned in #651. Both were issues when you entered a decimal number as the coupon value.

This PR contains both the fix and tests to cover both cases.

Fixes #651.