### PR TITLE
Return augmented orders from actions

### DIFF
--- a/src/Http/Controllers/CartController.php
+++ b/src/Http/Controllers/CartController.php
@@ -133,7 +133,7 @@ class CartController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Cart Updated'),
-            'cart'    => $cart->toResource(),
+            'cart'    => $cart->toAugmentedArray(),
         ]);
     }
 

--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -192,7 +192,7 @@ class CartItemController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Added to Cart'),
-            'cart'    => $cart->fresh()->toResource(),
+            'cart'    => $cart->fresh()->toAugmentedArray(),
         ]);
     }
 
@@ -236,7 +236,7 @@ class CartItemController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Cart Item Updated'),
-            'cart'    => $cart->toResource(),
+            'cart'    => $cart->toAugmentedArray(),
         ]);
     }
 
@@ -248,7 +248,7 @@ class CartItemController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Item Removed from Cart'),
-            'cart'    => $cart->toResource(),
+            'cart'    => $cart->toAugmentedArray(),
         ]);
     }
 

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -61,9 +61,7 @@ class CheckoutController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Checkout Complete!'),
-            'cart'    => $request->wantsJson()
-                ? $this->order->toResource()
-                : $this->order->toAugmentedArray(),
+            'cart'    => $this->order->toAugmentedArray(),
             'is_checkout_request' => true,
         ]);
     }

--- a/src/Http/Controllers/CouponController.php
+++ b/src/Http/Controllers/CouponController.php
@@ -25,7 +25,7 @@ class CouponController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Coupon added to cart'),
-            'cart'    => $this->getCart()->toResource(),
+            'cart'    => $this->getCart()->toAugmentedArray(),
         ]);
     }
 
@@ -41,7 +41,7 @@ class CouponController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Coupon removed from cart'),
-            'cart'    => $this->getCart()->toResource(),
+            'cart'    => $this->getCart()->toAugmentedArray(),
         ]);
     }
 }

--- a/src/Http/Controllers/CustomerController.php
+++ b/src/Http/Controllers/CustomerController.php
@@ -12,7 +12,7 @@ class CustomerController extends BaseActionController
     public function index(IndexRequest $request, $customer)
     {
         return [
-            'data' => Customer::find($customer)->toResource(),
+            'data' => Customer::find($customer)->toAugmentedArray(),
         ];
     }
 
@@ -29,7 +29,7 @@ class CustomerController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message'  => __('Customer Updated'),
-            'customer' => $customer->toResource(),
+            'customer' => $customer->toAugmentedArray(),
         ]);
     }
 }

--- a/src/Http/Controllers/GatewayCallbackController.php
+++ b/src/Http/Controllers/GatewayCallbackController.php
@@ -46,9 +46,7 @@ class GatewayCallbackController extends BaseActionController
 
         return $this->withSuccess($request, [
             'success' => __('Checkout Complete!'),
-            'cart'    => $request->wantsJson()
-                ? $order->toResource()
-                : $order->toAugmentedArray(),
+            'cart'    => $order->toAugmentedArray(),
             'is_checkout_request' => true,
         ]);
     }


### PR DESCRIPTION
This was brought up recently in [a discussion](https://github.com/duncanmcclean/simple-commerce/discussions/798#discussioncomment-4845350). 

When you're using AJAX to submit forms, the order that you'd receive back would be a 'shallowly augmented' version of the order entry. This contained very limited information about the order.

This PR changes it so we return the fully augmented order from actions instead.