### PR TITLE
Allow for translating order emails

### DIFF
--- a/resources/views/emails/backoffice_order_paid.blade.php
+++ b/resources/views/emails/backoffice_order_paid.blade.php
@@ -1,39 +1,41 @@
 @component('mail::message')
-# New Order
+# {{ __('New Order') }}
 
-This email is to confirm that a new order has been placed. An overview of the order is shown below:
+{{ __('This email is to confirm that a new order has been placed. An overview of the order is shown below:') }}
 
-**Order Number:** #{{ $order->orderNumber() }}
+**{{ __('Order Number') }}:** #{{ $order->orderNumber() }}
 
 @component('mail::table')
-| Items       | Quantity         | Total |
+| {{ __('Items') }}       | {{ __('Quantity') }}         | {{ __('Total') }} |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
 | [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->total(), $site) }} |
 @endforeach
-| | Subtotal: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotal(), $site) }}
+| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotal(), $site) }}
 @if($order->coupon())
-| | Coupon: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
+| | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
-| | Shipping: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotal(), $site) }}
-| | Tax: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
-| | **Total:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
+| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotal(), $site) }}
+| | {{ __('Tax') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
+| | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent
 
-## Customer Details
+## {{ __('Customer Details') }}
 
 @if($order->customer())
-* **Name:** {{ $order->customer()->name() }}
-* **Email:** {{ $order->customer()->email() }}
-@endif
-@if($order->billingAddress())
-* **Billing Address:** {{ $order->billingAddress()->__toString() }}
-@endif
-@if($order->shippingAddress())
-* **Shipping Address:** {{ $order->shippingAddress()->__toString() }}
+* **{{ __('Name') }}:** {{ $order->customer()->name() }}
+* **{{ __('Email') }}:** {{ $order->customer()->email() }}
 @endif
 
-Thanks,<br>
+@if($order->billingAddress())
+* **{{ __('Billing Address') }}:** {{ $order->billingAddress()->__toString() }}
+@endif
+
+@if($order->shippingAddress())
+* **{{ __('Shipping Address') }}:** {{ $order->shippingAddress()->__toString() }}
+@endif
+
+{{ __('Thanks') }},<br>
 {{ config('app.name') }}
 @endcomponent

--- a/resources/views/emails/customer_order_paid.blade.php
+++ b/resources/views/emails/customer_order_paid.blade.php
@@ -1,43 +1,45 @@
 @component('mail::message')
-# Order Confirmation
+# {{ __('Order Confirmation') }}
 
-This email is to confirm that your order (**#{{ $order->orderNumber() }}**) has been marked as paid. An overview of your order is shown below:
+{{ __('This email is to confirm that your order (**#:orderNumber**) has been marked as paid. An overview of your order is shown below:', [
+    'orderNumber' => $order->orderNumber(),
+]) }}
 
 @component('mail::table')
-| Items       | Quantity         | Total |
+| {{ __('Items') }}       | {{ __('Quantity') }}         | {{ __('Total') }} |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
 | [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->total(), $site) }} |
 @endforeach
-| | Subtotal: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotal(), $site) }}
+| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotal(), $site) }}
 @if($order->coupon())
-| | Coupon: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
+| | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
-| | Shipping: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotal(), $site) }}
-| | Tax: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
-| | **Total:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
+| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotal(), $site) }}
+| | {{ __('Tax') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
+| | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent
 
-## Customer Details
+## {{ __('Customer Details') }}
 
 @if($order->customer())
-* **Name:** {{ $order->customer()->name() }}
-* **Email:** {{ $order->customer()->email() }}
+* **{{ __('Name') }}:** {{ $order->customer()->name() }}
+* **{{ __('Email') }}:** {{ $order->customer()->email() }}
 @endif
 
 @if($order->billingAddress())
-* **Billing Address:** {{ $order->billingAddress()->__toString() }}
+* **{{ __('Billing Address') }}:** {{ $order->billingAddress()->__toString() }}
 @endif
 
 @if($order->shippingAddress())
-* **Shipping Address:** {{ $order->shippingAddress()->__toString() }}
+* **{{ __('Shipping Address') }}:** {{ $order->shippingAddress()->__toString() }}
 @endif
 
 <br>
 
-If you have any questions about your order, please get in touch.
+{{ __('If you have any questions about your order, please get in touch.') }}
 
-Thanks,<br>
+{{ __('Thanks') }},<br>
 {{ config('app.name') }}
 @endcomponent

--- a/resources/views/emails/customer_order_shipped.blade.php
+++ b/resources/views/emails/customer_order_shipped.blade.php
@@ -1,43 +1,45 @@
 @component('mail::message')
-# Order Shipped
+# {{ __('Order Shipped') }}
 
-This email is to confirm that your recent order (**#{{ $order->orderNumber() }}**) has been marked as shipped. An overview of your order is shown below:
+{{ __('This email is to confirm that your order (**#:orderNumber**) has been marked as shipped. An overview of your order is shown below:', [
+    'orderNumber' => $order->orderNumber(),
+]) }}
 
 @component('mail::table')
-| Items       | Quantity         | Total |
+| {{ __('Items') }}       | {{ __('Quantity') }}         | {{ __('Total') }} |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
 | [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->total(), $site) }} |
 @endforeach
-| | Subtotal: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotal(), $site) }}
+| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotal(), $site) }}
 @if($order->coupon())
