### PR TITLE
Handle £0 orders when redirecting to off-site gateways

### DIFF
--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -141,7 +141,7 @@ class Order implements Contract
                 }
 
                 if ($value instanceof CustomerContract) {
-                    return $value->id();
+                    return $value;
                 }
 
                 return Customer::find($value);
@@ -159,7 +159,7 @@ class Order implements Contract
                 }
 
                 if ($value instanceof CouponContract) {
-                    return $value->id();
+                    return $value;
                 }
 
                 return Coupon::find($value);

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -48,7 +48,7 @@ class CheckoutTags extends SubTag
                         $config = Gateway::use($gateway['class'])->config();
 
                         $callbackUrl = Gateway::use($gateway['class'])
-                            ->withRedirectUrl($this->params->get('redirect'))
+                            ->withRedirectUrl($this->params->get('redirect') ?? request()->path())
                             ->withErrorRedirectUrl($this->params->get('error_redirect') ?? request()->path())
                             ->callbackUrl();
 

--- a/tests/Tags/CheckoutTagTest.php
+++ b/tests/Tags/CheckoutTagTest.php
@@ -5,6 +5,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Tests\Tags;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order as ContractsOrder;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Prepare;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Purchase;
@@ -28,6 +29,8 @@ class CheckoutTagTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        $this->useBasicTaxEngine();
 
         $this->tag = resolve(CheckoutTags::class)
             ->setParser(Antlers::parser())
@@ -124,7 +127,17 @@ class CheckoutTagTest extends TestCase
     protected function fakeCart($cart = null)
     {
         if (is_null($cart)) {
-            $cart = Order::make();
+            $product = Product::make()->price(1500);
+            $product->save();
+
+            $cart = Order::make()->lineItems([
+                [
+                    'product' => $product->id(),
+                    'quantity' => 1,
+                    'total' => 1500,
+                ],
+            ]);
+            $cart->recalculate();
             $cart->save();
         }
 

--- a/tests/Tags/CheckoutTagTest.php
+++ b/tests/Tags/CheckoutTagTest.php
@@ -125,9 +125,9 @@ class CheckoutTagTest extends TestCase
         $this->tag->wildcard('testoffsitegateway');
     }
 
-     /** @test */
-     public function can_redirect_user_to_confirmation_page_instead_of_offsite_gateway_when_order_total_is_0()
-     {
+    /** @test */
+    public function can_redirect_user_to_confirmation_page_instead_of_offsite_gateway_when_order_total_is_0()
+    {
         $product = Product::make()->price(1500);
         $product->save();
 
@@ -161,7 +161,7 @@ class CheckoutTagTest extends TestCase
         $usage = $this->tag->wildcard('testoffsitegateway');
 
         $this->assertTrue($cart->fresh()->isPaid());
-     }
+    }
 
     protected function fakeCart($cart = null)
     {

--- a/tests/Tags/CheckoutTagTest.php
+++ b/tests/Tags/CheckoutTagTest.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Tests\Tags;
 
 use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order as ContractsOrder;
+use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
@@ -123,6 +124,44 @@ class CheckoutTagTest extends TestCase
 
         $this->tag->wildcard('testoffsitegateway');
     }
+
+     /** @test */
+     public function can_redirect_user_to_confirmation_page_instead_of_offsite_gateway_when_order_total_is_0()
+     {
+        $product = Product::make()->price(1500);
+        $product->save();
+
+        $cart = Order::make()->lineItems([
+            [
+                'product' => $product->id(),
+                'quantity' => 1,
+                'total' => 1500,
+            ],
+        ]);
+        $cart->save();
+
+        $coupon = Coupon::make()->code('FREEBIE')->value(100)->type('percentage')->enabled(true);
+        $coupon->save();
+
+        $cart->coupon($coupon);
+        $cart->recalculate();
+        $cart->save();
+
+        $this->fakeCart($cart);
+
+        Session::shouldReceive('forget');
+        Session::shouldReceive('put');
+
+        $this->assertFalse($cart->isPaid());
+
+        $this->tag->setParameters([
+            'redirect' => 'http://localhost/order-confirmation',
+        ]);
+
+        $usage = $this->tag->wildcard('testoffsitegateway');
+
+        $this->assertTrue($cart->fresh()->isPaid());
+     }
 
     protected function fakeCart($cart = null)
     {


### PR DESCRIPTION
This pull request fixes #821 where a customer checking out via an off-site gateway, where the order's grand total is £0, would run into an error thrown by the gateway due to it not being able to handle £0 payments.

One workaround for this would be to check if the order's grand total is £0 and if it is, take them to the `{{ sc:checkout }}` form to checkout (as it doesn't require a gateway if the order is £0).

This PR introduces a fix for this: any customers with £0 orders that make their way to the off-site checkout flow will have the order marked as paid & redirected to the status/confirmation page.