### PR TITLE
Fixed offsite payments with the PayPal gateway

### DIFF
--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -163,8 +163,6 @@ class PayPalGateway extends BaseGateway implements Gateway
             return false;
         }
 
-        // $paypalOrderId = $order->gateway()['data']['id'];
-
         $paypalOrderId = isset($order->get('paypal')['result']['id'])
             ? $order->get('paypal')['result']['id']
             : null;

--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -163,7 +163,11 @@ class PayPalGateway extends BaseGateway implements Gateway
             return false;
         }
 
-        $paypalOrderId = $order->gateway()['data']['id'];
+        // $paypalOrderId = $order->gateway()['data']['id'];
+
+        $paypalOrderId = isset($order->get('paypal')['result']['id'])
+            ? $order->get('paypal')['result']['id']
+            : null;
 
         if (! $paypalOrderId) {
             throw new PayPalDetailsMissingOnOrderException("Order [{$order->id()}] does not have a PayPal Order ID.");


### PR DESCRIPTION
This pull request fixes an issue where you'd receive an error when checking out with the PayPal gateway in it's off-site mode. Fixes #755.

This fix is me reverting a change I did in 31d319b. In that commit, I change it to grab the payment ID from the `gateway` data array instead of the temporary `paypal` data that's added to order entries during checkout. 

However, due to there being no gateway data at the point of the callback happening, it would fail as reported. 