### PR TITLE
Money Fieldtype: Don't return £0 if no value is set

### DIFF
--- a/src/Fieldtypes/MoneyFieldtype.php
+++ b/src/Fieldtypes/MoneyFieldtype.php
@@ -62,10 +62,6 @@ class MoneyFieldtype extends Fieldtype
 
     public function augment($value)
     {
-        // if (! $value) {
-        //     return Currency::parse(0, Site::current());
-        // }
-
         return Currency::parse($value, Site::current());
     }
 

--- a/src/Fieldtypes/MoneyFieldtype.php
+++ b/src/Fieldtypes/MoneyFieldtype.php
@@ -62,9 +62,9 @@ class MoneyFieldtype extends Fieldtype
 
     public function augment($value)
     {
-        if (! $value) {
-            return Currency::parse(0, Site::current());
-        }
+        // if (! $value) {
+        //     return Currency::parse(0, Site::current());
+        // }
 
         return Currency::parse($value, Site::current());
     }


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 
  Maybe include a short demo video to go along with it? (https://www.loom.com/)
-->

This pull request rolls back a change from a couple of months ago which returns £0 when augmenting a Money field which doesn't have any value set.

Hopefully this won't break anyone's sites... if it does, open an issue and we'll see if we can workaround it. Probably makes sense it returning nothing if the value is nothing.

Resolves a recent comment in #459