### PR TITLE
Mollie Gateway: Fix false 'checkout complete' responses on callback

### DIFF
--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -107,6 +107,15 @@ class MollieGateway extends BaseGateway implements Gateway
         return new Response(true, []);
     }
 
+    public function callback(Request $request): bool
+    {
+        sleep(2);
+
+        $order = OrderFacade::find($request->input('_order_id'));
+
+        return $order->isPaid();
+    }
+
     public function webhook(Request $request)
     {
         $this->setupMollie();


### PR DESCRIPTION
This pull request fixes an issue where a customer would see a 'checkout complete' message even if they cancelled checking out via Mollie.

Fixes #674