### PR TITLE
Product Variant not being displayed

### DIFF
--- a/resources/js/components/Fieldtypes/ProductVariantFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariantFieldtype.vue
@@ -19,7 +19,7 @@
             <select-field
                 v-else-if="
                     productVariantsData &&
-                        productVariantsData.purchasable_type === 'VARIANT'
+                        productVariantsData.purchasable_type === 'variant'
                 "
                 :options="productVariantOptions"
                 :disabled="readOnly"
@@ -29,7 +29,7 @@
             <p
                 v-else-if="
                     productVariantsData &&
-                        productVariantsData.purchasable_type === 'PRODUCT'
+                        productVariantsData.purchasable_type === 'product'
                 "
                 class="text-sm p-1"
             >


### PR DESCRIPTION
This pull request fixes #727. 

After implementing proper PHP enums in #712, the values to compare against are lowercase instead of uppercase. As there was no match, nothing would be displayed to the user.