### PR TITLE
Ensure additional customer information is being saved

### DIFF
--- a/src/Http/Controllers/CartController.php
+++ b/src/Http/Controllers/CartController.php
@@ -72,7 +72,9 @@ class CartController extends BaseActionController
             }
 
             if (is_array($data['customer'])) {
-                $customer->merge($data['customer'])->save();
+                $customer
+                    ->merge(Arr::only($data['customer'], config('simple-commerce.field_whitelist.customers')))
+                    ->save();
             }
 
             $cart->customer($customer->id());

--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -73,7 +73,7 @@ class CartItemController extends BaseActionController
                 if (isset($customer) && Arr::except($request->get('customer'), ['email', 'name', 'first_name', 'last_name']) !== []) {
                     $customer
                         ->merge(
-                            Arr::except($request->get('customer'), ['email', 'name', 'first_name', 'last_name'])
+                            Arr::only($request->get('customer'), config('simple-commerce.field_whitelist.customers'))
                         )
                         ->save();
                 }

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -167,7 +167,11 @@ class CheckoutController extends BaseActionController
                 $customer->save();
             }
 
-            $customer->merge($customerData)->save();
+            $customer
+                ->merge(
+                    Arr::only($customerData, config('simple-commerce.field_whitelist.customers'))
+                )
+                ->save();
 
             $this->cart->customer($customer->id());
             $this->cart->save();

--- a/tests/Http/Controllers/CartControllerTest.php
+++ b/tests/Http/Controllers/CartControllerTest.php
@@ -198,6 +198,48 @@ class CartControllerTest extends TestCase
         $this->assertSame($cart->customer()->id(), $customer->id);
     }
 
+    /**
+     * @test
+     * https://github.com/doublethreedigital/simple-commerce/issues/658
+     */
+    public function can_update_cart_with_customer_already_in_cart_with_additional_data()
+    {
+        Config::set('simple-commerce.field_whitelist.orders', ['shipping_note']);
+
+        Config::set('simple-commerce.field_whitelist.customers', [
+            'name', 'email', 'dob',
+        ]);
+
+        $customer = Customer::make()
+            ->email('dan.smith@example.com')
+            ->data([
+                'name'  => 'Dan Smith',
+            ]);
+
+        $customer->save();
+
+        $cart = Order::make()->customer($customer->id);
+        $cart->save();
+
+        $data = [
+            'customer' => [
+                'dob' => '1st January 1980',
+            ],
+        ];
+
+        $response = $this
+            ->from('/cart')
+            ->withSession(['simple-commerce-cart' => $cart->id])
+            ->post(route('statamic.simple-commerce.cart.update'), $data);
+
+        $response->assertRedirect('/cart');
+
+        $cart = $cart->fresh();
+
+        $this->assertSame($cart->customer()->id(), $customer->id);
+        $this->assertSame($cart->customer()->get('dob'), '1st January 1980');
+    }
+
     /** @test */
     public function can_update_cart_and_create_new_customer()
     {
@@ -349,6 +391,46 @@ class CartControllerTest extends TestCase
     }
 
     /** @test */
+    public function can_update_cart_and_existing_customer_by_email_with_additional_data()
+    {
+        Config::set('simple-commerce.field_whitelist.customers', [
+            'name', 'email', 'dob',
+        ]);
+
+        $customer = Customer::make()->email('jack.simpson@example.com')->data([
+             'name'  => 'Jak Simpson',
+        ]);
+
+        $customer->save();
+
+        $cart = Order::make();
+        $cart->save();
+
+        $data = [
+             'customer' => [
+                 'name'  => 'Jack Simpson',
+                 'email' => 'jack.simpson@example.com',
+                 'dob' => '1st January 1980',
+             ],
+         ];
+
+        $response = $this
+             ->from('/cart')
+             ->withSession(['simple-commerce-cart' => $cart->id])
+             ->post(route('statamic.simple-commerce.cart.update'), $data);
+
+        $response->assertRedirect('/cart');
+
+        $cart = $cart->fresh();
+
+        $customer = Customer::findByEmail('jack.simpson@example.com');
+
+        $this->assertSame($cart->customer()->id(), $customer->id);
+        $this->assertSame($customer->get('name'), 'Jack Simpson');
+        $this->assertSame($cart->customer()->get('dob'), '1st January 1980');
+    }
+
+    /** @test */
     public function can_update_cart_and_create_new_customer_via_customer_array()
     {
         $cart = Order::make();
@@ -403,6 +485,40 @@ class CartControllerTest extends TestCase
         $this->assertSame($cart->customer()->id, $customer->id);
         $this->assertSame($customer->name(), 'Rebecca Logan');
         $this->assertSame($customer->email(), 'rebecca.logan@example.com');
+    }
+
+    /** @test */
+    public function can_update_cart_and_create_new_customer_via_customer_array_with_additional_data()
+    {
+        Config::set('simple-commerce.field_whitelist.customers', [
+            'name', 'email', 'dob',
+        ]);
+
+        $cart = Order::make();
+        $cart->save();
+
+        $data = [
+            'customer' => [
+                'name'  => 'Rebecca Logan',
+                'email' => 'rebecca.logan@example.com',
+                'dob' => '1st January 1980',
+            ],
+        ];
+
+        $response = $this
+            ->from('/cart')
+            ->withSession(['simple-commerce-cart' => $cart->id])
+            ->post(route('statamic.simple-commerce.cart.update'), $data);
+
+        $response->assertRedirect('/cart');
+
+        $cart = $cart->fresh();
+        $customer = Customer::findByEmail('rebecca.logan@example.com');
+
+        $this->assertSame($cart->customer()->id, $customer->id);
+        $this->assertSame($customer->name(), 'Rebecca Logan');
+        $this->assertSame($customer->email(), 'rebecca.logan@example.com');
+        $this->assertSame($cart->customer()->get('dob'), '1st January 1980');
     }
 
     /** @test */