-| | Coupon: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
+| | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
-| | Shipping: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotal(), $site) }}
-| | Tax: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
-| | **Total:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
+| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotal(), $site) }}
+| | {{ __('Tax') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
+| | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent
 
-## Customer Details
+## {{ __('Customer Details') }}
 
 @if($order->customer())
-* **Name:** {{ $order->customer()->name() }}
-* **Email:** {{ $order->customer()->email() }}
+* **{{ __('Name') }}:** {{ $order->customer()->name() }}
+* **{{ __('Email') }}:** {{ $order->customer()->email() }}
 @endif
 
 @if($order->billingAddress())
-* **Billing Address:** {{ $order->billingAddress()->__toString() }}
+* **{{ __('Billing Address') }}:** {{ $order->billingAddress()->__toString() }}
 @endif
 
 @if($order->shippingAddress())
-* **Shipping Address:** {{ $order->shippingAddress()->__toString() }}
+* **{{ __('Shipping Address') }}:** {{ $order->shippingAddress()->__toString() }}
 @endif
 
 <br>
 
-If you have any questions about your order, please get in touch.
+{{ __('If you have any questions about your order, please get in touch.') }}
 
-Thanks,<br>
+{{ __('Thanks') }},<br>
 {{ config('app.name') }}
 @endcomponent

--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -14,6 +14,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Http\Resources\API\EntryResource;
+use Statamic\Sites\Site;
 
 class Customer implements Contract
 {
@@ -42,6 +43,15 @@ class Customer implements Contract
         return $this
             ->fluentlyGetOrSet('resource')
             ->args(func_get_args());
+    }
+
+    public function site(): ?Site
+    {
+        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EntryOrderRepository::class)) {
+            return $this->resource()->site();
+        }
+
+        return null;
     }
 
     public function name(): ?string

--- a/src/Listeners/SendConfiguredNotifications.php
+++ b/src/Listeners/SendConfiguredNotifications.php
@@ -25,11 +25,17 @@ class SendConfiguredNotifications implements ShouldQueue
             return;
         }
 
+        $locale = $event->order->site()
+            ? $event->order->site()->locale()
+            : config('app.locale');
+
         foreach ($notifications as $notification => $config) {
             $freshNotification = null;
 
             $notifiables = $this->getNotifiables($config, $notification, $event);
+
             $notification = new $notification(...$this->getNotificationParameters($config, $notification, $event));
+            $notification->locale($locale);
 
             if (! $notifiables) {
                 break;

--- a/src/Notifications/BackOfficeOrderPaid.php
+++ b/src/Notifications/BackOfficeOrderPaid.php
@@ -6,7 +6,6 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
-use Statamic\Facades\Site;
 
 class BackOfficeOrderPaid extends Notification
 {
@@ -42,15 +41,11 @@ class BackOfficeOrderPaid extends Notification
      */
     public function toMail($notifiable)
     {
-        if ($site = $this->order->site()) {
-            $this->locale($site->locale());
-        }
-
         return (new MailMessage)
             ->subject(config('app.name') . ': New Order')
             ->markdown('simple-commerce::emails.backoffice_order_paid', [
                 'order' => $this->order,
-                'site' => $site,
+                'site' => $this->order->site(),
             ]);
     }
 }

--- a/src/Notifications/BackOfficeOrderPaid.php
+++ b/src/Notifications/BackOfficeOrderPaid.php
@@ -42,11 +42,15 @@ class BackOfficeOrderPaid extends Notification
      */
     public function toMail($notifiable)
     {
+        if ($site = $this->order->site()) {
+            $this->locale($site->locale());
+        }
+
         return (new MailMessage)
             ->subject(config('app.name') . ': New Order')
             ->markdown('simple-commerce::emails.backoffice_order_paid', [
                 'order' => $this->order,
-                'site' => Site::current(),
+                'site' => $site,
             ]);
     }
 }

--- a/src/Notifications/CustomerOrderPaid.php
+++ b/src/Notifications/CustomerOrderPaid.php
@@ -41,15 +41,11 @@ class CustomerOrderPaid extends Notification
      */
     public function toMail($notifiable)
     {
-        if ($site = $this->order->site()) {
-            $this->locale($site->locale());
-        }
-
         return (new MailMessage)
             ->subject(config('app.name') . ': Order Confirmation')
             ->markdown('simple-commerce::emails.customer_order_paid', [
                 'order' => $this->order,
-                'site' => $site,
+                'site' => $this->order->site(),
             ]);
     }
 }

