### PR TITLE
Better handle deleted products in the cart

### DIFF
--- a/src/Orders/HasLineItems.php
+++ b/src/Orders/HasLineItems.php
@@ -33,18 +33,11 @@ trait HasLineItems
                         $item['total'] = 0;
                     }
 
-                    try {
-                        $lineItem = (new LineItem($item))
-                            ->id($item['id'])
-                            ->product($item['product'])
-                            ->quantity($item['quantity'])
-                            ->total($item['total']);
-                    } catch (ProductNotFound $e) {
-                        // If product doesn't exist, remove it from the line items & return null.
-                        $this->removeLineItem($item['id']);
-
-                        return null;
-                    }
+                    $lineItem = (new LineItem($item))
+                        ->id($item['id'])
+                        ->product($item['product'])
+                        ->quantity($item['quantity'])
+                        ->total($item['total']);
 
                     if (isset($item['variant'])) {
                         $lineItem->variant($item['variant']);
@@ -56,6 +49,14 @@ trait HasLineItems
 
                     if (isset($item['metadata'])) {
                         $lineItem->metadata($item['metadata']);
+                    }
+
+                    // If the line item's product has been deleted, remove
+                    // it from the cart & return null.
+                    if (! $this->isPaid() && ! $lineItem->product()) {
+                        $this->removeLineItem($item['id']);
+
+                        return null;
                     }
 
                     return $lineItem;

--- a/src/Orders/HasLineItems.php
+++ b/src/Orders/HasLineItems.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Orders;
 
-use DoubleThreeDigital\SimpleCommerce\Exceptions\ProductNotFound;
 use Illuminate\Support\Collection;
 
 trait HasLineItems

--- a/src/Orders/LineItem.php
+++ b/src/Orders/LineItem.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\SimpleCommerce\Orders;
 
 use DoubleThreeDigital\SimpleCommerce\Contracts\Product;
+use DoubleThreeDigital\SimpleCommerce\Exceptions\ProductNotFound;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product as ProductFacade;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
@@ -35,11 +36,15 @@ class LineItem
         return $this
             ->fluentlyGetOrSet('product')
             ->setter(function ($product) {
-                if (! $product instanceof Product) {
-                    return ProductFacade::find($product);
+                if ($product instanceof Product) {
+                    return $product;
                 }
 
-                return $product;
+                try {
+                    return ProductFacade::find($product);
+                } catch (ProductNotFound $e) {
+                    return null;
+                }
             })
             ->args(func_get_args());
     }
@@ -90,7 +95,7 @@ class LineItem
     {
         return [
             'id' => $this->id,
-            'product' => $this->product->id(),
+            'product' => optional($this->product)->id(),
             'variant' => $this->variant,
             'quantity' => $this->quantity,
             'total' => $this->total,

--- a/tests/Orders/LineItemsTest.php
+++ b/tests/Orders/LineItemsTest.php
@@ -50,6 +50,60 @@ class LineItemsTest extends TestCase
     }
 
     /** @test */
+    public function can_get_line_items_when_item_has_to_be_filtered_out_to_a_deleted_product()
+    {
+        $productOne = Product::make()->price(1000);
+        $productOne->save();
+
+        $order = Order::make()->lineItems([
+            [
+                'id'       => 'un-doone-two-three-twa',
+                'product'  => $productOne->id(),
+                'quantity' => 2,
+            ],
+            [
+                'id'       => 'nine-ten-eleven',
+                'product'  => 'blah-blah', // this product doesn't exist
+                'quantity' => 2,
+            ],
+        ]);
+
+        $order->save();
+
+        $lineItems = $order->lineItems();
+
+        $this->assertTrue($lineItems instanceof Collection);
+        $this->assertSame($lineItems->count(), 1);
+    }
+
+    /** @test */
+    public function can_get_line_items_when_item_has_null_product_due_to_a_deleted_product_and_paid_order()
+    {
+        $productOne = Product::make()->price(1000);
+        $productOne->save();
+
+        $order = Order::make()->isPaid(true)->lineItems([
+            [
+                'id'       => 'un-doone-two-three-twa',
+                'product'  => $productOne->id(),
+                'quantity' => 2,
+            ],
+            [
+                'id'       => 'nine-ten-eleven',
+                'product'  => 'blah-blah', // this product doesn't exist
+                'quantity' => 2,
+            ],
+        ]);
+
+        $order->save();
+
+        $lineItems = $order->lineItems();
+
+        $this->assertTrue($lineItems instanceof Collection);
+        $this->assertSame($lineItems->count(), 2);
+    }
+
+    /** @test */
     public function line_items_return_empty_if_order_has_no_items()
     {
         $order = Order::make();


### PR DESCRIPTION
This pull request implements better handling for deleted products in the cart. 

This might be a bit of an edge case but if a product is deleted while a customer has it in their cart, we will now remove that line item from their cart.

It's worth noting that line items won't be removed from paid orders as they need to be preserved, along with the totals.

This PR fixes #732.