--- a/tests/Http/Controllers/CartControllerTest.php
+++ b/tests/Http/Controllers/CartControllerTest.php
@@ -461,6 +461,10 @@ class CartControllerTest extends TestCase
     /** @test */
     public function can_update_cart_and_create_new_customer_via_customer_array_with_first_name_and_last_name()
     {
+        Config::set('simple-commerce.field_whitelist.customers', [
+            'first_name', 'last_name',
+        ]);
+
         $cart = Order::make();
         $cart->save();
 

--- a/tests/Http/Controllers/CartControllerTest.php
+++ b/tests/Http/Controllers/CartControllerTest.php
@@ -398,7 +398,7 @@ class CartControllerTest extends TestCase
         ]);
 
         $customer = Customer::make()->email('jack.simpson@example.com')->data([
-             'name'  => 'Jak Simpson',
+            'name'  => 'Jak Simpson',
         ]);
 
         $customer->save();
@@ -407,12 +407,12 @@ class CartControllerTest extends TestCase
         $cart->save();
 
         $data = [
-             'customer' => [
-                 'name'  => 'Jack Simpson',
-                 'email' => 'jack.simpson@example.com',
-                 'dob' => '1st January 1980',
-             ],
-         ];
+            'customer' => [
+                'name'  => 'Jack Simpson',
+                'email' => 'jack.simpson@example.com',
+                'dob' => '1st January 1980',
+            ],
+        ];
 
         $response = $this
              ->from('/cart')

--- a/tests/Http/Controllers/CartItemControllerTest.php
+++ b/tests/Http/Controllers/CartItemControllerTest.php
@@ -913,6 +913,10 @@ class CartItemControllerTest extends TestCase
      */
     public function can_store_item_with_customer_array_and_additional_customer_information()
     {
+        Config::set('simple-commerce.field_whitelist.customers', [
+            'name', 'email', 'dob',
+        ]);
+
         $product = Product::make()
              ->price(1000)
              ->data([

--- a/tests/Http/Controllers/CartItemControllerTest.php
+++ b/tests/Http/Controllers/CartItemControllerTest.php
@@ -831,13 +831,13 @@ class CartItemControllerTest extends TestCase
         $product->save();
 
         $data = [
-             'product'  => $product->id,
-             'quantity' => 1,
-             'customer' => [
+            'product'  => $product->id,
+            'quantity' => 1,
+            'customer' => [
                 'name' => 'James',
                 'email' => 'james@example.com',
-             ],
-         ];
+            ],
+        ];
 
         $response = $this
              ->from('/products/' . $product->get('slug'))
@@ -880,12 +880,12 @@ class CartItemControllerTest extends TestCase
         $customer->save();
 
         $data = [
-             'product'  => $product->id,
-             'quantity' => 1,
-             'customer' => [
+            'product'  => $product->id,
+            'quantity' => 1,
+            'customer' => [
                 'email' => 'pluto@clubhouse.disney',
-             ],
-         ];
+            ],
+        ];
 
         $response = $this
              ->from('/products/' . $product->get('slug'))
@@ -923,14 +923,14 @@ class CartItemControllerTest extends TestCase
         $product->save();
 
         $data = [
-             'product'  => $product->id,
-             'quantity' => 1,
-             'customer' => [
+            'product'  => $product->id,
+            'quantity' => 1,
+            'customer' => [
                 'name' => 'James',
                 'email' => 'james@example.com',
                 'dob' => '01/01/2000',
-             ],
-         ];
+            ],
+        ];
 
         $response = $this
              ->from('/products/' . $product->get('slug'))