--- a/src/Notifications/CustomerOrderPaid.php
+++ b/src/Notifications/CustomerOrderPaid.php
@@ -6,7 +6,6 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
-use Statamic\Facades\Site;
 
 class CustomerOrderPaid extends Notification
 {
@@ -42,11 +41,15 @@ class CustomerOrderPaid extends Notification
      */
     public function toMail($notifiable)
     {
+        if ($site = $this->order->site()) {
+            $this->locale($site->locale());
+        }
+
         return (new MailMessage)
             ->subject(config('app.name') . ': Order Confirmation')
             ->markdown('simple-commerce::emails.customer_order_paid', [
                 'order' => $this->order,
-                'site' => Site::current(),
+                'site' => $site,
             ]);
     }
 }

--- a/src/Notifications/CustomerOrderShipped.php
+++ b/src/Notifications/CustomerOrderShipped.php
@@ -6,7 +6,6 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
-use Statamic\Facades\Site;
 
 class CustomerOrderShipped extends Notification
 {
@@ -42,11 +41,15 @@ class CustomerOrderShipped extends Notification
      */
     public function toMail($notifiable)
     {
+        if ($site = $this->order->site()) {
+            $this->locale($site->locale());
+        }
+
         return (new MailMessage)
             ->subject(config('app.name') . ': Order Confirmation')
             ->markdown('simple-commerce::emails.customer_order_shipped', [
                 'order' => $this->order,
-                'site' => Site::current(),
+                'site' => $site,
             ]);
     }
 }

--- a/src/Notifications/CustomerOrderShipped.php
+++ b/src/Notifications/CustomerOrderShipped.php
@@ -41,15 +41,11 @@ class CustomerOrderShipped extends Notification
      */
     public function toMail($notifiable)
     {
-        if ($site = $this->order->site()) {
-            $this->locale($site->locale());
-        }
-
         return (new MailMessage)
             ->subject(config('app.name') . ': Order Confirmation')
             ->markdown('simple-commerce::emails.customer_order_shipped', [
                 'order' => $this->order,
-                'site' => $site,
+                'site' => $this->order->site(),
             ]);
     }
 }

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Http\Resources\API\EntryResource;
+use Statamic\Sites\Site;
 
 class Order implements Contract
 {
@@ -191,6 +192,15 @@ class Order implements Contract
         return $this
             ->fluentlyGetOrSet('resource')
             ->args(func_get_args());
+    }
+
+    public function site(): ?Site
+    {
+        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EntryOrderRepository::class)) {
+            return $this->resource()->site();
+        }
+
+        return null;
     }
 
     public function billingAddress(): ?Address
@@ -404,5 +414,11 @@ class Order implements Contract
         }
 
         return [];
+    }
+
+    protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool
+    {
+        return is_subclass_of($class, $classToCheckAgainst)
+            || $class === $classToCheckAgainst;
     }
 }

--- a/src/Products/Product.php
+++ b/src/Products/Product.php
@@ -6,10 +6,12 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Product as Contract;
 use DoubleThreeDigital\SimpleCommerce\Data\HasData;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product as ProductFacade;
 use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory as TaxCategoryFacade;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxCategory;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Statamic\Http\Resources\API\EntryResource;
+use Statamic\Sites\Site;
 
 class Product implements Contract
 {
@@ -96,6 +98,15 @@ class Product implements Contract
         return $this
             ->fluentlyGetOrSet('resource')
             ->args(func_get_args());
+    }
+
+    public function site(): ?Site
+    {
+        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EntryOrderRepository::class)) {
+            return $this->resource()->site();
+        }
+
+        return null;
     }
 
     public function purchasableType(): ProductType
@@ -199,5 +210,11 @@ class Product implements Contract
             $this->toArray(),
             $augmentedData,
         );
+    }
+
+    protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool
+    {
+        return is_subclass_of($class, $classToCheckAgainst)
+            || $class === $classToCheckAgainst;
     }
 }


### PR DESCRIPTION
This pull request makes it possible to translate the order emails that are sent automatically by Simple Commerce.

All of the 'strings' in the order emails are wrapped in Laravel's `__()` helper - allowing for the individual strings to be overridden in a `lang/{locale}.json` file like this:

```json
{
    "This email is to confirm that your order (**#:orderNumber**) has been marked as paid. An overview of your order is shown below:": "Diese E-Mail dient dazu, zu bestätigen, dass Ihre Bestellung (**#:orderNumber**) als bezahlt markiert wurde.",
    "Customer Details": "Kunde",
    "If you have any questions about your order, please get in touch.": "Wenn Sie Fragen zu Ihrer Bestellung haben, wenden Sie sich bitte an uns."
}
```

^ example above in German (`lang/de_de.json`)

Any notifications triggered by Simple Commerce will be sent in the locale of the site the order was created in. So, if an order is created in your German variation of a site, the emails will use the associated locale.

Fixes #768