### PR TITLE
Ensure stock is checked when updating line items

### DIFF
--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -224,7 +224,6 @@ class CartItemController extends BaseActionController
             }
         }
 
-
         $cart->updateLineItem(
             $requestItem,
             array_merge(


### PR DESCRIPTION
This pull request fixes an issue when updating line items using the `{{ sc:cart:updateItem }}` tag where the quantity wasn't being checked against the stock of the product/variant to ensure enough stock exists to fulfil the customer's order.

This check was already being done when you add the product to the cart originally, just not on update. 

Fixes #797