### PR TITLE
Fix issues with Simple Commerce's Relationship fieldtypes

### DIFF
--- a/src/Fieldtypes/CountryFieldtype.php
+++ b/src/Fieldtypes/CountryFieldtype.php
@@ -50,7 +50,10 @@ class CountryFieldtype extends Relationship
         return collect($data)->map(function ($item) {
             $country = Countries::firstWhere('iso', $item);
 
-            return $country['name'];
-        })->join(', ');
+            return [
+                'id' => $country['iso'],
+                'title' => $country['name'],
+            ];
+        });
     }
 }

--- a/src/Fieldtypes/CountryFieldtype.php
+++ b/src/Fieldtypes/CountryFieldtype.php
@@ -9,6 +9,7 @@ use Statamic\Fieldtypes\Relationship;
 class CountryFieldtype extends Relationship
 {
     protected $canCreate = false;
+    protected $indexComponent = null;
 
     public function getIndexItems($request)
     {

--- a/src/Fieldtypes/CountryFieldtype.php
+++ b/src/Fieldtypes/CountryFieldtype.php
@@ -50,10 +50,7 @@ class CountryFieldtype extends Relationship
         return collect($data)->map(function ($item) {
             $country = Countries::firstWhere('iso', $item);
 
-            return [
-                'id' => $country['iso'],
-                'title' => $country['name'],
-            ];
-        });
+            return $country['name'];
+        })->join(', ');
     }
 }

--- a/src/Fieldtypes/CouponFieldtype.php
+++ b/src/Fieldtypes/CouponFieldtype.php
@@ -55,7 +55,11 @@ class CouponFieldtype extends Relationship
         return collect($data)->map(function ($item) {
             $coupon = Coupon::find($item);
 
-            return $coupon->code();
-        })->join(', ');
+            return [
+                'id' => $coupon->id(),
+                'title' => $coupon->code(),
+                'edit_url' => $coupon->editUrl(),
+            ];
+        });
     }
 }

--- a/src/Fieldtypes/CouponFieldtype.php
+++ b/src/Fieldtypes/CouponFieldtype.php
@@ -55,11 +55,7 @@ class CouponFieldtype extends Relationship
         return collect($data)->map(function ($item) {
             $coupon = Coupon::find($item);
 
-            return [
-                'id' => $coupon->id(),
-                'title' => $coupon->code(),
-                'edit_url' => $coupon->editUrl(),
-            ];
-        });
+            return $coupon->code();
+        })->join(', ');
     }
 }

--- a/src/Fieldtypes/RegionFieldtype.php
+++ b/src/Fieldtypes/RegionFieldtype.php
@@ -51,10 +51,7 @@ class RegionFieldtype extends Relationship
         return collect($data)->map(function ($item) {
             $region = Regions::find($item);
 
-            return [
-                'id' => $region['id'],
-                'title' => $region['name'],
-            ];
-        });
+            return $region['name'];
+        })->join(', ');
     }
 }

--- a/src/Fieldtypes/RegionFieldtype.php
+++ b/src/Fieldtypes/RegionFieldtype.php
@@ -51,7 +51,10 @@ class RegionFieldtype extends Relationship
         return collect($data)->map(function ($item) {
             $region = Regions::find($item);
 
-            return $region['name'];
-        })->join(', ');
+            return [
+                'id' => $region['id'],
+                'title' => $region['name'],
+            ];
+        });
     }
 }

--- a/src/Fieldtypes/RegionFieldtype.php
+++ b/src/Fieldtypes/RegionFieldtype.php
@@ -10,6 +10,7 @@ use Statamic\Fieldtypes\Relationship;
 class RegionFieldtype extends Relationship
 {
     protected $canCreate = false;
+    protected $indexComponent = null;
 
     public function getIndexItems($request)
     {

--- a/src/Fieldtypes/ShippingMethodFieldtype.php
+++ b/src/Fieldtypes/ShippingMethodFieldtype.php
@@ -10,6 +10,7 @@ use Statamic\Fieldtypes\Relationship;
 class ShippingMethodFieldtype extends Relationship
 {
     protected $canCreate = false;
+    protected $indexComponent = null;
 
     protected function configFieldItems(): array
     {

--- a/src/Fieldtypes/ShippingMethodFieldtype.php
+++ b/src/Fieldtypes/ShippingMethodFieldtype.php
@@ -86,11 +86,8 @@ class ShippingMethodFieldtype extends Relationship
                 return null;
             }
 
-            return [
-                'id' => $shippingMethod['class'],
-                'title' => $shippingMethod['name'],
-            ];
-        });
+            return $shippingMethod['name'];
+        })->join(', ');
     }
 
     public function rules(): array

