### PR TITLE
Money Fieldtype: Empty value should return null

### DIFF
--- a/src/Fieldtypes/MoneyFieldtype.php
+++ b/src/Fieldtypes/MoneyFieldtype.php
@@ -62,6 +62,10 @@ class MoneyFieldtype extends Fieldtype
 
     public function augment($value)
     {
+        if (empty($value)) {
+            return null;
+        }
+
         return Currency::parse($value, Site::current());
     }
 

--- a/tests/Fieldtypes/MoneyFieldtypeTest.php
+++ b/tests/Fieldtypes/MoneyFieldtypeTest.php
@@ -79,6 +79,16 @@ class MoneyFieldtypeTest extends TestCase
     }
 
     /** @test */
+    public function can_augment_data_when_value_is_null()
+    {
+        $value = null;
+
+        $augment = (new MoneyFieldtype())->augment($value);
+
+        $this->assertSame(null, $augment);
+    }
+
+    /** @test */
     public function can_get_pre_process_index()
     {
         $value = 2572;


### PR DESCRIPTION
This pull request fixes an issue where even after #699, empty price fields were still returning £0.00 because they were falling back to the Currency class which has formatting for 'null values'.

Hopefully this won't break anyone's sites... if it does, open an issue and we'll see if we can workaround it. Probably makes sense it returning nothing if the value is nothing.

Hopefully fixes #459 once and for all!