### PR TITLE
Fix Money Fieldtype behaving badly

### DIFF
--- a/resources/js/components/Fieldtypes/MoneyFieldtype.vue
+++ b/resources/js/components/Fieldtypes/MoneyFieldtype.vue
@@ -2,7 +2,7 @@
     <div>
         <text-input
             :type="inputType"
-            :value="formattedValue"
+            :value="value"
             :prepend="symbol"
             :isReadOnly="config.read_only || readOnly"
             placeholder="00.00"
@@ -34,16 +34,8 @@ export default {
 
     mounted() {
         if (isNaN(parseFloat(this.value)) == false) {
-            this.formattedValue = parseFloat(this.value).toFixed(2)
+            this.$emit('input', parseFloat(this.value).toFixed(2))
         }
-    },
-
-    watch: {
-        value() {
-            if (isNaN(parseFloat(this.value)) == false) {
-                this.formattedValue = parseFloat(this.value).toFixed(2)
-            }
-        },
     },
 }
 </script>


### PR DESCRIPTION
Instead of using `formattedValue` (which causes issues when you need to change the value in the parent component), we're using the `value` we get given.

We're simply ensuring when the fieldtype is loaded, we do some initial formatting in case it's not formatted properly.

*Hopefully* fixes #791.