### PR TITLE
Fix: Gateway not included in order when listening to `OrderPaid` event

### DIFF
--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -127,6 +127,13 @@ class BaseGateway
 
     public function markOrderAsPaid(Order $order): bool
     {
+        // We need to ensure that the gateway is available in the
+        // order when the OrderPaid event is dispatched.
+        $order->gateway([
+            'use' => $this,
+            'data' => [],
+        ]);
+
         if ($this->isOffsiteGateway()) {
             $order = app(Pipeline::class)
                 ->send($order)

--- a/tests/Gateways/Builtin/BaseGatewayTest.php
+++ b/tests/Gateways/Builtin/BaseGatewayTest.php
@@ -61,6 +61,47 @@ class BaseGatewayTest extends TestCase
     }
 
     /** @test */
+    public function can_mark_order_as_paid_with_offsite_gateway_and_ensure_gateway_is_set_in_order_paid_event()
+    {
+        Event::fake();
+
+        $fakeGateway = new FakeOffsiteGateway();
+
+        $product = Product::make()
+            ->price(1500)
+            ->stock(10)
+            ->data([
+                'title' => 'Smth',
+            ]);
+
+        $product->save();
+
+        $order = Order::make()
+            ->lineItems([
+                [
+                    'product' => $product->id(),
+                    'quantity' => 1,
+                    'total' => 1500,
+                ],
+            ]);
+
+        $order->save();
+
+        $markOrderAsPaid = $fakeGateway->markOrderAsPaid($order);
+
+        // Assert order has been marked as paid
+        $this->assertTrue($markOrderAsPaid);
+        $this->assertTrue($order->fresh()->isPaid());
+
+        Event::assertDispatched(function (OrderPaid $event) use ($fakeGateway) {
+            return $event->order->gateway['use'] instanceof FakeOffsiteGateway;
+        });
+
+        // Assert stock count has been updated
+        $this->assertSame($product->fresh()->stock(), 9);
+    }
+
+    /** @test */
     public function can_mark_order_as_paid_with_onsite_gateway()
     {
         Event::fake();
@@ -93,6 +134,43 @@ class BaseGatewayTest extends TestCase
         $this->assertTrue($order->fresh()->isPaid());
 
         Event::assertDispatched(OrderPaid::class);
+    }
+
+    /** @test */
+    public function can_mark_order_as_paid_with_onsite_gateway_and_ensure_gateway_is_set_in_order_paid_event()
+    {
+        Event::fake();
+
+        $fakeGateway = new FakeOnsiteGateway();
+
+        $product = Product::make()
+            ->price(1500)
+            ->data([
+                'title' => 'Smth',
+            ]);
+
+        $product->save();
+
+        $order = Order::make()
+            ->lineItems([
+                [
+                    'product' => $product->id(),
+                    'quantity' => 1,
+                    'total' => 1500,
+                ],
+            ]);
+
+        $order->save();
+
+        $markOrderAsPaid = $fakeGateway->markOrderAsPaid($order);
+
+        // Assert order has been marked as paid
+        $this->assertTrue($markOrderAsPaid);
+        $this->assertTrue($order->fresh()->isPaid());
+
+        Event::assertDispatched(function (OrderPaid $event) use ($fakeGateway) {
+            return $event->order->gateway['use'] instanceof FakeOnsiteGateway;
+        });
     }
 }
 

--- a/tests/Gateways/Builtin/BaseGatewayTest.php
+++ b/tests/Gateways/Builtin/BaseGatewayTest.php
@@ -93,7 +93,7 @@ class BaseGatewayTest extends TestCase
         $this->assertTrue($markOrderAsPaid);
         $this->assertTrue($order->fresh()->isPaid());
 
-        Event::assertDispatched(function (OrderPaid $event) use ($fakeGateway) {
+        Event::assertDispatched(function (OrderPaid $event) {
             return $event->order->gateway['use'] instanceof FakeOffsiteGateway;
         });
 
@@ -168,7 +168,7 @@ class BaseGatewayTest extends TestCase
         $this->assertTrue($markOrderAsPaid);
         $this->assertTrue($order->fresh()->isPaid());
 
-        Event::assertDispatched(function (OrderPaid $event) use ($fakeGateway) {
+        Event::assertDispatched(function (OrderPaid $event) {
             return $event->order->gateway['use'] instanceof FakeOnsiteGateway;
         });
     }


### PR DESCRIPTION
This pull request fixes an issue where the gateway wasn't being included in the `$order` parameter of the `OrderPaid` event which was happening due to a timing issue.

The `OrderPaid` event is dispatched by the `BaseGateway@markOrderAsPaid` method. 

However, the gateway was only set in the `Manager@purchase` method & was run based on if the `purchase` method in the gateway returned as being successful.

This meant that developers who wanted to include the gateway name in their order paid notifications weren't able to do so as they couldn't tell which gateway was used.

This PR sets the order's gateway in the `BaseGateway@markOrderAsPaid` method before the event is dispatched, this means it's available for those who need it. 

It's worth noting any of the 'gateway data' won't be available in the event because we can't get that until the `payment` method has ran.