### PR TITLE
Fix Price Fieldtype not picking up changes in the value prop

### DIFF
--- a/resources/js/components/Fieldtypes/MoneyFieldtype.vue
+++ b/resources/js/components/Fieldtypes/MoneyFieldtype.vue
@@ -37,5 +37,13 @@ export default {
             this.formattedValue = parseFloat(this.value).toFixed(2)
         }
     },
+
+    watch: {
+        value() {
+            if (isNaN(parseFloat(this.value)) == false) {
+                this.formattedValue = parseFloat(this.value).toFixed(2)
+            }
+        },
+    },
 }
 </script>


### PR DESCRIPTION
This pull request fixes an issue where any changes made to the `value` prop after the 'mounting' of the Money Fieldtype wouldn't actually be shown to the user. Yet, the change in value would actually be saved (unless manually changed).

Fixes #719