### PR TITLE
Enforce 'Orders' field on customer blueprints

### DIFF
--- a/src/Listeners/EnforceBlueprintFields.php
+++ b/src/Listeners/EnforceBlueprintFields.php
@@ -2,6 +2,11 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Listeners;
 
+use DoubleThreeDigital\SimpleCommerce\Customers\EloquentCustomerRepository;
+use DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository;
+use DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository;
+use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
+use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Statamic\Events\EntryBlueprintFound;
 use Statamic\Fields\Blueprint;
@@ -10,8 +15,21 @@ class EnforceBlueprintFields
 {
     public function handle(EntryBlueprintFound $event)
     {
+        $customerDriver = SimpleCommerce::customerDriver();
         $productDriver = SimpleCommerce::productDriver();
         $orderDriver = SimpleCommerce::orderDriver();
+
+        if ($this->isOrExtendsClass($customerDriver['repository'], EntryCustomerRepository::class)) {
+            return $this->enforceCustomerFields($event);
+        }
+
+        if ($this->isOrExtendsClass($customerDriver['repository'], UserCustomerRepository::class)) {
+            return $this->enforceCustomerFields($event);
+        }
+
+        if ($this->isOrExtendsClass($customerDriver['repository'], EloquentCustomerRepository::class)) {
+            return $this->enforceCustomerFields($event);
+        }
 
         if (isset($productDriver['collection']) && $event->blueprint->namespace() === "collections.{$productDriver['collection']}") {
             return $this->enforceProductFields($event);
@@ -20,6 +38,39 @@ class EnforceBlueprintFields
         if (isset($orderDriver['collection']) && $event->blueprint->namespace() === "collections.{$orderDriver['collection']}") {
             return $this->enforceOrderFields($event);
         }
+    }
+
+    protected function enforceCustomerFields($event): Blueprint
+    {
+        $orderDriver = SimpleCommerce::orderDriver();
+
+        if ($this->isOrExtendsClass($orderDriver['repository'], EntryOrderRepository::class)) {
+            if (! $event->blueprint->hasField('orders')) {
+                $event->blueprint->ensureField('orders', [
+                    'type' => 'entries',
+                    'display' => __('Orders'),
+                    'mode' => 'default',
+                    'collections' => [
+                        $orderDriver['collection'],
+                    ],
+                    'create' => false,
+                ]);
+            }
+        }
+
+        if ($this->isOrExtendsClass($orderDriver['repository'], EloquentOrderRepository::class)) {
+            if (! $event->blueprint->hasField('orders')) {
+                $event->blueprint->ensureField('orders', [
+                    'type' => 'has_many',
+                    'display' => __('Orders'),
+                    'mode' => 'default',
+                    'resource' => 'orders',
+                    'create' => false,
+                ]);
+            }
+        }
+
+        return $event->blueprint;
     }
 
     protected function enforceProductFields($event): Blueprint
@@ -81,5 +132,11 @@ class EnforceBlueprintFields
         ]);
 
         return $event->blueprint;
+    }
+
+    protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool
+    {
+        return is_subclass_of($class, $classToCheckAgainst)
+            || $class === $classToCheckAgainst;
     }
 }


### PR DESCRIPTION
This pull request ensures that an 'Orders' field is added to the customer blueprint when using the Entry/User customer repositories. 

The Orders fieldtype will vary depending on the current orders repository in use.