### PR TITLE
Fix: Stock should decrease on origin product when the Stock field isn't localised

### DIFF
--- a/src/Orders/Checkout/HandleStock.php
+++ b/src/Orders/Checkout/HandleStock.php
@@ -7,8 +7,12 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use DoubleThreeDigital\SimpleCommerce\Events\StockRunningLow;
 use DoubleThreeDigital\SimpleCommerce\Events\StockRunOut;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\CheckoutProductHasNoStockException;
+use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
+use DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository;
 use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Statamic\Facades\Site;
 
 class HandleStock
 {
@@ -17,6 +21,16 @@ class HandleStock
         $order->lineItems()
             ->each(function (LineItem $item) {
                 $product = $item->product();
+
+                // Multi-site: Is the Stock field not localised? If so, we want the origin
+                // version of the product for stock purposes.
+                if (
+                    $this->isOrExtendsClass(SimpleCommerce::productDriver()['repository'], EntryProductRepository::class)
+                    && $product->resource()->hasOrigin()
+                    && ! $product->resource()->blueprint()->field('stock')->isLocalizable()
+                ) {
+                    $product = Product::find($product->resource()->origin()->id());
+                }
 
                 if ($product->purchasableType() === ProductType::Product) {
                     if (is_int($product->stock())) {
@@ -68,5 +82,11 @@ class HandleStock
             });
 
         return $next($order);
+    }
+
+    protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool
+    {
+        return is_subclass_of($class, $classToCheckAgainst)
+            || $class === $classToCheckAgainst;
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where you'd purchase a localised version of a product, then the Stock field would be updated on the localised product, even if the Stock field doesn't have 'Localised' enabled.

In that case, Simple Commerce will now update the stock on the origin version of the product entry, rather than the localised version.

Fixes #721