### PR TITLE
Workaround issues with CP Nav issues

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\SimpleCommerce;
 
 use Barryvdh\Debugbar\Facade as Debugbar;
+use Statamic\CP\Navigation\NavItem;
 use Statamic\Events\EntryBlueprintFound;
 use Statamic\Facades\Collection;
 use Statamic\Facades\CP\Nav;
@@ -318,10 +319,12 @@ class ServiceProvider extends AddonServiceProvider
             }
 
             // Drop any collection items from 'Collections' nav
-            $collections = $nav->content('Collections');
+            $collectionsNavItem = collect($nav->items())->first(function (NavItem $navItem) {
+                return $navItem->url() === cp_route('collections.index');
+            });
 
-            if ($collections->children()) {
-                $children = $collections->children()()
+            if ($collectionsNavItem && $collectionsNavItem->children()) {
+                $children = $collectionsNavItem->children()()
                     ->reject(function ($child) {
                         return in_array(
                             $child->name(),
@@ -338,7 +341,7 @@ class ServiceProvider extends AddonServiceProvider
                         );
                     });
 
-                $collections->children(function () use ($children) {
+                $collectionsNavItem->children(function () use ($children) {
                     return $children;
                 });
             }


### PR DESCRIPTION
If you rename the 'Collections' nav item, it would get ignored thanks to #691.

However, then you'd end up with a new 'Collections' nav item in the Content nav because of SC's code.

This change essentially makes the nav item lookup code a little more robust.