### PR TITLE
Add cart tag to get tax split by tax rate.

### DIFF
--- a/docs/tags/cart.md
+++ b/docs/tags/cart.md
@@ -1,5 +1,5 @@
 ---
-title: "Cart"
+title: 'Cart'
 ---
 
 ## Cart Information
@@ -31,8 +31,8 @@ To get the total quantity of products in the customers' cart, use `{{ sc:cart:qu
 
 When you're looping through line items, you may do some bits like this:
 
-- You can get the tax amount for the current line item with `{{ tax:amount }}`
-- You can get the total including tax with `{{ total_including_tax }}`
+-   You can get the tax amount for the current line item with `{{ tax:amount }}`
+-   You can get the total including tax with `{{ total_including_tax }}`
 
 ## Check if customer has a cart
 
@@ -48,13 +48,14 @@ This tag allows you to check if the current customer has a cart attached to them
 
 There's tags for each of the different totals in a cart.
 
-- `{{ sc:cart:total }}` - Returns the overall/grand total of the cart
-- `{{ sc:cart:grand_total }}` - Does the same thing as `sc:cart:total`
-- `{{ sc:cart:items_total }}` - Returns the total of all cart items.
-- `{{ sc:cart:shipping_total }}` - Returns the shipping total of the cart.
-- `{{ sc:cart:tax_total }}` - Returns the tax total of the cart.
-- `{{ sc:cart:coupon_total }}` - Returns the total amount saved from coupons.
-- `{{ sc:cart:itemsTotalWithTax }}` - Sums up both the items total & tax totals
+-   `{{ sc:cart:total }}` - Returns the overall/grand total of the cart
+-   `{{ sc:cart:grand_total }}` - Does the same thing as `sc:cart:total`
+-   `{{ sc:cart:items_total }}` - Returns the total of all cart items.
+-   `{{ sc:cart:shipping_total }}` - Returns the shipping total of the cart.
+-   `{{ sc:cart:tax_total }}` - Returns the tax total of the cart.
+-   `{{ sc:cart:tax_total_split }}` - Returns the tax total of the cart, split by tax rate.
+-   `{{ sc:cart:coupon_total }}` - Returns the total amount saved from coupons.
+-   `{{ sc:cart:itemsTotalWithTax }}` - Sums up both the items total & tax totals
 
 If you need the 'raw' value for any of these totals, meaning the integer, rather than the formatted currency amount, you can do this: `{{ sc:cart:raw_grand_total }}`.
 
@@ -72,9 +73,9 @@ If you find yourself needing to check if an order is 'free' (grand total is £0)
 
 This tag allows you to add a product/variant to your cart. It's a [form tag](/tags#form-tags) so you need to provide a couple of parameters (form fields) when submitting:
 
