### PR TITLE
Add support for separate first & last name fields on `Address`

### DIFF
--- a/src/Orders/Address.php
+++ b/src/Orders/Address.php
@@ -4,10 +4,13 @@ namespace DoubleThreeDigital\SimpleCommerce\Orders;
 
 use DoubleThreeDigital\SimpleCommerce\Countries;
 use DoubleThreeDigital\SimpleCommerce\Regions;
+use Illuminate\Support\Arr;
 
 class Address
 {
     protected static $name;
+    protected static $firstName;
+    protected static $lastName;
     protected static $addressLine1;
     protected static $addressLine2;
     protected static $city;
@@ -19,6 +22,8 @@ class Address
     public static function from(string $addressType, $data): self
     {
         static::$name = $data->get("{$addressType}_name");
+        static::$firstName = $data->get("{$addressType}_first_name");
+        static::$lastName = $data->get("{$addressType}_last_name");
         static::$addressLine1 = $data->get("{$addressType}_address") ?? $data->get("{$addressType}_address_line1");
         static::$addressLine2 = $data->get("{$addressType}_address_line2");
         static::$city = $data->get("{$addressType}_city");
@@ -29,9 +34,28 @@ class Address
         return new static;
     }
 
+    public function fullName(): ?string
+    {
+        if (static::$firstName && static::$lastName) {
+            return static::$firstName . ' ' . static::$lastName;
+        }
+
+        return static::$name;
+    }
+
     public function name(): ?string
     {
         return static::$name;
+    }
+
+    public function firstName(): ?string
+    {
+        return static::$firstName;
+    }
+
+    public function lastName(): ?string
+    {
+        return static::$lastName;
     }
 
     public function addressLine1(): ?string
@@ -88,6 +112,8 @@ class Address
     {
         return [
             'name'           => $this->name(),
+            'first_name'     => $this->firstName(),
+            'last_name'      => $this->lastName(),
             'address_line_1' => $this->addressLine1(),
             'address_line_2' => $this->addressLine2(),
             'city'           => $this->city(),
@@ -99,7 +125,10 @@ class Address
 
     public function __toString()
     {
-        return collect($this->toArray())
+        $toArray = Arr::except($this->toArray(), ['name', 'first_name', 'last_name']);
+        $toArray = collect(['name' => $this->fullName()])->merge($toArray)->toArray();
+
+        return collect($toArray)
             ->values()
             ->reject(function ($value) {
                 return empty($value);

--- a/tests/Orders/AddressTest.php
+++ b/tests/Orders/AddressTest.php
@@ -28,6 +28,39 @@ class AddressTest extends TestCase
 
         $this->assertSame($address->toArray(), [
             'name' => 'John Smith',
+            'first_name' => null,
+            'last_name' => null,
+            'address_line_1' => '11 Test Street',
+            'address_line_2' => null,
+            'city' => 'Glasgow',
+            'region' => Regions::find('gb-sct'),
+            'country' => Countries::find('GB'),
+            'zip_code' => 'G11 222',
+        ]);
+    }
+
+    /** @test */
+    public function can_get_address_as_array_with_first_name_and_last_name()
+    {
+        $order = Order::make()
+            ->merge([
+                'billing_first_name' => 'John',
+                'billing_last_name' => 'Doe',
+                'billing_address' => '11 Test Street',
+                'billing_city' => 'Glasgow',
+                'billing_country' => 'GB',
+                'billing_zip_code' => 'G11 222',
+                'billing_region' => 'gb-sct',
+            ]);
+
+        $address = $order->billingAddress();
+
+        $this->assertIsArray($address->toArray());
+
+        $this->assertSame($address->toArray(), [
+            'name' => null,
+            'first_name' => 'John',
+            'last_name' => 'Doe',
             'address_line_1' => '11 Test Street',
             'address_line_2' => null,
             'city' => 'Glasgow',
@@ -63,11 +96,39 @@ G11 222');
     }
 
     /** @test */
+    public function can_get_address_as_string_with_first_name_and_last_name()
+    {
+        $order = Order::make()
+            ->merge([
+                'billing_first_name' => 'John',
+                'billing_last_name' => 'Doe',
+                'billing_address' => '11 Test Street',
+                'billing_city' => 'Glasgow',
+                'billing_country' => 'GB',
+                'billing_zip_code' => 'G11 222',
+                'billing_region' => 'gb-sct',
+            ]);
+
+        $address = $order->billingAddress();
+
+        $this->assertIsString((string) $address);
+
+        $this->assertSame((string) $address, 'John Doe,
+11 Test Street,
+Glasgow,
+Scotland,
+United Kingdom,
+G11 222');
+    }
+
+    /** @test */
     public function can_get_name()
     {
         $order = Order::make()
             ->merge([
                 'billing_name' => 'John Smith',
+                'billing_first_name' => null,
+                'billing_last_name' => null,
                 'billing_address' => '11 Test Street',
                 'billing_city' => 'Glasgow',
                 'billing_country' => 'GB',
@@ -79,6 +140,90 @@ G11 222');
 
         $this->assertIsString($address->name());
         $this->assertSame($address->name(), 'John Smith');
+    }
+
+    /** @test */
+    public function can_get_first_name()
+    {
+        $order = Order::make()
+            ->merge([
+                'billing_name' => null,
+                'billing_first_name' => 'Joseph',
+                'billing_last_name' => null,
+                'billing_address' => '11 Test Street',
+                'billing_city' => 'Glasgow',
+                'billing_country' => 'GB',
+                'billing_zip_code' => 'G11 222',
+                'billing_region' => 'gb-sct',
+            ]);
+
+        $address = $order->billingAddress();
+
+        $this->assertIsString($address->firstName());
+        $this->assertSame($address->firstName(), 'Joseph');
+    }
+
+    /** @test */
+    public function can_get_last_name()
+    {
+        $order = Order::make()
+            ->merge([
+                'billing_name' => null,
+                'billing_first_name' => null,
+                'billing_last_name' => 'Samuel',
+                'billing_address' => '11 Test Street',
+                'billing_city' => 'Glasgow',
+                'billing_country' => 'GB',
+                'billing_zip_code' => 'G11 222',
+                'billing_region' => 'gb-sct',
+            ]);
+
+        $address = $order->billingAddress();
+
+        $this->assertIsString($address->lastName());
+        $this->assertSame($address->lastName(), 'Samuel');
+    }
+
+    /** @test */
+    public function can_get_full_name_when_name_is_one_string()
+    {
+        $order = Order::make()
+            ->merge([
+                'billing_name' => 'Joseph Samuel',
+                'billing_first_name' => null,
+                'billing_last_name' => null,
+                'billing_address' => '11 Test Street',
+                'billing_city' => 'Glasgow',
+                'billing_country' => 'GB',
+                'billing_zip_code' => 'G11 222',
+                'billing_region' => 'gb-sct',
+            ]);
+
+        $address = $order->billingAddress();
+
+        $this->assertIsString($address->fullName());
+        $this->assertSame($address->fullName(), 'Joseph Samuel');
+    }
+
+    /** @test */
+    public function can_get_full_name_when_name_is_separate_first_and_last_names()
+    {
+        $order = Order::make()
+            ->merge([
+                'billing_name' => null,
+                'billing_first_name' => 'Joseph',
+                'billing_last_name' => 'Matthews',
+                'billing_address' => '11 Test Street',
+                'billing_city' => 'Glasgow',
+                'billing_country' => 'GB',
+                'billing_zip_code' => 'G11 222',
+                'billing_region' => 'gb-sct',
+            ]);
+
+        $address = $order->billingAddress();
+
+        $this->assertIsString($address->fullName());
+        $this->assertSame($address->fullName(), 'Joseph Matthews');
     }
 
     /** @test */
@@ -106,6 +251,8 @@ G11 222');
         $order = Order::make()
             ->merge([
                 'billing_name' => 'John Smith',
+                'first_name' => null,
+                'last_name' => null,
                 'billing_address' => '11 Test Street',
                 'billing_address_line2' => 'Cardonald',
                 'billing_city' => 'Glasgow',


### PR DESCRIPTION
This pull request adds support for using separate first & last name fields for billing/shipping addresses. The `Address` class will now automatically pick up fields called `shipping_first_name`, `shipping_last_name`.

If you wish to use separate fields for the first & last names of addresses, you need to:

1. Adjust the fields on your Order blueprint. They'll need to match this naming convention:
    * `shipping_first_name`
    * `shipping_last_name`
    * `billing_first_name`
    * `billing_last_name`
2. Replace `shipping_name` and `billing_name` in your [field whitelist](https://simple-commerce.duncanmcclean.com/tags#content-field-whitelisting) with the new field handles.
3. Adjust the inputs on your frontend forms to accommodate for the separate fields.
4. That should be all! 🎉 