### PR TITLE
v5.0: Rename 'Standard Post' shipping method to 'Free Shipping'

### DIFF
--- a/config/simple-commerce.php
+++ b/config/simple-commerce.php
@@ -20,7 +20,7 @@ return [
 
             'shipping' => [
                 'methods' => [
-                    \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class => [],
+                    \DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping::class => [],
                 ],
             ],
         ],

--- a/docs/multisite.md
+++ b/docs/multisite.md
@@ -30,7 +30,7 @@ Each Statamic site you have setup in your `config/statamic/sites.php` config sho
 
         'shipping' => [
             'methods' => [
-                \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class,
+                \DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping::class,
             ],
         ],
     ],

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -17,7 +17,7 @@ Shipping Methods can be configured on a site-by-site basis, helpful for if you h
 
         'shipping' => [
             'methods' => [
-                \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class => [],
+                \DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping::class => [],
             ],
         ],
     ],
@@ -40,10 +40,10 @@ In these cases, you may configure a default Shipping Method which will be used w
         ...
 
         'shipping' => [
-            'default_method' => \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class,
+            'default_method' => \DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping::class,
 
             'methods' => [
-                \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class => [],
+                \DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping::class => [],
             ],
         ],
     ],

--- a/src/Shipping/FreeShipping.php
+++ b/src/Shipping/FreeShipping.php
@@ -6,21 +6,21 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\Orders\Address;
 
-class StandardPost extends BaseShippingMethod implements ShippingMethod
+class FreeShipping extends BaseShippingMethod implements ShippingMethod
 {
     public function name(): string
     {
-        return __('Standard Post');
+        return __('Free Shipping');
     }
 
     public function description(): string
     {
-        return __('Posted through the national post service. Usually delivered within 1-2 working days.');
+        return __("You don't need to pay for shipping, since it's free!");
     }
 
     public function calculateCost(Order $order): int
     {
-        return 100;
+        return 0;
     }
 
     public function checkAvailability(Order $order, Address $address): bool

--- a/tests/Fieldtypes/ShippingMethodFieldtypeTest.php
+++ b/tests/Fieldtypes/ShippingMethodFieldtypeTest.php
@@ -3,7 +3,7 @@
 namespace DoubleThreeDigital\SimpleCommerce\Tests\Fieldtypes;
 
 use DoubleThreeDigital\SimpleCommerce\Fieldtypes\ShippingMethodFieldtype;
-use DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost;
+use DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping;
 use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\Invader;
 use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
 use Illuminate\Http\Request;
@@ -37,7 +37,7 @@ class ShippingMethodFieldtypeTest extends TestCase
         $this->assertTrue($getIndexItems instanceof Collection);
 
         $this->assertSame($getIndexItems->last(), [
-            'id' => StandardPost::class,
+            'id' => FreeShipping::class,
             'name' => 'Standard Post',
             'title' => 'Standard Post',
         ]);
@@ -58,12 +58,12 @@ class ShippingMethodFieldtypeTest extends TestCase
     /** @test */
     public function can_return_as_item_array()
     {
-        $toItemArray = $this->fieldtype->toItemArray(StandardPost::class);
+        $toItemArray = $this->fieldtype->toItemArray(FreeShipping::class);
 
         $this->assertIsArray($toItemArray);
 
         $this->assertSame($toItemArray, [
-            'id' => StandardPost::class,
+            'id' => FreeShipping::class,
             'title' => 'Standard Post',
         ]);
     }
@@ -71,7 +71,7 @@ class ShippingMethodFieldtypeTest extends TestCase
     /** @test */
     public function can_preprocess_index()
     {
-        $preProcessIndex = $this->fieldtype->preProcessIndex(StandardPost::class);
+        $preProcessIndex = $this->fieldtype->preProcessIndex(FreeShipping::class);
 
         $this->assertIsString($preProcessIndex);
         $this->assertSame($preProcessIndex, 'Standard Post');

--- a/tests/Fieldtypes/ShippingMethodFieldtypeTest.php
+++ b/tests/Fieldtypes/ShippingMethodFieldtypeTest.php
@@ -38,8 +38,8 @@ class ShippingMethodFieldtypeTest extends TestCase
 
         $this->assertSame($getIndexItems->last(), [
             'id' => FreeShipping::class,
-            'name' => 'Standard Post',
-            'title' => 'Standard Post',
+            'name' => 'Free Shipping',
+            'title' => 'Free Shipping',
         ]);
     }
 
@@ -64,7 +64,7 @@ class ShippingMethodFieldtypeTest extends TestCase
 
         $this->assertSame($toItemArray, [
             'id' => FreeShipping::class,
-            'title' => 'Standard Post',
+            'title' => 'Free Shipping',
         ]);
     }
 
@@ -74,7 +74,7 @@ class ShippingMethodFieldtypeTest extends TestCase
         $preProcessIndex = $this->fieldtype->preProcessIndex(FreeShipping::class);
 
         $this->assertIsString($preProcessIndex);
-        $this->assertSame($preProcessIndex, 'Standard Post');
+        $this->assertSame($preProcessIndex, 'Free Shipping');
     }
 
     /** @test */

--- a/tests/Tags/ShippingTagsTest.php
+++ b/tests/Tags/ShippingTagsTest.php
@@ -55,7 +55,7 @@ class ShippingTagsTest extends TestCase
         $this->assertIsArray($usage);
         $this->assertCount(2, $usage);
 
-        $this->assertSame($usage[0]['name'], 'Standard Post');
+        $this->assertSame($usage[0]['name'], 'Free Shipping');
         $this->assertSame($usage[1]['name'], 'Royal Mail');
     }
 
@@ -88,7 +88,7 @@ class ShippingTagsTest extends TestCase
         $this->assertIsArray($usage);
         $this->assertCount(3, $usage);
 
-        $this->assertSame($usage[0]['name'], 'Standard Post');
+        $this->assertSame($usage[0]['name'], 'Free Shipping');
         $this->assertSame($usage[1]['name'], 'Royal Mail');
         $this->assertSame($usage[2]['name'], 'Store Pickup - Glasgow');
     }


### PR DESCRIPTION
This pull request changes the name of the built-in shipping method to 'Free Shipping'. 

Changing the default shipping method to be a free one makes more sense than a generic one that no-one will use. Some people will at least use a free shipping method.

