### PR TITLE
Fix tax categories/zones/rates erroring out after deletion

### DIFF
--- a/src/Http/Controllers/CP/TaxCategoryController.php
+++ b/src/Http/Controllers/CP/TaxCategoryController.php
@@ -61,6 +61,8 @@ class TaxCategoryController
     {
         TaxCategory::find($taxCategory)->delete();
 
-        return redirect(cp_route('simple-commerce.tax-categories.index'));
+        return [
+            'success' => true,
+        ];
     }
 }

--- a/src/Http/Controllers/CP/TaxRateController.php
+++ b/src/Http/Controllers/CP/TaxRateController.php
@@ -75,6 +75,8 @@ class TaxRateController
     {
         TaxRate::find($taxRate)->delete();
 
-        return redirect(cp_route('simple-commerce.tax-rates.index'));
+        return [
+            'success' => true,
+        ];
     }
 }

--- a/src/Http/Controllers/CP/TaxZoneController.php
+++ b/src/Http/Controllers/CP/TaxZoneController.php
@@ -73,6 +73,8 @@ class TaxZoneController
     {
         TaxZone::find($taxZone)->delete();
 
-        return redirect(cp_route('simple-commerce.tax-zones.index'));
+        return [
+            'success' => true,
+        ];
     }
 }

--- a/tests/Http/Controllers/CP/TaxCategoryControllerTest.php
+++ b/tests/Http/Controllers/CP/TaxCategoryControllerTest.php
@@ -109,7 +109,7 @@ class TaxCategoryControllerTest extends TestCase
         $this
             ->actingAs($this->user())
             ->delete('/cp/simple-commerce/tax/categories/birthday/delete')
-            ->assertRedirect('/cp/simple-commerce/tax/categories');
+            ->assertJson(['success' => true]);
     }
 
     /**
@@ -137,7 +137,7 @@ class TaxCategoryControllerTest extends TestCase
         $this
             ->actingAs($this->user())
             ->delete('/cp/simple-commerce/tax/categories/birthday/delete')
-            ->assertRedirect('/cp/simple-commerce/tax/categories');
+            ->assertJson(['success' => true]);
 
         $this->assertFileDoesNotExist($taxRate->path());
     }

--- a/tests/Http/Controllers/CP/TaxRateControllerTest.php
+++ b/tests/Http/Controllers/CP/TaxRateControllerTest.php
@@ -147,7 +147,7 @@ class TaxRateControllerTest extends TestCase
         $this
             ->actingAs($this->user())
             ->delete('/cp/simple-commerce/tax/rates/uk-standard-products/delete')
-            ->assertRedirect('/cp/simple-commerce/tax/rates');
+            ->assertJson(['success' => true]);
     }
 
     protected function user()

--- a/tests/Http/Controllers/CP/TaxZoneControllerTest.php
+++ b/tests/Http/Controllers/CP/TaxZoneControllerTest.php
@@ -205,7 +205,7 @@ class TaxZoneControllerTest extends TestCase
         $this
             ->actingAs($this->user())
             ->delete('/cp/simple-commerce/tax/zones/the-states/delete')
-            ->assertRedirect('/cp/simple-commerce/tax/zones');
+            ->assertJson(['success' => true]);
     }
 
     /**
@@ -233,7 +233,7 @@ class TaxZoneControllerTest extends TestCase
         $this
             ->actingAs($this->user())
             ->delete('/cp/simple-commerce/tax/zones/the-states/delete')
-            ->assertRedirect('/cp/simple-commerce/tax/zones');
+            ->assertJson(['success' => true]);
 
         $this->assertFileDoesNotExist($taxRate->path());
     }


### PR DESCRIPTION
This pull request fixes an issue where you'd get an error after deleting a tax category/zone/rate. 

This seemed to be happening as the controller was redirecting the browser to a URL which seemed to 404 (not quite sure why) but changing to a JSON return seems to sort it. 🤷‍♂️ 

Fixes #802