-- `product` - The ID of the product you want to add to the cart.
-- `variant` - If applicable, the key of the variant you wish to add to the cart. Bear in mind, you will also need to provide the `product` with this.
-- `quantity` - The quantity of the cart item you're adding.
+-   `product` - The ID of the product you want to add to the cart.
+-   `variant` - If applicable, the key of the variant you wish to add to the cart. Bear in mind, you will also need to provide the `product` with this.
+-   `quantity` - The quantity of the cart item you're adding.
 
 ```antlers
 {{ sc:cart:addItem }}

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -144,7 +144,7 @@ class CartTags extends SubTag
 
     public function taxTotalSplit()
     {
-        $taxSplit = $this->rawTaxTotalSplit()->map(function($tax) {
+        $taxSplit = $this->rawTaxTotalSplit()->map(function ($tax) {
             $tax['amount'] = Currency::parse($tax['amount'], Site::current());
 
             return $tax;
@@ -156,12 +156,12 @@ class CartTags extends SubTag
     public function rawTaxTotalSplit()
     {
         $items = $this->items();
-        $taxSplit = $items->groupBy(function($item) {
+        $taxSplit = $items->groupBy(function ($item) {
             return $item['tax']->value()['rate'];
-        })->map(function($group, $groupRate) {
+        })->map(function ($group, $groupRate) {
             return [
                 'rate' => $groupRate,
-                'amount' => $group->sum(function($item) {
+                'amount' => $group->sum(function ($item) {
                     return $item['tax']->raw()['amount'];
                 }),
             ];

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -142,6 +142,34 @@ class CartTags extends SubTag
         return 0;
     }
 
+    public function taxTotalSplit()
+    {
+        $taxSplit = $this->rawTaxTotalSplit()->map(function($tax) {
+            $tax['amount'] = Currency::parse($tax['amount'], Site::current());
+
+            return $tax;
+        });
+
+        return $taxSplit;
+    }
+
+    public function rawTaxTotalSplit()
+    {
+        $items = $this->items();
+        $taxSplit = $items->groupBy(function($item) {
+            return $item['tax']->value()['rate'];
+        })->map(function($group, $groupRate) {
+            return [
+                'rate' => $groupRate,
+                'amount' => $group->sum(function($item) {
+                    return $item['tax']->raw()['amount'];
+                }),
+            ];
+        })->values();
+
+        return $taxSplit;
+    }
+
     public function couponTotal()
     {
         if ($this->hasCart()) {

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -5,6 +5,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Tags;
 use DoubleThreeDigital\SimpleCommerce\Currency;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Statamic\Facades\Site;
 
@@ -142,32 +143,30 @@ class CartTags extends SubTag
         return 0;
     }
 
-    public function taxTotalSplit()
+    public function taxTotalSplit(): Collection
     {
-        $taxSplit = $this->rawTaxTotalSplit()->map(function ($tax) {
+        return $this->rawTaxTotalSplit()->map(function ($tax) {
             $tax['amount'] = Currency::parse($tax['amount'], Site::current());
 
             return $tax;
         });
-
-        return $taxSplit;
     }
 
-    public function rawTaxTotalSplit()
+    public function rawTaxTotalSplit(): Collection
     {
-        $items = $this->items();
-        $taxSplit = $items->groupBy(function ($item) {
-            return $item['tax']->value()['rate'];
-        })->map(function ($group, $groupRate) {
-            return [
-                'rate' => $groupRate,
-                'amount' => $group->sum(function ($item) {
-                    return $item['tax']->raw()['amount'];
-                }),
-            ];
-        })->values();
-
-        return $taxSplit;
+        return $this->items()
+            ->groupBy(function ($item) {
+                return $item['tax']->value()['rate'];
+            })
+            ->map(function ($group, $groupRate) {
+                return [
+                    'rate' => $groupRate,
+                    'amount' => $group->sum(function ($item) {
+                        return $item['tax']->raw()['amount'];
+                    }),
+                ];
+            })
+            ->values();
     }
 
     public function couponTotal()

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -284,7 +284,6 @@ class CartTagTest extends TestCase
             ->zone($taxZone->id());
         $taxRateDefault->save();
 
-
         // Create reduced tax
         $taxCategoryReduced = TaxCategory::make()
             ->id('reduced-vat')
@@ -298,7 +297,6 @@ class CartTagTest extends TestCase
             ->category($taxCategoryReduced->id())
             ->zone($taxZone->id());
         $taxRateReduced->save();
-
 
         // Create test products
         $product1 = Product::make()
@@ -324,7 +322,6 @@ class CartTagTest extends TestCase
                 'title' => 'Elephant Food',
             ]);
         $product3->save();
-
 
         // Create face cart
         $cart = Order::make()->lineItems([


### PR DESCRIPTION
Depending on local rights, the order taxes have to be shown split by tax rate, e. g. 7% -> 4,55€: 19% -> 15,21€. The new tag allows just this, and comes with a variant to get also the raw values.

Also the documentation includes the new tag.