### PR TITLE
Don't remove CP Nav children if we can't resolve the 'Collections' section

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -320,26 +320,28 @@ class ServiceProvider extends AddonServiceProvider
             // Drop any collection items from 'Collections' nav
             $collections = $nav->content('Collections');
 
-            $children = $collections->children()()
-                ->reject(function ($child) {
-                    return in_array(
-                        $child->name(),
-                        collect(config('simple-commerce.content'))
-                            ->pluck('collection')
-                            ->filter()
-                            ->reject(function ($collectionHandle) {
-                                return is_null(Collection::find($collectionHandle));
-                            })
-                            ->map(function ($collectionHandle) {
-                                return __(Collection::find($collectionHandle)->title());
-                            })
-                            ->toArray(),
-                    );
-                });
+            if ($collections->children()) {
+                $children = $collections->children()()
+                    ->reject(function ($child) {
+                        return in_array(
+                            $child->name(),
+                            collect(config('simple-commerce.content'))
+                                ->pluck('collection')
+                                ->filter()
+                                ->reject(function ($collectionHandle) {
+                                    return is_null(Collection::find($collectionHandle));
+                                })
+                                ->map(function ($collectionHandle) {
+                                    return __(Collection::find($collectionHandle)->title());
+                                })
+                                ->toArray(),
+                        );
+                    });
 
-            $collections->children(function () use ($children) {
-                return $children;
-            });
+                $collections->children(function () use ($children) {
+                    return $children;
+                });
+            }
         });
 
         return $this;


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 
  Maybe include a short demo video to go along with it? (https://www.loom.com/)
-->

This pull request fixes an issue where you'd receive an error if you rename the 'Collections' nav section in your own site. 

Simple Commerce would attempt to remove it's Product/Order/Customer/Coupon collections from the Collections nav section which wouldn't work if it can't be resolved. If it can't be resolved, we'll just skip removing the collections because that's an easy fix 😅 
