### PR TITLE
Fixed Blade error in email views

### DIFF
--- a/resources/views/emails/backoffice_order_paid.blade.php
+++ b/resources/views/emails/backoffice_order_paid.blade.php
@@ -9,9 +9,6 @@ This email is to confirm that a new order has been placed. An overview of the or
 | Items       | Quantity         | Total |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
-@php
-$site = \Statamic\Facades\Site::current();
-@endphp
 | [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->total(), $site) }} |
 @endforeach
 | | Subtotal: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotal(), $site) }}

--- a/resources/views/emails/customer_order_paid.blade.php
+++ b/resources/views/emails/customer_order_paid.blade.php
@@ -7,9 +7,6 @@ This email is to confirm that your order (**#{{ $order->orderNumber() }}**) has 
 | Items       | Quantity         | Total |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
-@php
-$site = \Statamic\Facades\Site::current();
-@endphp
 | [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->total(), $site) }} |
 @endforeach
 | | Subtotal: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotal(), $site) }}

--- a/resources/views/emails/customer_order_shipped.blade.php
+++ b/resources/views/emails/customer_order_shipped.blade.php
@@ -8,7 +8,6 @@ This email is to confirm that your recent order (**#{{ $order->orderNumber() }}*
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
 @php
-$site = \Statamic\Facades\Site::current();
 $product = \DoubleThreeDigital\SimpleCommerce\Facades\Product::find($lineItem['product']);
 @endphp
 | [{{ $product->get('title') }}]({{ optional($product->resource())->absoluteUrl() }}) | {{ $lineItem['quantity'] }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem['total'], $site) }} |

--- a/src/Notifications/BackOfficeOrderPaid.php
+++ b/src/Notifications/BackOfficeOrderPaid.php
@@ -6,6 +6,7 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use Statamic\Facades\Site;
 
 class BackOfficeOrderPaid extends Notification
 {
@@ -48,6 +49,7 @@ class BackOfficeOrderPaid extends Notification
             ->subject(config('app.name') . ': New Order')
             ->markdown('simple-commerce::emails.backoffice_order_paid', [
                 'order' => $this->order,
+                'site' => Site::current(),
             ]);
     }
 }

--- a/src/Notifications/CustomerOrderPaid.php
+++ b/src/Notifications/CustomerOrderPaid.php
@@ -6,6 +6,7 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use Statamic\Facades\Site;
 
 class CustomerOrderPaid extends Notification
 {
@@ -48,6 +49,7 @@ class CustomerOrderPaid extends Notification
             ->subject(config('app.name') . ': Order Confirmation')
             ->markdown('simple-commerce::emails.customer_order_paid', [
                 'order' => $this->order,
+                'site' => Site::current(),
             ]);
     }
 }

--- a/src/Notifications/CustomerOrderShipped.php
+++ b/src/Notifications/CustomerOrderShipped.php
@@ -6,6 +6,7 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use Statamic\Facades\Site;
 
 class CustomerOrderShipped extends Notification
 {
@@ -48,6 +49,7 @@ class CustomerOrderShipped extends Notification
             ->subject(config('app.name') . ': Order Confirmation')
             ->markdown('simple-commerce::emails.customer_order_shipped', [
                 'order' => $this->order,
+                'site' => Site::current(),
             ]);
     }
 }


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 
  Maybe include a short demo video to go along with it? (https://www.loom.com/)
-->

This pull request fixes a bug in email notifications where sometimes the `$site` variable would be undefined. I've been unable to reproduce but just had it reported for the second time (first was #666, second was via email)

```
[2022-06-16 11:34:12] production.ERROR: Undefined variable $site (View: /home/forge/domain/releases/20220616-113238/resources/views/mail/customer_order_paid.blade.php) {"exception":"[object] (Illuminate\\View\\ViewException(code: 0): Undefined variable $site (View: /home/forge/www.toos.nu/releases/20220616-113238/resources/views/mail/customer_order_paid.blade.php) at /home/forge/domain/storage/framework/views/ae92b9e916b067f4fa74e6777e781c85d869671a.php:15)
[stacktrace]
```

Fixes #666