### PR TITLE
v5.0: Refactor how we pass variables into the Checkout Form tag

### DIFF
--- a/docs/payment-gateways/paypal.md
+++ b/docs/payment-gateways/paypal.md
@@ -78,7 +78,7 @@ A rough example of a PayPal implementation is provided below.
 <div id="paypal-button"></div>
 <input id="paypal-payment-id" type="hidden" name="payment_id">
 <input type="hidden" name="gateway" value="DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\PayPalGateway">
-<script src="https://www.paypal.com/sdk/js?client-id={{ gateway-config:client_id }}&currency={{ result.currency_code }}"></script>
+<script src="https://www.paypal.com/sdk/js?client-id={{ paypal:config:client_id }}&currency={{ result.currency_code }}"></script>
 <script>
     paypal.Buttons({
         createOrder: () => {

--- a/docs/payment-gateways/stripe.md
+++ b/docs/payment-gateways/stripe.md
@@ -42,7 +42,7 @@ A rough example of a Stripe Elements implementation is provided below.
 
 <script src="https://js.stripe.com/v3/"></script>
 <script>
-    var stripe = Stripe('{{ gateway-config:key }}')
+    var stripe = Stripe('{{ stripe:config:key }}')
     var elements = stripe.elements()
 
     const card = elements.create('card')
@@ -53,7 +53,7 @@ A rough example of a Stripe Elements implementation is provided below.
     })
 
     function confirmPayment() {
-        stripe.confirmCardPayment('{{ client_secret }}', {
+        stripe.confirmCardPayment('{{ stripe:client_secret }}', {
             payment_method: { card: card },
         }).then(function (result) {
           	if (result.paymentIntent.status === 'succeeded') {

--- a/docs/upgrade-guides/v4-x-to-v5-0.md
+++ b/docs/upgrade-guides/v4-x-to-v5-0.md
@@ -84,6 +84,21 @@ It'll then work through the orders in your database and set the status columns. 
 
 You may create your own migration to remove the 'old' columns after deploying if you wish (`is_paid`, `is_shipped`, `is_refunded`).
 
+### High: Variables are passed differently into the `{{ sc:checkout }}` form
+
+Sometimes, you could run into issues with the `{{ sc:checkout }}` form where variables for one gateway would leak over into the other because they were sharing the same "space" for their variables.
+
+In v5, we've slightly changed the format variables are passed into the `{{ sc:checkout }}` form to prevent this from happening.
+
+Due to the format changing, you may need to update code in your checkout form.
+
+1. If you're getting any variables that come from gateways, you should get it from that gateway's array:
+    - `{{ client_secret }}` -> `{{ stripe:client_secret }}`
+2. If you're getting config values for a gateway, you should get it from that gateway's config array:
+    - `{{ gateway-config:key }}` -> `{{ stripe:config:key }}`
+3. If you're getting the callback URL for a gateway, you should get it from that gateway's array:
+    - `{{ callback_url }}` -> `{{ stripe:callback_url }}`
+
 ### Medium: Support for Statamic 3.3 has been dropped
 
 Simple Commerce has dropped support for Statamic 3.3, leaving only Statamic 3.4 the only current version supported.

--- a/src/Gateways/Manager.php
+++ b/src/Gateways/Manager.php
@@ -141,7 +141,7 @@ class Manager implements Contract
             ->first();
 
         $data = [
-            'config' => $gateway['gateway-config'],
+            'config' => $gateway['config'],
             'handle' => $gateway['handle'],
         ];
 

--- a/src/SimpleCommerce.php
+++ b/src/SimpleCommerce.php
@@ -62,7 +62,7 @@ class SimpleCommerce
                     'formatted_class' => addslashes($gateway[0]),
                     'display'         => isset($gateway[1]['display']) ? $gateway[1]['display'] : $instance->name(),
                     'checkoutRules'   => $instance->checkoutRules(),
-                    'gateway-config'  => $gateway[1],
+                    'config'  => $gateway[1],
                     'webhook_url'     => Str::finish(config('app.url'), '/') . config('statamic.routes.action') . '/simple-commerce/gateways/' . $handle . '/webhook',
                 ];
             })

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -3,7 +3,6 @@
 namespace DoubleThreeDigital\SimpleCommerce\Tags;
 
 use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayDoesNotExist;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayException;
 use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;

--- a/tests/Fieldtypes/GatewayFieldtypeTest.php
+++ b/tests/Fieldtypes/GatewayFieldtypeTest.php
@@ -107,7 +107,7 @@ class GatewayFieldtypeTest extends TestCase
         $this->assertArrayHasKey('formatted_class', $augment);
         $this->assertArrayHasKey('display', $augment);
         $this->assertArrayHasKey('checkoutRules', $augment);
-        $this->assertArrayHasKey('gateway-config', $augment);
+        $this->assertArrayHasKey('config', $augment);
         $this->assertArrayHasKey('webhook_url', $augment);
         $this->assertArrayHasKey('data', $augment);
     }

--- a/tests/Tags/CheckoutTagTest.php
+++ b/tests/Tags/CheckoutTagTest.php
@@ -60,7 +60,7 @@ class CheckoutTagTest extends TestCase
 
             {{ sc:gateways }}
                 ---
-                {{ name }} - Duncan Cool ({{ gateway-config:is-duncan-cool }}) - Haggis - Tatties
+                {{ name }} - Duncan Cool ({{ config:is-duncan-cool }}) - Haggis - Tatties
                 ---
             {{ /sc:gateways }}
         ');


### PR DESCRIPTION
Sometimes, you could run into issues with the `{{ sc:checkout }}` form where variables for one gateway would leak over into the other because they were sharing the same "space" for their variables.

This PR changes the format the variables are passed into the `{{ sc:checkout }}` form to prevent this from happening. 

This **will** introduce breaking changes for most sites. However, it's documented as a high priority item in the upgrade guide.