### PR TITLE
Computed value for raw price

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4777,16 +4777,16 @@
         },
         {
             "name": "statamic/cms",
-            "version": "v3.3.34",
+            "version": "v3.3.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/statamic/cms.git",
-                "reference": "929a829bb5ea15194081a2c04641d585e8332b21"
+                "reference": "d7f3259da21dd6533d4a0a76fc118c50bbbfe171"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/statamic/cms/zipball/929a829bb5ea15194081a2c04641d585e8332b21",
-                "reference": "929a829bb5ea15194081a2c04641d585e8332b21",
+                "url": "https://api.github.com/repos/statamic/cms/zipball/d7f3259da21dd6533d4a0a76fc118c50bbbfe171",
+                "reference": "d7f3259da21dd6533d4a0a76fc118c50bbbfe171",
                 "shasum": ""
             },
             "require": {
@@ -4820,7 +4820,7 @@
                 "fakerphp/faker": "~1.10",
                 "google/cloud-translate": "^1.6",
                 "mockery/mockery": "^1.2.3",
-                "orchestra/testbench": "^6.7.0 || ^7.0"
+                "orchestra/testbench": "^6.18 || ^7.0"
             },
             "type": "library",
             "extra": {
@@ -4865,7 +4865,7 @@
             ],
             "support": {
                 "issues": "https://github.com/statamic/cms/issues",
-                "source": "https://github.com/statamic/cms/tree/v3.3.34"
+                "source": "https://github.com/statamic/cms/tree/v3.3.48"
             },
             "funding": [
                 {
@@ -4873,7 +4873,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-05T21:41:22+00:00"
+            "time": "2022-10-20T14:10:38+00:00"
         },
         {
             "name": "statamic/stringy",

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -139,7 +139,8 @@ class ServiceProvider extends AddonServiceProvider
             $this
                 ->bootStacheStores()
                 ->createNavItems()
-                ->registerPermissions();
+                ->registerPermissions()
+                ->registerComputedValues();
         });
 
         if (class_exists('Barryvdh\Debugbar\ServiceProvider') && config('debugbar.enabled', false) === true) {
@@ -434,6 +435,18 @@ class ServiceProvider extends AddonServiceProvider
         }
 
         return $this;
+    }
+
+    protected function registerComputedValues()
+    {
+        if (
+            $this->isOrExtendsClass(SimpleCommerce::productDriver()['repository'], \DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository::class)
+            && Statamic::version() >= '3.3.48'
+        ) {
+            Collection::computed(SimpleCommerce::productDriver()['collection'], 'raw_price', function ($entry, $value) {
+                return $entry->get('price');
+            });
+        }
     }
 
     protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -441,7 +441,6 @@ class ServiceProvider extends AddonServiceProvider
     {
         if (
             $this->isOrExtendsClass(SimpleCommerce::productDriver()['repository'], \DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository::class)
-            && Statamic::version() >= '3.3.48'
         ) {
             Collection::computed(SimpleCommerce::productDriver()['collection'], 'raw_price', function ($entry, $value) {
                 return $entry->get('price');

--- a/tests/ComputedValuesTest.php
+++ b/tests/ComputedValuesTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Tests;
+
+use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+
+class ComputedValuesTest extends TestCase
+{
+    use SetupCollections;
+
+    /** @test */
+    public function product_returns_with_raw_price_value()
+    {
+        $product = Product::make()->price(1500);
+        $product->save();
+
+        $this->assertSame(1500, $product->resource()->raw_price);
+    }
+}


### PR DESCRIPTION
This pull request takes advantage of Statamic's new [Computed Values](https://statamic.dev/computed-values) feature to allow for getting the 'raw price' of a product (the value in pence with no formatting).

You could previously do this yourself when using Antlers:

```antlers
{{ price | raw }}
```

However, there was no way to get it when getting the products via AJAX without somehow stripping away the formatting that's added to the main `price` field.

Related discussion: #747