### PR TITLE
Add tests for `SendConfiguredNotifications` listener

### DIFF
--- a/src/Events/PaymentStatusUpdated.php
+++ b/src/Events/PaymentStatusUpdated.php
@@ -12,7 +12,7 @@ class PaymentStatusUpdated
     use Dispatchable;
     use InteractsWithSockets;
 
-    public function __construct(public Order $order, public PaymentStatus $orderStatus)
+    public function __construct(public Order $order, public PaymentStatus $paymentStatus)
     {
     }
 }

--- a/src/Listeners/SendConfiguredNotifications.php
+++ b/src/Listeners/SendConfiguredNotifications.php
@@ -56,7 +56,7 @@ class SendConfiguredNotifications implements ShouldQueue
         // If the event is OrderStatusUpdated, then we want to use the
         // order's status as the "event name".
         if ($event instanceof OrderStatusUpdated) {
-            $orderStatus = $event->order->status();
+            $orderStatus = $event->orderStatus;
 
             return "order_{$orderStatus->value}";
         }
@@ -64,7 +64,7 @@ class SendConfiguredNotifications implements ShouldQueue
         // If the event is PaymentStatusUpdated, then we want to use the
         // order's payment status as the "event name".
         if ($event instanceof PaymentStatusUpdated) {
-            $paymentStatus = $event->order->paymentStatus();
+            $paymentStatus = $event->paymentStatus;
 
             return "order_{$paymentStatus->value}";
         }