@@ -981,13 +981,13 @@ class CartItemControllerTest extends TestCase
         $customer->save();
 
         $data = [
-             'product'  => $product->id,
-             'quantity' => 1,
-             'customer' => [
+            'product'  => $product->id,
+            'quantity' => 1,
+            'customer' => [
                 'email' => 'pluto@clubhouse.disney',
                 'dob' => '01/01/2000',
-             ],
-         ];
+            ],
+        ];
 
         $response = $this
              ->from('/products/' . $product->get('slug'))

--- a/tests/Http/Controllers/CheckoutControllerTest.php
+++ b/tests/Http/Controllers/CheckoutControllerTest.php
@@ -764,13 +764,13 @@ class CheckoutControllerTest extends TestCase
         $product->save();
 
         $order = Order::make()->lineItems([
-             [
-                 'id'       => Stache::generateId(),
-                 'product'  => $product->id,
-                 'quantity' => 1,
-                 'total'    => 5000,
-             ],
-         ])->grandTotal(5000);
+            [
+                'id'       => Stache::generateId(),
+                'product'  => $product->id,
+                'quantity' => 1,
+                'total'    => 5000,
+            ],
+        ])->grandTotal(5000);
 
         $order->save();
 
@@ -809,8 +809,8 @@ class CheckoutControllerTest extends TestCase
         $this->assertSame($order->customer()->get('dob'), '01/01/2000');
 
         $this->assertSame($order->customer()->orders()->pluck('id')->unique()->toArray(), [
-             $order->id,
-         ]);
+            $order->id,
+        ]);
 
         // Finally, assert order is no longer attached to the users' session
         $this->assertFalse(session()->has('simple-commerce-cart'));
@@ -837,13 +837,13 @@ class CheckoutControllerTest extends TestCase
         $product->save();
 
         $order = Order::make()->lineItems([
-             [
-                 'id'       => Stache::generateId(),
-                 'product'  => $product->id,
-                 'quantity' => 1,
-                 'total'    => 5000,
-             ],
-         ])->grandTotal(5000);
+            [
+                'id'       => Stache::generateId(),
+                'product'  => $product->id,
+                'quantity' => 1,
+                'total'    => 5000,
+            ],
+        ])->grandTotal(5000);
 
         $order->save();
 
@@ -891,8 +891,8 @@ class CheckoutControllerTest extends TestCase
         $this->assertSame($order->customer()->get('dob'), '01/01/2000');
 
         $this->assertSame($order->customer()->orders()->pluck('id')->unique()->toArray(), [
-             $order->id,
-         ]);
+            $order->id,
+        ]);
 
         // Finally, assert order is no longer attached to the users' session
         $this->assertFalse(session()->has('simple-commerce-cart'));

--- a/tests/Http/Controllers/CheckoutControllerTest.php
+++ b/tests/Http/Controllers/CheckoutControllerTest.php
@@ -743,7 +743,10 @@ class CheckoutControllerTest extends TestCase
         $this->assertFalse(session()->has('simple-commerce-cart'));
     }
 
