### PR TITLE
Fix order shipped notification

### DIFF
--- a/resources/views/emails/customer_order_shipped.blade.php
+++ b/resources/views/emails/customer_order_shipped.blade.php
@@ -7,10 +7,7 @@ This email is to confirm that your recent order (**#{{ $order->orderNumber() }}*
 | Items       | Quantity         | Total |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
-@php
-$product = \DoubleThreeDigital\SimpleCommerce\Facades\Product::find($lineItem['product']);
-@endphp
-| [{{ $product->get('title') }}]({{ optional($product->resource())->absoluteUrl() }}) | {{ $lineItem['quantity'] }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem['total'], $site) }} |
+| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->total(), $site) }} |
 @endforeach
 | | Subtotal: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotal(), $site) }}
 @if($order->coupon())


### PR DESCRIPTION
This pull request fixes an issue where the Order Shipped email would error out. 

Some changes were made in #612 which changed the way Line Items worked behind the scenes, from being arrays to being `LineItem` objects for each line item.

The two other order notifications were updated in that PR but it doesn't look like the Order Shipped one was 🤷‍♂️ . It has been now.

Fixes #743