### PR TITLE
After removing a line item, items array would end up with keys

### DIFF
--- a/src/Orders/HasLineItems.php
+++ b/src/Orders/HasLineItems.php
@@ -81,7 +81,7 @@ trait HasLineItems
             $lineItem->metadata($lineItemData['metadata']);
         }
 
-        $this->lineItems = $this->lineItems->push($lineItem);
+        $this->lineItems = $this->lineItems->push($lineItem)->values();
 
         $this->save();
 
@@ -126,7 +126,7 @@ trait HasLineItems
             }
 
             return $lineItem;
-        });
+        })->values();
 
         $this->save();
 
@@ -141,7 +141,7 @@ trait HasLineItems
     {
         $this->lineItems = $this->lineItems->reject(function ($item) use ($lineItemId) {
             return $item->id() === $lineItemId;
-        });
+        })->values();
 
         $this->save();
 


### PR DESCRIPTION
This pull request fixes #676.

Essentially, when a line item was removed from a cart, the line items array would contain keys like 0/2/4, when it should really just be the 'values'. 