### PR TITLE
Ability to filter orders by products

### DIFF
--- a/src/Filters/OrderContainsProduct.php
+++ b/src/Filters/OrderContainsProduct.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Filters;
+
+use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
+use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Statamic\Query\Scopes\Filter;
+
+class OrderContainsProduct extends Filter
+{
+    public static $title = 'Contains Product';
+
+    public function fieldItems()
+    {
+        return [
+            'products' => [
+                'type' => 'select',
+                'display' => __('Product'),
+                'options' => $this->getProducts(),
+                'multiple' => true,
+            ],
+        ];
+    }
+
+    protected function getProducts(): array
+    {
+        return collect(Product::all())->mapWithKeys(function ($product) {
+            return [$product->id() => $product->get('title')];
+        })->toArray();
+    }
+
+    public function apply($query, $values)
+    {
+        $products = $values['products'];
+
+        // TODO: Refactor query once we have a better way of querying
+        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EntryOrderRepository::class)) {
+            $query
+                ->whereIn('items->0->product', $products)
+                ->orWhereIn('items->1->product', $products)
+                ->orWhereIn('items->2->product', $products)
+                ->orWhereIn('items->3->product', $products)
+                ->orWhereIn('items->4->product', $products)
+                ->orWhereIn('items->5->product', $products)
+                ->orWhereIn('items->6->product', $products)
+                ->orWhereIn('items->7->product', $products)
+                ->orWhereIn('items->8->product', $products)
+                ->orWhereIn('items->9->product', $products);
+        }
+
+        // TODO: Make this query work when using the Eloquent driver
+        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EloquentOrderRepository::class)) {
+            //
+        }
+
+        return $query;
+    }
+
+    public function badge($values)
+    {
+        $products = collect($values['products'])->map(function ($productId) {
+            return Product::find($productId)->get('title');
+        })->join(', ');
+
+        return "Contains Product: {$products}";
+    }
+
+    public function visibleTo($key)
+    {
+        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EntryOrderRepository::class)) {
+            return $key === 'entries'
+                && $this->context['collection'] === SimpleCommerce::orderDriver()['collection'];
+        }
+
+        // if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EloquentOrderRepository::class)) {
+        //     $orderModelClass = SimpleCommerce::orderDriver()['model'];
+        //     $runwayResource = \DoubleThreeDigital\Runway\Runway::findResourceByModel(new $orderModelClass);
+
+        //     return $key === "runway_{$runwayResource->handle()}";
+        // }
+
+        return false;
+    }
+
+    protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool
+    {
+        return is_subclass_of($class, $classToCheckAgainst)
+            || $class === $classToCheckAgainst;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -136,6 +136,7 @@ class ServiceProvider extends AddonServiceProvider
                 ->registerPermissions();
         });
 
+        Filters\OrderContainsProduct::register();
         Filters\OrderStatusFilter::register();
 
         if (class_exists('Barryvdh\Debugbar\ServiceProvider') && config('debugbar.enabled', false) === true) {


### PR DESCRIPTION
This pull request implements a feature a few customers have asked for recently: the ability to filter orders by products.

> **Note**
> This filter only currently works when using the Entries order repository, it won't work for the Eloquent order repository due to constraints in Eloquent & JSON columns (sorry!).

![image](https://user-images.githubusercontent.com/19637309/194703164-80357006-3154-44f8-bc24-0c4ec9c4028a.png)

## Usage

1. Go to the top left of the Orders Listing Table, click 'Filter'
2. Choose 'Contains Product'
3. Then select the products you wish to filter by

## Implementation

The current implementation currently only supports querying the first 10 line items on an order because there's not currently a way to query 'array fields' with a wildcard, like `->where('items->*->product', ...)`. 

However, I believe this may be something coming in the next couple of months 👀 