### PR TITLE
Off-site gateways: Fix issue where you'd see empty order after checking out

### DIFF
--- a/src/Http/Controllers/GatewayCallbackController.php
+++ b/src/Http/Controllers/GatewayCallbackController.php
@@ -16,8 +16,11 @@ class GatewayCallbackController extends BaseActionController
 
     public function index(Request $request, $gateway)
     {
-        // $order = Order::find($request->get('_order_id'));
-        $order = $this->getCart();
+        if ($request->has('_order_id')) {
+            $order = Order::find($request->get('_order_id'));
+        } else {
+            $order = $this->getCart();
+        }
 
         $gatewayName = $gateway;
 


### PR DESCRIPTION
This pull request fixes an issue when using an off-site gateway, after being redirected back from the checkout, you'd go to the 'checkout complete' page but all the order information would be blank.

Instead of the order that was just checked out being used, a fresh order was being used (hence the blank information).

Partially fixes #664.