### PR TITLE
Fixed rounding from causing issues with coupon total calculations

### DIFF
--- a/src/Orders/Calculator.php
+++ b/src/Orders/Calculator.php
@@ -69,6 +69,7 @@ class Calculator implements Contract
         $data = $this->calculateOrderShipping($data)['data'];
 
         $data['grand_total'] = (($data['items_total'] + $data['tax_total']) - $data['coupon_total']) + $data['shipping_total'];
+        $data['grand_total'] = (int) round($data['grand_total']);
 
         return $data;
     }
@@ -178,6 +179,8 @@ class Calculator implements Contract
             if ($coupon->type() === 'fixed') {
                 $data['coupon_total'] = (int) $baseAmount - ($baseAmount - $value);
             }
+
+            $data['coupon_total'] = (int) round($data['coupon_total']);
         }
 
         return [


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request fixes an issue where rounding issues would cause the coupon total & grand total of an order to multiply. This screenshot looks much better - how it should be:

<img width="243" alt="image" src="https://user-images.githubusercontent.com/19637309/173923659-396d131a-d672-488d-a422-4e92b8ef5505.png">

Fixes #651

### How to reproduce

* Product: £24.99
* Coupon: 10%