### PR TITLE
Hydrate `Product` with inherited data, in addition to product data

### DIFF
--- a/src/Products/EntryProductRepository.php
+++ b/src/Products/EntryProductRepository.php
@@ -36,25 +36,25 @@ class EntryProductRepository implements RepositoryContract
             ->resource($entry)
             ->id($entry->id());
 
-        if ($entry->has('price')) {
-            $product->price($entry->get('price'));
+        if ($entry->has('price') || $entry->originValues()->has('price')) {
+            $product->price($entry->value('price'));
         }
 
-        if ($entry->has('product_variants')) {
-            $product->productVariants($entry->get('product_variants'));
+        if ($entry->has('product_variants') || $entry->originValues()->has('product_variants')) {
+            $product->productVariants($entry->value('product_variants'));
         }
 
-        if ($entry->has('stock')) {
-            $product->stock($entry->get('stock'));
+        if ($entry->has('stock') || $entry->originValues()->has('stock')) {
+            $product->stock($entry->value('stock'));
         }
 
-        if (SimpleCommerce::isUsingStandardTaxEngine() && $entry->has('tax_category')) {
-            $product->taxCategory($entry->get('tax_category'));
+        if (SimpleCommerce::isUsingStandardTaxEngine() && ($entry->has('tax_category') || $entry->originValues()->has('tax_category'))) {
+            $product->taxCategory($entry->value('tax_category'));
         }
 
         return $product->data(array_merge(
             Arr::except(
-                $entry->data()->toArray(),
+                $entry->values()->toArray(),
                 ['price', 'product_variants', 'stock', 'tax_category']
             ),
             [


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 
  Maybe include a short demo video to go along with it? (https://www.loom.com/)
-->

This pull request implements a change to how we're hydrating the `Product` class with data. 

Previously, only values directly on the entry would be hydrated into the class. Whereas now, inherited values will also be hydrated into the class.

This means you can do things like `$product->price()` on a localised product entry and it'll pick up the price from the origin entry.

Fixes #697