@@ -87,12 +87,6 @@ class SendConfiguredNotifications implements ShouldQueue
             }
 
             if ($email = $event->order->get('email')) {
-                return [
-                    ['channel' => 'mail', 'route' => $email],
-                ];
-            }
-
-            if ($email = $event->order->customer()) {
                 return [
                     ['channel' => 'mail', 'route' => $email],
                 ];

--- a/tests/Listeners/SendConfiguredNotificationsTest.php
+++ b/tests/Listeners/SendConfiguredNotificationsTest.php
@@ -1,0 +1,433 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Tests\Listeners;
+
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
+use DoubleThreeDigital\SimpleCommerce\Events\OrderStatusUpdated;
+use DoubleThreeDigital\SimpleCommerce\Events\PaymentStatusUpdated;
+use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
+use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DoubleThreeDigital\SimpleCommerce\Listeners\SendConfiguredNotifications;
+use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
+use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
+use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+
+class SendConfiguredNotificationsTest extends TestCase
+{
+    use SetupCollections;
+
+    /** @test */
+    public function can_send_configured_notification_to_customer()
+    {
+        NotificationFacade::fake();
+
+        Config::set('simple-commerce.notifications', [
+            'order_placed' => [
+                OrderPlacedNotification::class => [
+                    'to' => 'customer',
+                ],
+            ],
+        ]);
+
+        $customer = Customer::make()->email($email = 'cj.cregg@example.com');
+        $customer->save();
+
+        $order = Order::make()->customer($customer);
+        $order->save();
+
+        $event = new OrderStatusUpdated(
+            $order,
+            OrderStatus::Placed
+        );
+
+        (new SendConfiguredNotifications())->handle($event);
+
+        NotificationFacade::assertSentOnDemand(
+            OrderPlacedNotification::class,
+            function (OrderPlacedNotification $notification, array $channels, object $notifiable) use ($email) {
+                return $notifiable->routes['mail'] === $email;
+            }
+        );
+    }
+
+    /** @test */
+    public function can_send_configured_notification_to_order_email()
+    {
+        NotificationFacade::fake();
+
+        Config::set('simple-commerce.notifications', [
+            'order_placed' => [
+                OrderPlacedNotification::class => [
+                    'to' => 'customer',
+                ],
+            ],
+        ]);
+
+        $order = Order::make()->data(['email' => $email = 'leo.mcgarry@example.com']);
+        $order->save();
+
+        $event = new OrderStatusUpdated(
+            $order,
+            OrderStatus::Placed
+        );
+
+        (new SendConfiguredNotifications())->handle($event);
+
+        NotificationFacade::assertSentOnDemand(
+            OrderPlacedNotification::class,
+            function (OrderPlacedNotification $notification, array $channels, object $notifiable) use ($email) {
+                return $notifiable->routes['mail'] === $email;
+            }
+        );
+    }
+
+    /** @test */
+    public function cant_send_configured_notification_to_customer_when_no_customer_exists_on_the_order()
+    {
+        NotificationFacade::fake();
+
+        Config::set('simple-commerce.notifications', [
+            'order_placed' => [
+                OrderPlacedNotification::class => [
+                    'to' => 'customer',
+                ],
+            ],
+        ]);
+
+        $order = Order::make();
+        $order->save();
+
+        $event = new OrderStatusUpdated(
+            $order,
+            OrderStatus::Placed
+        );
+
+        (new SendConfiguredNotifications())->handle($event);
+
+        NotificationFacade::assertSentOnDemandTimes(
+            OrderPlacedNotification::class,
+            0
+        );
+    }
+
+    /** @test */
+    public function can_send_configured_notification_to_hard_coded_email_address()
+    {
+        NotificationFacade::fake();
+
+        Config::set('simple-commerce.notifications', [
+            'order_placed' => [
+                OrderPlacedNotification::class => [
+                    'to' => $email = 'duncan@example.com',
+                ],
+            ],
+        ]);
+
+        $order = Order::make();
+        $order->save();
+
+        $event = new OrderStatusUpdated(
+            $order,
+            OrderStatus::Placed
+        );
+
+        (new SendConfiguredNotifications())->handle($event);
+
+        NotificationFacade::assertSentOnDemand(
+            OrderPlacedNotification::class,
+            function (OrderPlacedNotification $notification, array $channels, object $notifiable) use ($email) {
+                return $notifiable->routes['mail'] === $email;
+            }
+        );
+    }
+
+    /** @test */
+    public function can_send_configured_notification_to_hard_coded_email_address_with_antlers()
+    {
+        NotificationFacade::fake();
+
+        Config::set('simple-commerce.notifications', [
+            'order_placed' => [
+                OrderPlacedNotification::class => [
+                    'to' => '{{ some_random_email_field }}',
+                ],
+            ],
+        ]);
+
+        $order = Order::make()->merge(['some_random_email_field' => $email = 'josh.lyman@example.com']);
+        $order->save();
+
+        $event = new OrderStatusUpdated(
+            $order,
+            OrderStatus::Placed
+        );
+
+        (new SendConfiguredNotifications())->handle($event);
+
+        NotificationFacade::assertSentOnDemand(
+            OrderPlacedNotification::class,
+            function (OrderPlacedNotification $notification, array $channels, object $notifiable) use ($email) {
+                return $notifiable->routes['mail'] === $email;
+            }
+        );
+    }
+
+    /** @test */
+    public function can_send_configured_notification_for_order_status_event()
+    {
+        NotificationFacade::fake();
+
+        Config::set('simple-commerce.notifications', [
+            'order_dispatched' => [
+                OrderDispatchedNotification::class => [
+                    'to' => $email = 'random@email.com',
+                ],
+            ],
+        ]);
+
+        $customer = Customer::make();
+        $customer->save();
+
+        $order = Order::make()->customer($customer);
+        $order->save();
+
+        $event = new OrderStatusUpdated(
+            $order,
+            OrderStatus::Dispatched
+        );
+
+        (new SendConfiguredNotifications())->handle($event);
+
+        NotificationFacade::assertSentOnDemand(
+            OrderDispatchedNotification::class,
+            function (OrderDispatchedNotification $notification, array $channels, object $notifiable) use ($email) {
+                return $notifiable->routes['mail'] === $email;
+            }
+        );
+    }
+
+    /** @test */
+    public function can_send_configured_notification_for_payment_status_event()
+    {
+        NotificationFacade::fake();
+
+        Config::set('simple-commerce.notifications', [
+            'order_refunded' => [
+                PaymentRefundedNotification::class => [
+                    'to' => $email = 'random@email.com',
+                ],
+            ],
+        ]);
+
+        $customer = Customer::make();
+        $customer->save();
+
+        $order = Order::make()->customer($customer);
+        $order->save();
+
+        $event = new PaymentStatusUpdated(
+            $order,
+            PaymentStatus::Refunded
+        );
+
+        (new SendConfiguredNotifications())->handle($event);
+
+        NotificationFacade::assertSentOnDemand(
+            PaymentRefundedNotification::class,
+            function (PaymentRefundedNotification $notification, array $channels, object $notifiable) use ($email) {
+                return $notifiable->routes['mail'] === $email;
+            }
+        );
+    }
+
+     /** @test */
+     public function can_send_configured_notification_for_some_random_event()
+     {
+         NotificationFacade::fake();
+
+         Config::set('simple-commerce.notifications', [
+             'some_random_event' => [
+                    SomeRandomEventNotification::class => [
+                     'to' => $email = 'random@email.com',
+                 ],
+             ],
+         ]);
+
+         $customer = Customer::make();
+         $customer->save();
+
+         $order = Order::make()->customer($customer);
+         $order->save();
+
+         $event = new SomeRandomEvent(
+             $order
+         );
+
+         (new SendConfiguredNotifications())->handle($event);
+
+         NotificationFacade::assertSentOnDemand(
+            SomeRandomEventNotification::class,
+             function (SomeRandomEventNotification $notification, array $channels, object $notifiable) use ($email) {
+                 return $notifiable->routes['mail'] === $email;
+             }
+         );
+     }
+
+     /** @test */
+     public function can_send_configured_notification_and_ensure_all_events_defined_in_notifications_constructor_are_passed_along()
+     {
+         NotificationFacade::fake();
+
+         Config::set('simple-commerce.notifications', [
+             'another_random_event' => [
+                    AnotherRandomEventNotification::class => [
+                     'to' => $email = 'random@email.com',
+                 ],
+             ],
+         ]);
+
+         $customer = Customer::make();
+         $customer->save();
+
+         $order = Order::make()->customer($customer);
+         $order->save();
+
+         $event = new AnotherRandomEvent(
+             $order,
+             'foo',
+             true
+         );
+
+         (new SendConfiguredNotifications())->handle($event);
+
+         NotificationFacade::assertSentOnDemand(
+            AnotherRandomEventNotification::class,
+             function (AnotherRandomEventNotification $notification, array $channels, object $notifiable) use ($email, $order) {
+                 return $notifiable->routes['mail'] === $email
+                    && $notification->order === $order
+                    && $notification->somethingElseThatIsAProperty === true
+                    && ! property_exists($notification, 'someOtherProperty');
+             }
+         );
+     }
+}
+
+class OrderPlacedNotification extends Notification
+{
+    public function __construct(protected OrderContract $order)
+    {
+    }
+
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->line('The introduction to the notification.')
+            ->action('Notification Action', url('/'))
+            ->line('Thank you for using our application!');
+    }
+}
+
+
+class OrderDispatchedNotification extends Notification
+{
+    public function __construct(protected OrderContract $order)
+    {
+    }
+
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->line('The introduction to the notification.')
+            ->action('Notification Action', url('/'))
+            ->line('Thank you for using our application!');
+    }
+}
+
+class PaymentRefundedNotification extends Notification
+{
+    public function __construct(protected OrderContract $order)
+    {
+    }
+
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->line('The introduction to the notification.')
+            ->action('Notification Action', url('/'))
+            ->line('Thank you for using our application!');
+    }
+}
+
+class SomeRandomEvent
+{
+    public function __construct(public OrderContract $order)
+    {
+    }
+}
+
+class SomeRandomEventNotification extends Notification
+{
+    public function __construct(protected OrderContract $order)
+    {
+    }
+
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->line('The introduction to the notification.')
+            ->action('Notification Action', url('/'))
+            ->line('Thank you for using our application!');
+    }
+}
+
+class AnotherRandomEvent
+{
+    public function __construct(public OrderContract $order, public string $someOtherProperty, public bool $somethingElseThatIsAProperty)
+    {
+    }
+}
+
+class AnotherRandomEventNotification extends Notification
+{
+    public function __construct(public OrderContract $order, public bool $somethingElseThatIsAProperty)
+    {
+    }
+
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->line('The introduction to the notification.')
+            ->action('Notification Action', url('/'))
+            ->line('Thank you for using our application!');
+    }
+}

