### PR TITLE
Check stock field exists when doing origin check

### DIFF
--- a/src/Orders/Checkout/HandleStock.php
+++ b/src/Orders/Checkout/HandleStock.php
@@ -27,6 +27,7 @@ class HandleStock
                 if (
                     $this->isOrExtendsClass(SimpleCommerce::productDriver()['repository'], EntryProductRepository::class)
                     && $product->resource()->hasOrigin()
+                    && $product->resource()->blueprint()->hasField('stock')
                     && ! $product->resource()->blueprint()->field('stock')->isLocalizable()
                 ) {
                     $product = Product::find($product->resource()->origin()->id());


### PR DESCRIPTION
This pull request fixes #721. It adds a check to ensure the `stock` field actually exists when performing the 'origin check' (to ensure we update stock on the right product in a multi-site case)