### PR TITLE
Ensure coupon fields are processed when creating/updating coupons

### DIFF
--- a/src/Coupons/CouponBlueprint.php
+++ b/src/Coupons/CouponBlueprint.php
@@ -6,10 +6,11 @@ use DoubleThreeDigital\SimpleCommerce\Customers\EloquentCustomerRepository;
 use DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Statamic\Facades\Blueprint;
+use Statamic\Fields\Blueprint as FieldsBlueprint;
 
 class CouponBlueprint
 {
-    public static function getBlueprint()
+    public static function getBlueprint(): FieldsBlueprint
     {
         $customerField = [
             'mode' => 'default',

--- a/src/Http/Controllers/CP/CouponController.php
+++ b/src/Http/Controllers/CP/CouponController.php
@@ -38,12 +38,18 @@ class CouponController
 
     public function store(StoreRequest $request)
     {
+        $fields = CouponBlueprint::getBlueprint()
+            ->fields()
+            ->addValues($request->validated())
+            ->process()
+            ->values();
+
         $coupon = Coupon::make()
-            ->code(Str::upper($request->code))
-            ->type($request->type)
-            ->value($request->value)
-            ->enabled($request->enabled ?? true)
-            ->data(Arr::except($request->validated(), ['code', 'type', 'value', 'enabled']));
+            ->code(Str::upper($fields->get('code')))
+            ->type($fields->get('type'))
+            ->value($fields->get('value'))
+            ->enabled($fields->get('enabled'))
+            ->data(Arr::except($fields, ['code', 'type', 'value', 'enabled']));
 
         $coupon->save();
 
@@ -79,12 +85,18 @@ class CouponController
     {
         $coupon = Coupon::find($coupon);
 
+        $fields = CouponBlueprint::getBlueprint()
+            ->fields()
+            ->addValues($request->validated())
+            ->process()
+            ->values();
+
         $coupon
-            ->code(Str::upper($request->code))
-            ->type($request->type)
-            ->value($request->value)
-            ->enabled($request->enabled ?? true)
-            ->data(Arr::except($request->validated(), ['code', 'type', 'value', 'enabled']))
+            ->code(Str::upper($fields->get('code')))
+            ->type($fields->get('type'))
+            ->value($fields->get('value'))
+            ->enabled($fields->get('enabled'))
+            ->data(Arr::except($fields, ['code', 'type', 'value', 'enabled']))
             ->save();
 
         return [

--- a/tests/Http/Controllers/CP/CouponControllerTest.php
+++ b/tests/Http/Controllers/CP/CouponControllerTest.php
@@ -51,6 +51,7 @@ class CouponControllerTest extends TestCase
                 'type' => 'percentage',
                 'value' => 30,
                 'description' => '30% discount on a Thursday!',
+                'minimum_cart_value' => '65.00',
                 'enabled' => true,
             ])
             ->assertJsonStructure([
@@ -63,6 +64,7 @@ class CouponControllerTest extends TestCase
         $this->assertSame($coupon->value(), 30);
         $this->assertSame($coupon->enabled(), true);
         $this->assertSame($coupon->get('description'), '30% discount on a Thursday!');
+        $this->assertSame($coupon->get('minimum_cart_value'), 6500);
     }
 
     /** @test */
@@ -153,6 +155,7 @@ class CouponControllerTest extends TestCase
                 'value' => 51,
                 'description' => 'You can actually get a 51% discount on Friday!',
                 'enabled' => false,
+                'minimum_cart_value' => '76.00',
             ])
             ->assertJsonStructure([
                 'coupon',
@@ -163,6 +166,7 @@ class CouponControllerTest extends TestCase
         $this->assertSame($coupon->value(), 51);
         $this->assertSame($coupon->enabled(), false);
         $this->assertSame($coupon->get('description'), 'You can actually get a 51% discount on Friday!');
+        $this->assertSame($coupon->get('minimum_cart_value'), 7600);
     }
 
     /** @test */


### PR DESCRIPTION
While looking into #816, I discovered that in setting the 'Minimum cart value' in the Control Panel, it wasn't being saved properly.

If I entered '56' in the field, `56` would be saved. Then when you load the edit page, it would be showing as £0.56 as it expects the value to be in pence.

This was happening because the user's inputs were being directly saved on the coupon, rather than being processed via the blueprint.