--- a/tests/Listeners/SendConfiguredNotificationsTest.php
+++ b/tests/Listeners/SendConfiguredNotificationsTest.php
@@ -245,67 +245,67 @@ class SendConfiguredNotificationsTest extends TestCase
         );
     }
 
-     /** @test */
-     public function can_send_configured_notification_for_some_random_event()
-     {
-         NotificationFacade::fake();
+    /** @test */
+    public function can_send_configured_notification_for_some_random_event()
+    {
+        NotificationFacade::fake();
 
-         Config::set('simple-commerce.notifications', [
-             'some_random_event' => [
-                    SomeRandomEventNotification::class => [
-                     'to' => $email = 'random@email.com',
-                 ],
-             ],
-         ]);
+        Config::set('simple-commerce.notifications', [
+            'some_random_event' => [
+                SomeRandomEventNotification::class => [
+                    'to' => $email = 'random@email.com',
+                ],
+            ],
+        ]);
 
-         $customer = Customer::make();
-         $customer->save();
+        $customer = Customer::make();
+        $customer->save();
 
-         $order = Order::make()->customer($customer);
-         $order->save();
+        $order = Order::make()->customer($customer);
+        $order->save();
 
-         $event = new SomeRandomEvent(
+        $event = new SomeRandomEvent(
              $order
          );
 
-         (new SendConfiguredNotifications())->handle($event);
+        (new SendConfiguredNotifications())->handle($event);
 
-         NotificationFacade::assertSentOnDemand(
+        NotificationFacade::assertSentOnDemand(
             SomeRandomEventNotification::class,
              function (SomeRandomEventNotification $notification, array $channels, object $notifiable) use ($email) {
                  return $notifiable->routes['mail'] === $email;
              }
          );
-     }
+    }
 
-     /** @test */
-     public function can_send_configured_notification_and_ensure_all_events_defined_in_notifications_constructor_are_passed_along()
-     {
-         NotificationFacade::fake();
+    /** @test */
+    public function can_send_configured_notification_and_ensure_all_events_defined_in_notifications_constructor_are_passed_along()
+    {
+        NotificationFacade::fake();
 
-         Config::set('simple-commerce.notifications', [
-             'another_random_event' => [
-                    AnotherRandomEventNotification::class => [
-                     'to' => $email = 'random@email.com',
-                 ],
-             ],
-         ]);
+        Config::set('simple-commerce.notifications', [
+            'another_random_event' => [
+                AnotherRandomEventNotification::class => [
+                    'to' => $email = 'random@email.com',
+                ],
+            ],
+        ]);
 
-         $customer = Customer::make();
-         $customer->save();
+        $customer = Customer::make();
+        $customer->save();
 
-         $order = Order::make()->customer($customer);
-         $order->save();
+        $order = Order::make()->customer($customer);
+        $order->save();
 
-         $event = new AnotherRandomEvent(
+        $event = new AnotherRandomEvent(
              $order,
              'foo',
              true
          );
 
-         (new SendConfiguredNotifications())->handle($event);
+        (new SendConfiguredNotifications())->handle($event);
 
-         NotificationFacade::assertSentOnDemand(
+        NotificationFacade::assertSentOnDemand(
             AnotherRandomEventNotification::class,
              function (AnotherRandomEventNotification $notification, array $channels, object $notifiable) use ($email, $order) {
                  return $notifiable->routes['mail'] === $email
@@ -314,7 +314,7 @@ class SendConfiguredNotificationsTest extends TestCase
                     && ! property_exists($notification, 'someOtherProperty');
              }
          );
-     }
+    }
 }
 
 class OrderPlacedNotification extends Notification
@@ -336,7 +336,6 @@ class OrderPlacedNotification extends Notification
             ->line('Thank you for using our application!');
     }
 }
-
 
 class OrderDispatchedNotification extends Notification
 {


### PR DESCRIPTION
After making some changes to this listener recently for the Order & Payment status changes, I realised that this pretty core listener didn't have any tests around it.

The `SendConfiguredNotifications` listener is responsible for sending things like order confirmation emails or order dispatched emails. 

It does some pretty cool things like allowing you to use Antlers for the email address config & using Reflection to figure out what properties need to be passed along from the event to the notification.

Anyways, this PR adds some tests to make sure all of that is all working like it should. 