### PR TITLE
Allow parsing of notification 'to' value

### DIFF
--- a/src/Listeners/SendConfiguredNotifications.php
+++ b/src/Listeners/SendConfiguredNotifications.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionParameter;
+use Statamic\View\Antlers\Parser;
 
 class SendConfiguredNotifications implements ShouldQueue
 {
@@ -73,7 +74,12 @@ class SendConfiguredNotifications implements ShouldQueue
 
         if (is_string($config['to'])) {
             return [
-                ['channel' => 'mail', 'route' => $config['to']],
+                [
+                    'channel' => 'mail',
+                    'route' => (new Parser)
+                        ->parse($config['to'], $event->order->toAugmentedArray())
+                        ->__toString(),
+                ],
             ];
         }
 


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request implements a cool little feature which allows for using Antlers in a notifications `to` value. 

For example, you may need to send an email to a 'billing email', which is different from a customer's email. In that case, you might do something like this:

```php
// config/simple-commerce

'notifications' => [
    'order_paid' => [
        \DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderPaid::class => [
            'to' => '{{ billing_email }}',
        ],
    ],
],
```