--- a/src/Fieldtypes/ShippingMethodFieldtype.php
+++ b/src/Fieldtypes/ShippingMethodFieldtype.php
@@ -86,8 +86,11 @@ class ShippingMethodFieldtype extends Relationship
                 return null;
             }
 
-            return $shippingMethod['name'];
-        })->join(', ');
+            return [
+                'id' => $shippingMethod['class'],
+                'title' => $shippingMethod['name'],
+            ];
+        });
     }
 
     public function rules(): array

--- a/src/Fieldtypes/TaxCategoryFieldtype.php
+++ b/src/Fieldtypes/TaxCategoryFieldtype.php
@@ -75,7 +75,10 @@ class TaxCategoryFieldtype extends Relationship
         return collect($data)->map(function ($item) {
             $taxCategory = TaxCategory::find($item);
 
-            return $taxCategory->name();
-        })->join(', ');
+            return [
+                'id' => $taxCategory->id(),
+                'title' => $taxCategory->name(),
+            ];
+        });
     }
 }

--- a/src/Fieldtypes/TaxCategoryFieldtype.php
+++ b/src/Fieldtypes/TaxCategoryFieldtype.php
@@ -75,10 +75,7 @@ class TaxCategoryFieldtype extends Relationship
         return collect($data)->map(function ($item) {
             $taxCategory = TaxCategory::find($item);
 
-            return [
-                'id' => $taxCategory->id(),
-                'title' => $taxCategory->name(),
-            ];
-        });
+            return $taxCategory->name();
+        })->join(', ');
     }
 }

--- a/src/Fieldtypes/TaxCategoryFieldtype.php
+++ b/src/Fieldtypes/TaxCategoryFieldtype.php
@@ -75,7 +75,11 @@ class TaxCategoryFieldtype extends Relationship
         return collect($data)->map(function ($item) {
             $taxCategory = TaxCategory::find($item);
 
-            return $taxCategory->name();
-        })->join(', ');
+            return [
+                'id' => $taxCategory->id(),
+                'title' => $taxCategory->name(),
+                'edit_url' => $taxCategory->editUrl(),
+            ];
+        });
     }
 }

--- a/tests/Fieldtypes/CouponFieldtypeTest.php
+++ b/tests/Fieldtypes/CouponFieldtypeTest.php
@@ -107,8 +107,14 @@ class CouponFieldtypeTest extends TestCase
     {
         $preProcessIndex = $this->fieldtype->preProcessIndex('foo');
 
-        $this->assertIsString($preProcessIndex);
-        $this->assertSame($preProcessIndex, 'TUPLE');
+        $this->assertTrue($preProcessIndex instanceof Collection);
+        $this->assertCount(1, $preProcessIndex);
+
+        $this->assertSame($preProcessIndex[0], [
+            'id' => 'foo',
+            'title' => 'TUPLE',
+            'edit_url' => 'http://localhost/cp/simple-commerce/coupons/foo/edit',
+        ]);
     }
 
     /** @test */
@@ -124,7 +130,19 @@ class CouponFieldtypeTest extends TestCase
     {
         $preProcessIndex = $this->fieldtype->preProcessIndex(['foo', 'rad']);
 
-        $this->assertIsString($preProcessIndex);
-        $this->assertSame($preProcessIndex, 'TUPLE, STATAMIC');
+        $this->assertTrue($preProcessIndex instanceof Collection);
+        $this->assertCount(2, $preProcessIndex);
+
+        $this->assertSame($preProcessIndex[0], [
+            'id' => 'foo',
+            'title' => 'TUPLE',
+            'edit_url' => 'http://localhost/cp/simple-commerce/coupons/foo/edit',
+        ]);
+
+        $this->assertSame($preProcessIndex[1], [
+            'id' => 'rad',
+            'title' => 'STATAMIC',
+            'edit_url' => 'http://localhost/cp/simple-commerce/coupons/rad/edit',
+        ]);
     }
 }


### PR DESCRIPTION
This pull request fixes issues with Simple Commerce's relationship fieldtypes where instead of returning useful output, they'd return a big useless gap.

![image](https://user-images.githubusercontent.com/19637309/192107979-8fd64987-12dd-4408-9490-3d764eecd532.png)

For some of the fieldtypes, we don't actually need them to really be relationship fields apart from the fieldtype UI, so we're setting the `indexComponent` to `null` so we get the normal text index component.

For the ones where we do need them to be proper relationship fields (coupon & tax category), we're now returning arrays as expected by the [relationship index component](https://github.com/statamic/cms/blob/3.3/resources/js/components/fieldtypes/relationship/RelationshipIndexFieldtype.vue). They'll also link through to the relevant edit pages.

Fixes #723