### PR TITLE
Fix issue where orders field was being added to every blueprint

### DIFF
--- a/src/Listeners/EnforceEntryBlueprintFields.php
+++ b/src/Listeners/EnforceEntryBlueprintFields.php
@@ -2,9 +2,7 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Listeners;
 
-use DoubleThreeDigital\SimpleCommerce\Customers\EloquentCustomerRepository;
 use DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository;
-use DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository;
 use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
 use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;

--- a/src/Listeners/EnforceEntryBlueprintFields.php
+++ b/src/Listeners/EnforceEntryBlueprintFields.php
@@ -11,7 +11,7 @@ use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Statamic\Events\EntryBlueprintFound;
 use Statamic\Fields\Blueprint;
 
-class EnforceBlueprintFields
+class EnforceEntryBlueprintFields
 {
     public function handle(EntryBlueprintFound $event)
     {
@@ -19,15 +19,10 @@ class EnforceBlueprintFields
         $productDriver = SimpleCommerce::productDriver();
         $orderDriver = SimpleCommerce::orderDriver();
 
-        if ($this->isOrExtendsClass($customerDriver['repository'], EntryCustomerRepository::class)) {
-            return $this->enforceCustomerFields($event);
-        }
-
-        if ($this->isOrExtendsClass($customerDriver['repository'], UserCustomerRepository::class)) {
-            return $this->enforceCustomerFields($event);
-        }
-
-        if ($this->isOrExtendsClass($customerDriver['repository'], EloquentCustomerRepository::class)) {
+        if (
+            $this->isOrExtendsClass($customerDriver['repository'], EntryCustomerRepository::class)
+            && $event->blueprint->namespace() === "collections.{$customerDriver['collection']}"
+        ) {
             return $this->enforceCustomerFields($event);
         }
 

--- a/src/Listeners/EnforceUserBlueprintFields.php
+++ b/src/Listeners/EnforceUserBlueprintFields.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Listeners;
+
+use DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository;
+use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
+use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Statamic\Events\UserBlueprintFound;
+use Statamic\Fields\Blueprint;
+
+class EnforceUserBlueprintFields
+{
+    public function handle(UserBlueprintFound $event)
+    {
+        $customerDriver = SimpleCommerce::customerDriver();
+
+        if ($this->isOrExtendsClass($customerDriver['repository'], UserCustomerRepository::class)) {
+            return $this->enforceCustomerFields($event);
+        }
+    }
+
+    protected function enforceCustomerFields($event): Blueprint
+    {
+        $orderDriver = SimpleCommerce::orderDriver();
+
+        if ($this->isOrExtendsClass($orderDriver['repository'], EntryOrderRepository::class)) {
+            if (! $event->blueprint->hasField('orders')) {
+                $event->blueprint->ensureField('orders', [
+                    'type' => 'entries',
+                    'display' => __('Orders'),
+                    'mode' => 'default',
+                    'collections' => [
+                        $orderDriver['collection'],
+                    ],
+                    'create' => false,
+                ]);
+            }
+        }
+
+        if ($this->isOrExtendsClass($orderDriver['repository'], EloquentOrderRepository::class)) {
+            if (! $event->blueprint->hasField('orders')) {
+                $event->blueprint->ensureField('orders', [
+                    'type' => 'has_many',
+                    'display' => __('Orders'),
+                    'mode' => 'default',
+                    'resource' => 'orders',
+                    'create' => false,
+                ]);
+            }
+        }
+
+        return $event->blueprint;
+    }
+
+    protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool
+    {
+        return is_subclass_of($class, $classToCheckAgainst)
+            || $class === $classToCheckAgainst;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -6,6 +6,7 @@ use Barryvdh\Debugbar\Facade as Debugbar;
 use Illuminate\Foundation\Console\AboutCommand;
 use Statamic\CP\Navigation\NavItem;
 use Statamic\Events\EntryBlueprintFound;
+use Statamic\Events\UserBlueprintFound;
 use Statamic\Facades\Collection;
 use Statamic\Facades\CP\Nav;
 use Statamic\Facades\Permission;
@@ -49,8 +50,11 @@ class ServiceProvider extends AddonServiceProvider
 
     protected $listen = [
         EntryBlueprintFound::class  => [
-            Listeners\EnforceBlueprintFields::class,
+            Listeners\EnforceEntryBlueprintFields::class,
             Listeners\AddHiddenFields::class,
+        ],
+        UserBlueprintFound::class => [
+            Listeners\EnforceUserBlueprintFields::class,
         ],
         Events\PostCheckout::class => [
             Listeners\TidyTemporaryGatewayData::class,


### PR DESCRIPTION
This pull request fixes an issue where an Orders relationship field was being added to every entry blueprint, instead of being added to *just* the Customer entries.

Introduced by #772. Fixes #785.