### PR TITLE
Take advantage of constructor property promotion

### DIFF
--- a/src/Events/CouponRedeemed.php
+++ b/src/Events/CouponRedeemed.php
@@ -11,10 +11,7 @@ class CouponRedeemed
     use Dispatchable;
     use InteractsWithSockets;
 
-    public $coupon;
-
-    public function __construct(Coupon $coupon)
+    public function __construct(public Coupon $coupon)
     {
-        $this->coupon = $coupon;
     }
 }

--- a/src/Events/OrderPaid.php
+++ b/src/Events/OrderPaid.php
@@ -11,10 +11,7 @@ class OrderPaid
     use Dispatchable;
     use InteractsWithSockets;
 
-    public Order $order;
-
-    public function __construct(Order $order)
+    public function __construct(public Order $order)
     {
-        $this->order = $order;
     }
 }

--- a/src/Events/OrderPaymentFailed.php
+++ b/src/Events/OrderPaymentFailed.php
@@ -11,10 +11,7 @@ class OrderPaymentFailed
     use Dispatchable;
     use InteractsWithSockets;
 
-    public Order $order;
-
-    public function __construct(Order $order)
+    public function __construct(public Order $order)
     {
-        $this->order = $order;
     }
 }

--- a/src/Events/OrderSaved.php
+++ b/src/Events/OrderSaved.php
@@ -11,10 +11,7 @@ class OrderSaved
     use Dispatchable;
     use InteractsWithSockets;
 
-    public $order;
-
-    public function __construct(Order $order)
+    public function __construct(public Order $order)
     {
-        $this->order = $order;
     }
 }

--- a/src/Events/OrderShipped.php
+++ b/src/Events/OrderShipped.php
@@ -11,10 +11,7 @@ class OrderShipped
     use Dispatchable;
     use InteractsWithSockets;
 
-    public $order;
-
-    public function __construct(Order $order)
+    public function __construct(public Order $order)
     {
-        $this->order = $order;
     }
 }

--- a/src/Events/PostCheckout.php
+++ b/src/Events/PostCheckout.php
@@ -11,12 +11,7 @@ class PostCheckout
     use Dispatchable;
     use InteractsWithSockets;
 
-    public Order $order;
-    public $request;
-
-    public function __construct(Order $order, $request)
+    public function __construct(public Order $order, public $request)
     {
-        $this->order = $order;
-        $this->request = $request;
     }
 }

--- a/src/Events/PreCheckout.php
+++ b/src/Events/PreCheckout.php
@@ -11,12 +11,7 @@ class PreCheckout
     use Dispatchable;
     use InteractsWithSockets;
 
-    public Order $order;
-    public $request;
-
-    public function __construct(Order $order, $request)
+    public function __construct(public Order $order, public $request)
     {
-        $this->order = $order;
-        $this->request = $request;
     }
 }

--- a/src/Events/ReceiveGatewayWebhook.php
+++ b/src/Events/ReceiveGatewayWebhook.php
@@ -10,10 +10,7 @@ class ReceiveGatewayWebhook
     use Dispatchable;
     use InteractsWithSockets;
 
-    public array $payload;
-
-    public function __construct(array $payload)
+    public function __construct(public array $payload)
     {
-        $this->payload = $payload;
     }
 }

--- a/src/Events/StockRunOut.php
+++ b/src/Events/StockRunOut.php
@@ -11,15 +11,8 @@ class StockRunOut
     use Dispatchable;
     use InteractsWithSockets;
 
-    public $product;
-    public $stock;
-    public $variant;
-
-    // v2.4: Switch the parameter order - product, variant, stock
-    public function __construct(Product $product, int $stock, $variant = null)
+    // TODO v5.0: Switch the parameter order - product, variant, stock
+    public function __construct(public Product $product, public int $stock, public $variant = null)
     {
-        $this->product = $product;
-        $this->stock = $stock;
-        $this->variant = $variant;
     }
 }

--- a/src/Events/StockRunningLow.php
+++ b/src/Events/StockRunningLow.php
@@ -11,15 +11,8 @@ class StockRunningLow
     use Dispatchable;
     use InteractsWithSockets;
 
-    public $product;
-    public $stock;
-    public $variant;
-
-    // v2.4: Switch the parameter order - product, variant, stock
-    public function __construct(Product $product, int $stock, $variant = null)
+    // TODO v5.0: Switch the parameter order - product, variant, stock
+    public function __construct(public Product $product, public int $stock, public $variant = null)
     {
-        $this->product = $product;
-        $this->stock = $stock;
-        $this->variant = $variant;
     }
 }

