### PR TITLE
Return SC information from Artisan's about command

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,11 +3,13 @@
 namespace DoubleThreeDigital\SimpleCommerce;
 
 use Barryvdh\Debugbar\Facade as Debugbar;
+use Illuminate\Foundation\Console\AboutCommand;
 use Statamic\CP\Navigation\NavItem;
 use Statamic\Events\EntryBlueprintFound;
 use Statamic\Facades\Collection;
 use Statamic\Facades\CP\Nav;
 use Statamic\Facades\Permission;
+use Statamic\Facades\Site;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Stache\Stache;
 use Statamic\Statamic;
@@ -140,6 +142,17 @@ class ServiceProvider extends AddonServiceProvider
         if (class_exists('Barryvdh\Debugbar\ServiceProvider') && config('debugbar.enabled', false) === true) {
             Debugbar::addCollector(new DebugbarDataCollector('simple-commerce'));
         }
+
+        AboutCommand::add('Simple Commerce', function () {
+            return [
+                'Repository: Customer' => SimpleCommerce::customerDriver()['repository'],
+                'Repository: Order' => SimpleCommerce::orderDriver()['repository'],
+                'Repository: Product' => SimpleCommerce::productDriver()['repository'],
+                'Gateways' => collect(SimpleCommerce::gateways())->pluck('name')->implode(', '),
+                'Shipping Methods' => SimpleCommerce::shippingMethods()->pluck('name')->implode(', '),
+                'Tax Engine' => get_class(SimpleCommerce::taxEngine()),
+            ];
+        });
     }
 
     protected function bootVendorAssets()

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,7 +9,6 @@ use Statamic\Events\EntryBlueprintFound;
 use Statamic\Facades\Collection;
 use Statamic\Facades\CP\Nav;
 use Statamic\Facades\Permission;
-use Statamic\Facades\Site;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Stache\Stache;
 use Statamic\Statamic;


### PR DESCRIPTION
This pull request adds some specific Simple Commerce information to what's outputted from Laravel's `php artisan about` command and what's returned from Statamic's `php please support:details` command.

This extra information may come in helpful when folks are creating GitHub issues and means I can easily dig into if a specific driver/gateway/shipping method may be causing the issue without the need for back and forth.

## Screenshot

![image](https://user-images.githubusercontent.com/19637309/193421452-5f8a8945-4356-4ef4-aee4-a95c2b83c80f.png)
