### PR TITLE
Add `itemsTotalWithTax` tag

### DIFF
--- a/docs/tags/cart.md
+++ b/docs/tags/cart.md
@@ -54,6 +54,7 @@ There's tags for each of the different totals in a cart.
 - `{{ sc:cart:shipping_total }}` - Returns the shipping total of the cart.
 - `{{ sc:cart:tax_total }}` - Returns the tax total of the cart.
 - `{{ sc:cart:coupon_total }}` - Returns the total amount saved from coupons.
+- `{{ sc:cart:itemsTotalWithTax }}` - Sums up both the items total & tax totals
 
 If you need the 'raw' value for any of these totals, meaning the integer, rather than the formatted currency amount, you can do this: `{{ sc:cart:raw_grand_total }}`.
 

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -2,9 +2,11 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Tags;
 
+use DoubleThreeDigital\SimpleCommerce\Currency;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use Illuminate\Support\Str;
+use Statamic\Facades\Site;
 
 class CartTags extends SubTag
 {
@@ -87,6 +89,18 @@ class CartTags extends SubTag
     {
         if ($this->hasCart()) {
             return $this->getCart()->itemsTotal();
+        }
+
+        return 0;
+    }
+
+    public function itemsTotalWithTax()
+    {
+        if ($this->hasCart()) {
+            return Currency::parse(
+                $this->getCart()->itemsTotal() + $this->getCart()->taxTotal(),
+                Site::current()
+            );
         }
 
         return 0;

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -216,6 +216,17 @@ class CartTagTest extends TestCase
         $this->assertSame('£25.50', (string) $this->tag('{{ sc:cart:itemsTotal }}'));
     }
 
+     /** @test */
+     public function can_get_cart_items_total_with_cart_tax_total()
+     {
+         $cart = Order::make()->itemsTotal(2550)->taxTotal(620);
+         $cart->save();
+
+         $this->fakeCart($cart);
+
+         $this->assertSame('£31.70', (string) $this->tag('{{ sc:cart:itemsTotalWithTax }}'));
+     }
+
     /** @test */
     public function can_get_cart_shipping_total()
     {

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -216,16 +216,16 @@ class CartTagTest extends TestCase
         $this->assertSame('£25.50', (string) $this->tag('{{ sc:cart:itemsTotal }}'));
     }
 
-     /** @test */
-     public function can_get_cart_items_total_with_cart_tax_total()
-     {
-         $cart = Order::make()->itemsTotal(2550)->taxTotal(620);
-         $cart->save();
+    /** @test */
+    public function can_get_cart_items_total_with_cart_tax_total()
+    {
+        $cart = Order::make()->itemsTotal(2550)->taxTotal(620);
+        $cart->save();
 
-         $this->fakeCart($cart);
+        $this->fakeCart($cart);
 
-         $this->assertSame('£31.70', (string) $this->tag('{{ sc:cart:itemsTotalWithTax }}'));
-     }
+        $this->assertSame('£31.70', (string) $this->tag('{{ sc:cart:itemsTotalWithTax }}'));
+    }
 
     /** @test */
     public function can_get_cart_shipping_total()


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 
  Maybe include a short demo video to go along with it? (https://www.loom.com/)
-->

This pull request adds a new `itemsTotalWithTax` tag which will let users grab the line items total & tax total combined. This has been requested a few time so thought it would be a nice thing to finally add 😅

Fixes #687

## Use case

```antlers
{{ sc:cart:items }}
    <a class="flex items-center justify-between mb-2 text-sm" href="{{ product:url }}">
        <span>{{ quantity }}x {{ product:title }} {{ if variant }}({{ variant:variant }}){{ /if }}</span>
        <span>{{ total }}</span>
    </a>
{{ /sc:cart:items }}

<div class="flex items-center justify-between mb-2 text-sm">
    <span class="font-semibold">Items Total (inc tax)</span>
    <span class="font-semibold">{{ sc:cart:itemsTotalWithTax }}</span>
</div>
```