--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -13,21 +13,10 @@ use Illuminate\Support\Str;
 
 class BaseGateway
 {
-    protected array $config = [];
-    protected string $handle = '';
-    protected string $webhookUrl = '';
-    protected string $redirectUrl = '/';
-    protected string $errorRedirectUrl = '/';
     protected string $displayName = '';
 
-    public function __construct(array $config = [], string $handle = '', string $webhookUrl = '', string $redirectUrl = '/', string $errorRedirectUrl = '/')
+    public function __construct(protected array $config = [], protected string $handle = '', protected string $webhookUrl = '', protected string $redirectUrl = '/', protected string $errorRedirectUrl = '/')
     {
-        $this->config = $config;
-        $this->handle = $handle;
-        $this->webhookUrl = $webhookUrl;
-        $this->redirectUrl = $redirectUrl;
-        $this->errorRedirectUrl = $errorRedirectUrl;
-
         $this->displayName = isset($config['display']) ? $config['display'] : $this->name();
     }
 

--- a/src/Gateways/Prepare.php
+++ b/src/Gateways/Prepare.php
@@ -7,13 +7,8 @@ use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderFacade;
 
 class Prepare
 {
-    protected $request;
-    protected $order;
-
-    public function __construct($request, Order $order)
+    public function __construct(protected $request, protected Order $order)
     {
-        $this->request = $request;
-        $this->order = $order;
     }
 
     public function request()

--- a/src/Gateways/Purchase.php
+++ b/src/Gateways/Purchase.php
@@ -6,13 +6,8 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 
 class Purchase
 {
-    protected $request;
-    protected $order;
-
-    public function __construct($request, Order $order)
+    public function __construct(protected $request, protected Order $order)
     {
-        $this->request = $request;
-        $this->order = $order;
     }
 
     public function request()

--- a/src/Gateways/Response.php
+++ b/src/Gateways/Response.php
@@ -4,17 +4,10 @@ namespace DoubleThreeDigital\SimpleCommerce\Gateways;
 
 class Response
 {
-    protected bool $success = false;
-    protected array $data = [];
-    protected string $checkoutUrl = '';
-
     protected string $error = '';
 
-    public function __construct(bool $success = false, array $data = [], string $checkoutUrl = '')
+    public function __construct(protected bool $success = false, protected array $data = [], protected string $checkoutUrl = '')
     {
-        $this->success = $success;
-        $this->data = $data;
-        $this->checkoutUrl = $checkoutUrl;
     }
 
     public function success(): bool

--- a/src/Notifications/BackOfficeOrderPaid.php
+++ b/src/Notifications/BackOfficeOrderPaid.php
@@ -12,16 +12,13 @@ class BackOfficeOrderPaid extends Notification
 {
     use Queueable;
 
-    protected $order;
-
     /**
      * Create a new notification instance.
      *
      * @return void
      */
-    public function __construct(Order $order)
+    public function __construct(protected Order $order)
     {
-        $this->order = $order;
     }
 
     /**

--- a/src/Notifications/CustomerOrderPaid.php
+++ b/src/Notifications/CustomerOrderPaid.php
@@ -12,16 +12,13 @@ class CustomerOrderPaid extends Notification
 {
     use Queueable;
 
-    protected $order;
-
     /**
      * Create a new notification instance.
      *
      * @return void
      */
-    public function __construct(Order $order)
+    public function __construct(protected Order $order)
     {
-        $this->order = $order;
     }
 
     /**

--- a/src/Notifications/CustomerOrderShipped.php
+++ b/src/Notifications/CustomerOrderShipped.php
@@ -12,16 +12,13 @@ class CustomerOrderShipped extends Notification
 {
     use Queueable;
 
-    protected $order;
-
     /**
      * Create a new notification instance.
      *
      * @return void
      */
-    public function __construct(Order $order)
+    public function __construct(protected Order $order)
     {
-        $this->order = $order;
     }
 
     /**

--- a/src/Orders/Address.php
+++ b/src/Orders/Address.php
@@ -15,6 +15,7 @@ class Address
     protected static $country;
     protected static $zipCode;
 
+    // TODO: Move this stuff to the constructor
     public static function from(string $addressType, $data): self
     {
         static::$name = $data->get("{$addressType}_name");

--- a/src/Shipping/BaseShippingMethod.php
+++ b/src/Shipping/BaseShippingMethod.php
@@ -7,11 +7,8 @@ use Illuminate\Support\Str;
 
 class BaseShippingMethod
 {
-    protected array $config = [];
-
-    public function __construct(array $config = [])
+    public function __construct(protected array $config = [])
     {
-        $this->config = $config;
     }
 
     public function config(): Collection

--- a/src/Tax/TaxCalculation.php
+++ b/src/Tax/TaxCalculation.php
@@ -4,15 +4,8 @@ namespace DoubleThreeDigital\SimpleCommerce\Tax;
 
 class TaxCalculation
 {
-    protected $amount;
-    protected $rate;
-    protected $priceIncludesTax;
-
-    public function __construct(int $amount = 0, $rate = 0, bool $priceIncludesTax = false)
+    public function __construct(protected int $amount = 0, protected $rate = 0, protected bool $priceIncludesTax = false)
     {
-        $this->amount = $amount;
-        $this->rate = $rate;
-        $this->priceIncludesTax = $priceIncludesTax;
     }
 
     public function amount(): int


### PR DESCRIPTION
Now we require PHP 8.1, we're safe to take advantage of constructor property promotion which was introduced in PHP 8.0 I believe.

This shouldn't make any difference to using Simple Commerce - it just makes Simple Commerce's code cleaner 🧹 