### PR TITLE
fix: fixed bug where custom fields where not filled for guest customers

### DIFF
--- a/src/Http/Controllers/CartController.php
+++ b/src/Http/Controllers/CartController.php
@@ -108,7 +108,8 @@ class CartController extends BaseActionController
 
                 $customer = Customer::make()
                     ->email($data['email'])
-                    ->data($customerData);
+                    ->data($customerData)
+                    ->merge(Arr::only($data, config('simple-commerce.field_whitelist.customers')));
 
                 $customer->save();
             }


### PR DESCRIPTION
After creating some custom fields for customers I noticed that the fields stayed empty after inserting orders.

Found out that only when a customer exists, the $data variable was compared to the field_whitelist.customers and merged with the customers model.

Fixed this by adding the merge function in the catch method when customer is guests and only an email exists.