-    /** @test */
+    /**
+     * @test
+     * https://github.com/doublethreedigital/simple-commerce/issues/658
+     */
     public function can_post_checkout_with_customer_array_with_additional_information()
     {
         Config::set('simple-commerce.field_whitelist.customers', [
@@ -813,9 +816,16 @@ class CheckoutControllerTest extends TestCase
         $this->assertFalse(session()->has('simple-commerce-cart'));
     }
 
-    /** @test */
+    /**
+     * @test
+     * https://github.com/doublethreedigital/simple-commerce/issues/658
+     */
     public function can_post_checkout_with_customer_array_and_existing_customer_with_additional_information()
     {
+        Config::set('simple-commerce.field_whitelist.customers', [
+            'name', 'email', 'dob',
+        ]);
+
         Event::fake();
 
         $product = Product::make()

--- a/tests/Http/Controllers/CheckoutControllerTest.php
+++ b/tests/Http/Controllers/CheckoutControllerTest.php
@@ -607,6 +607,288 @@ class CheckoutControllerTest extends TestCase
     }
 
     /** @test */
+    public function can_post_checkout_with_customer_array()
+    {
+        Event::fake();
+
+        $product = Product::make()
+            ->price(5000)
+            ->data([
+                'title' => 'Bacon',
+            ]);
+
+        $product->save();
+
+        $order = Order::make()->lineItems([
+            [
+                'id'       => Stache::generateId(),
+                'product'  => $product->id,
+                'quantity' => 1,
+                'total'    => 5000,
+            ],
+        ])->grandTotal(5000);
+
+        $order->save();
+
+        $this
+            ->withSession(['simple-commerce-cart' => $order->id])
+            ->post(route('statamic.simple-commerce.checkout.store'), [
+                'customer'     => [
+                    'name' => 'Joe Doe',
+                    'email' => 'joe.doe@example.com',
+                ],
+                'gateway'      => DummyGateway::class,
+                'card_number'  => '4242424242424242',
+                'expiry_month' => '01',
+                'expiry_year'  => '2025',
+                'cvc'          => '123',
+            ]);
+
+        $order = $order->fresh();
+
+        // Assert events have been dispatched
+        Event::assertDispatched(PreCheckout::class);
+        Event::assertDispatched(PostCheckout::class);
+
+        // Assert order has been marked as paid
+        $this->assertTrue($order->get('published'));
+
+        $this->assertTrue($order->isPaid());
+        $this->assertNotNull($order->get('paid_date'));
+
+        // Assert customer has been created with provided details
+        $this->assertNotNull($order->customer());
+
+        $this->assertSame($order->customer()->name(), 'Joe Doe');
+        $this->assertSame($order->customer()->email(), 'joe.doe@example.com');
+
+        $this->assertSame($order->customer()->orders()->pluck('id')->unique()->toArray(), [
+            $order->id,
+        ]);
+
+        // Finally, assert order is no longer attached to the users' session
+        $this->assertFalse(session()->has('simple-commerce-cart'));
+    }
+
+    /** @test */
+    public function can_post_checkout_with_customer_array_and_existing_customer()
+    {
+        Event::fake();
+
+        $product = Product::make()
+            ->price(5000)
+            ->data([
+                'title' => 'Bacon',
+            ]);
+
+        $product->save();
+
+        $order = Order::make()->lineItems([
+            [
+                'id'       => Stache::generateId(),
+                'product'  => $product->id,
+                'quantity' => 1,
+                'total'    => 5000,
+            ],
+        ])->grandTotal(5000);
+
+        $order->save();
+
+        $customer = Customer::make()
+            ->email('joe.doe@example.com')
+            ->data([
+                'name' => 'Joe Doe',
+            ]);
+
+        $customer->save();
+
+        $this
+            ->withSession(['simple-commerce-cart' => $order->id])
+            ->post(route('statamic.simple-commerce.checkout.store'), [
+                'customer'     => [
+                    'name' => 'Joe Doe',
+                    'email' => 'joe.doe@example.com',
+                ],
+                'gateway'      => DummyGateway::class,
+                'card_number'  => '4242424242424242',
+                'expiry_month' => '01',
+                'expiry_year'  => '2025',
+                'cvc'          => '123',
+            ]);
+
+        $order = $order->fresh();
+
+        // Assert events have been dispatched
+        Event::assertDispatched(PreCheckout::class);
+        Event::assertDispatched(PostCheckout::class);
+
+        // Assert order has been marked as paid
+        $this->assertTrue($order->get('published'));
+
+        $this->assertTrue($order->isPaid());
+        $this->assertNotNull($order->get('paid_date'));
+
+        // Assert customer has been created with provided details
+        $this->assertNotNull($order->customer());
+
+        $this->assertSame($order->customer()->id(), $customer->id);
+        $this->assertSame($order->customer()->name(), 'Joe Doe');
+        $this->assertSame($order->customer()->email(), 'joe.doe@example.com');
+
+        $this->assertSame($order->customer()->orders()->pluck('id')->unique()->toArray(), [
+            $order->id,
+        ]);
+
+        // Finally, assert order is no longer attached to the users' session
+        $this->assertFalse(session()->has('simple-commerce-cart'));
+    }
+
+    /** @test */
+    public function can_post_checkout_with_customer_array_with_additional_information()
+    {
+        Config::set('simple-commerce.field_whitelist.customers', [
+            'name', 'email', 'dob',
+        ]);
+
+        Event::fake();
+
+        $product = Product::make()
+             ->price(5000)
+             ->data([
+                 'title' => 'Bacon',
+             ]);
+
+        $product->save();
+
+        $order = Order::make()->lineItems([
+             [
+                 'id'       => Stache::generateId(),
+                 'product'  => $product->id,
+                 'quantity' => 1,
+                 'total'    => 5000,
+             ],
+         ])->grandTotal(5000);
+
+        $order->save();
+
+        $this
+             ->withSession(['simple-commerce-cart' => $order->id])
+             ->post(route('statamic.simple-commerce.checkout.store'), [
+                 'customer'     => [
+                     'name' => 'Joe Doe',
+                     'email' => 'joe.doe@example.com',
+                     'dob' => '01/01/2000',
+                 ],
+                 'gateway'      => DummyGateway::class,
+                 'card_number'  => '4242424242424242',
+                 'expiry_month' => '01',
+                 'expiry_year'  => '2025',
+                 'cvc'          => '123',
+             ]);
+
+        $order = $order->fresh();
+
+        // Assert events have been dispatched
+        Event::assertDispatched(PreCheckout::class);
+        Event::assertDispatched(PostCheckout::class);
+
+        // Assert order has been marked as paid
+        $this->assertTrue($order->get('published'));
+
+        $this->assertTrue($order->isPaid());
+        $this->assertNotNull($order->get('paid_date'));
+
+        // Assert customer has been created with provided details
+        $this->assertNotNull($order->customer());
+
+        $this->assertSame($order->customer()->name(), 'Joe Doe');
+        $this->assertSame($order->customer()->email(), 'joe.doe@example.com');
+        $this->assertSame($order->customer()->get('dob'), '01/01/2000');
+
+        $this->assertSame($order->customer()->orders()->pluck('id')->unique()->toArray(), [
+             $order->id,
+         ]);
+
+        // Finally, assert order is no longer attached to the users' session
+        $this->assertFalse(session()->has('simple-commerce-cart'));
+    }
+
+    /** @test */
+    public function can_post_checkout_with_customer_array_and_existing_customer_with_additional_information()
+    {
+        Event::fake();
+
+        $product = Product::make()
+             ->price(5000)
+             ->data([
+                 'title' => 'Bacon',
+             ]);
+
+        $product->save();
+
+        $order = Order::make()->lineItems([
+             [
+                 'id'       => Stache::generateId(),
+                 'product'  => $product->id,
+                 'quantity' => 1,
+                 'total'    => 5000,
+             ],
+         ])->grandTotal(5000);
+
+        $order->save();
+
+        $customer = Customer::make()
+             ->email('joe.doe@example.com')
+             ->data([
+                 'name' => 'Joe Doe',
+             ]);
+
+        $customer->save();
+
+        $this
+             ->withSession(['simple-commerce-cart' => $order->id])
+             ->post(route('statamic.simple-commerce.checkout.store'), [
+                 'customer'     => [
+                     'name' => 'Joe Doe',
+                     'email' => 'joe.doe@example.com',
+                     'dob' => '01/01/2000',
+                 ],
+                 'gateway'      => DummyGateway::class,
+                 'card_number'  => '4242424242424242',
+                 'expiry_month' => '01',
+                 'expiry_year'  => '2025',
+                 'cvc'          => '123',
+             ]);
+
+        $order = $order->fresh();
+
+        // Assert events have been dispatched
+        Event::assertDispatched(PreCheckout::class);
+        Event::assertDispatched(PostCheckout::class);
+
+        // Assert order has been marked as paid
+        $this->assertTrue($order->get('published'));
+
+        $this->assertTrue($order->isPaid());
+        $this->assertNotNull($order->get('paid_date'));
+
+        // Assert customer has been created with provided details
+        $this->assertNotNull($order->customer());
+
+        $this->assertSame($order->customer()->id(), $customer->id);
+        $this->assertSame($order->customer()->name(), 'Joe Doe');
+        $this->assertSame($order->customer()->email(), 'joe.doe@example.com');
+        $this->assertSame($order->customer()->get('dob'), '01/01/2000');
+
+        $this->assertSame($order->customer()->orders()->pluck('id')->unique()->toArray(), [
+             $order->id,
+         ]);
+
+        // Finally, assert order is no longer attached to the users' session
+        $this->assertFalse(session()->has('simple-commerce-cart'));
+    }
+
+    /** @test */
     public function can_post_checkout_with_coupon()
     {
         Config::set('simple-commerce.tax_engine_config.rate', 0);


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request fixes issues where additional customer information passed in via Simple Commerce forms don't end up being saved on the customer. 

As well fixing the issues, this PR adds tests to verify it is actually being done.

Fixes #658

## To Do

* [x] `{{ sc:cart:update }}` form
* [x] `{{ sc:cart:addItem }}` form
* [ ] ~~`{{ sc:cart:updateItem }}` form~~ (doesn't currently handle customer information)
* [x] `{{ sc:checkout }}` form
