### PR TITLE
Fix bug that overwrites some data of original order

### DIFF
--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -251,7 +251,7 @@ class Order implements Contract
     {
         $this->isShipped(true);
 
-        $this->data([
+        $this->merge([
             'shipped_date'  => now()->format('Y-m-d H:i'),
         ]);
 


### PR DESCRIPTION
Previously with data method, cause an error ignoring some data from original order object.

For instance, when is used `markAsShipped`, the order number is overwrites.