### PR TITLE
v5.0: Refactor `SimpleCommerce::gateways()` to return a Collection, not an array

### DIFF
--- a/docs/payment-gateways/paypal.md
+++ b/docs/payment-gateways/paypal.md
@@ -78,7 +78,7 @@ A rough example of a PayPal implementation is provided below.
 <div id="paypal-button"></div>
 <input id="paypal-payment-id" type="hidden" name="payment_id">
 <input type="hidden" name="gateway" value="DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\PayPalGateway">
-<script src="https://www.paypal.com/sdk/js?client-id={{ gateway-config:client_id }}&currency={{ result.currency_code }}"></script>
+<script src="https://www.paypal.com/sdk/js?client-id={{ paypal:config:client_id }}&currency={{ result.currency_code }}"></script>
 <script>
     paypal.Buttons({
         createOrder: () => {

--- a/docs/payment-gateways/stripe.md
+++ b/docs/payment-gateways/stripe.md
@@ -42,7 +42,7 @@ A rough example of a Stripe Elements implementation is provided below.
 
 <script src="https://js.stripe.com/v3/"></script>
 <script>
-    var stripe = Stripe('{{ gateway-config:key }}')
+    var stripe = Stripe('{{ stripe:config:key }}')
     var elements = stripe.elements()
 
     const card = elements.create('card')
@@ -53,7 +53,7 @@ A rough example of a Stripe Elements implementation is provided below.
     })
 
     function confirmPayment() {
-        stripe.confirmCardPayment('{{ client_secret }}', {
+        stripe.confirmCardPayment('{{ stripe:client_secret }}', {
             payment_method: { card: card },
         }).then(function (result) {
           	if (result.paymentIntent.status === 'succeeded') {

--- a/docs/upgrade-guides/v4-x-to-v5-0.md
+++ b/docs/upgrade-guides/v4-x-to-v5-0.md
@@ -84,6 +84,21 @@ It'll then work through the orders in your database and set the status columns. 
 
 You may create your own migration to remove the 'old' columns after deploying if you wish (`is_paid`, `is_shipped`, `is_refunded`).
 
+### High: Variables are passed differently into the `{{ sc:checkout }}` form
+
+Sometimes, you could run into issues with the `{{ sc:checkout }}` form where variables for one gateway would leak over into the other because they were sharing the same "space" for their variables.
+
+In v5, we've slightly changed the format variables are passed into the `{{ sc:checkout }}` form to prevent this from happening.
+
+Due to the format changing, you may need to update code in your checkout form.
+
+1. If you're getting any variables that come from gateways, you should get it from that gateway's array:
+    - `{{ client_secret }}` -> `{{ stripe:client_secret }}`
+2. If you're getting config values for a gateway, you should get it from that gateway's config array:
+    - `{{ gateway-config:key }}` -> `{{ stripe:config:key }}`
+3. If you're getting the callback URL for a gateway, you should get it from that gateway's array:
+    - `{{ callback_url }}` -> `{{ stripe:callback_url }}`
+
 ### Medium: Support for Statamic 3.3 has been dropped
 
 Simple Commerce has dropped support for Statamic 3.3, leaving only Statamic 3.4 the only current version supported.

--- a/src/DebugbarDataCollector.php
+++ b/src/DebugbarDataCollector.php
@@ -35,7 +35,7 @@ class DebugbarDataCollector extends \DebugBar\DataCollector\DataCollector implem
             'Coupon Total' => Currency::parse($cart->couponTotal(), Site::current()),
             'Grand Total' => Currency::parse($cart->grandTotal(), Site::current()),
             'Site Currency' => Currency::get(Site::current())['symbol'] . ' ' . Currency::get(Site::current())['name'],
-            'Enabled Gateways' => collect(SimpleCommerce::gateways())->pluck('name')->join(', '),
+            'Enabled Gateways' => SimpleCommerce::gateways()->pluck('name')->join(', '),
         ];
     }
 

--- a/src/Fieldtypes/GatewayFieldtype.php
+++ b/src/Fieldtypes/GatewayFieldtype.php
@@ -20,7 +20,7 @@ class GatewayFieldtype extends Fieldtype
     public function preload()
     {
         return [
-            'gateways' => SimpleCommerce::gateways(),
+            'gateways' => SimpleCommerce::gateways()->toArray(),
         ];
     }
 
@@ -32,7 +32,7 @@ class GatewayFieldtype extends Fieldtype
 
         $actionUrl = null;
 
-        $gateway = collect(SimpleCommerce::gateways())
+        $gateway = SimpleCommerce::gateways()
             ->where('class', isset($value['use']) ? $value['use'] : $value)
             ->first();
 
@@ -86,7 +86,7 @@ class GatewayFieldtype extends Fieldtype
 
     public function augment($value)
     {
-        $gateway = collect(SimpleCommerce::gateways())
+        $gateway = SimpleCommerce::gateways()
             ->where('class', isset($value['use']) ? $value['use'] : $value)
             ->first();
 
@@ -105,7 +105,7 @@ class GatewayFieldtype extends Fieldtype
             return;
         }
 
-        $gateway = collect(SimpleCommerce::gateways())
+        $gateway = SimpleCommerce::gateways()
             ->where('class', isset($value['use']) ? $value['use'] : $value)
             ->first();
 

--- a/src/Gateways/Manager.php
+++ b/src/Gateways/Manager.php
@@ -136,7 +136,7 @@ class Manager implements Contract
             throw new GatewayDoesNotExist("Gateway [{$this->className}] does not exist.");
         }
 
-        $gateway = collect(SimpleCommerce::gateways())
+        $gateway = SimpleCommerce::gateways()
             ->where('class', $this->className)
             ->first();
 

--- a/src/Gateways/Manager.php
+++ b/src/Gateways/Manager.php
@@ -141,7 +141,7 @@ class Manager implements Contract
             ->first();
 
         $data = [
-            'config' => $gateway['gateway-config'],
+            'config' => $gateway['config'],
             'handle' => $gateway['handle'],
         ];
 

--- a/src/Http/Controllers/GatewayCallbackController.php
+++ b/src/Http/Controllers/GatewayCallbackController.php
@@ -26,7 +26,7 @@ class GatewayCallbackController extends BaseActionController
 
         $gatewayName = $gateway;
 
-        $gateway = collect(SimpleCommerce::gateways())
+        $gateway = SimpleCommerce::gateways()
             ->where('handle', $gateway)
             ->first();
 

--- a/src/Http/Controllers/GatewayWebhookController.php
+++ b/src/Http/Controllers/GatewayWebhookController.php
@@ -14,7 +14,7 @@ class GatewayWebhookController extends BaseActionController
     {
         $gatewayName = $gateway;
 
-        $gateway = collect(SimpleCommerce::gateways())
+        $gateway = SimpleCommerce::gateways()
             ->where('handle', $gateway)
             ->first();
 

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -185,11 +185,11 @@ class Order implements Contract
     public function currentGateway(): ?array
     {
         if (is_string($this->gateway())) {
-            return collect(SimpleCommerce::gateways())->firstWhere('class', $this->gateway());
+            return SimpleCommerce::gateways()->firstWhere('class', $this->gateway());
         }
 
         if (is_array($this->gateway())) {
-            return collect(SimpleCommerce::gateways())->firstWhere('class', $this->gateway()['use']);
+            return SimpleCommerce::gateways()->firstWhere('class', $this->gateway()['use']);
         }
 
         return null;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -166,7 +166,7 @@ class ServiceProvider extends AddonServiceProvider
                 'Repository: Customer' => SimpleCommerce::customerDriver()['repository'],
                 'Repository: Order' => SimpleCommerce::orderDriver()['repository'],
                 'Repository: Product' => SimpleCommerce::productDriver()['repository'],
-                'Gateways' => collect(SimpleCommerce::gateways())->pluck('name')->implode(', '),
+                'Gateways' => SimpleCommerce::gateways()->pluck('name')->implode(', '),
                 'Shipping Methods' => SimpleCommerce::shippingMethods()->pluck('name')->implode(', '),
                 'Tax Engine' => get_class(SimpleCommerce::taxEngine()),
             ];

--- a/src/SimpleCommerce.php
+++ b/src/SimpleCommerce.php
@@ -62,7 +62,7 @@ class SimpleCommerce
                     'formatted_class' => addslashes($gateway[0]),
                     'display'         => isset($gateway[1]['display']) ? $gateway[1]['display'] : $instance->name(),
                     'checkoutRules'   => $instance->checkoutRules(),
-                    'gateway-config'  => $gateway[1],
+                    'config'  => $gateway[1],
                     'webhook_url'     => Str::finish(config('app.url'), '/') . config('statamic.routes.action') . '/simple-commerce/gateways/' . $handle . '/webhook',
                 ];
             })

--- a/src/SimpleCommerce.php
+++ b/src/SimpleCommerce.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\SimpleCommerce;
 
 use Closure;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Statamic\Facades\Addon;
@@ -48,7 +49,7 @@ class SimpleCommerce
         });
     }
 
-    public static function gateways(): array
+    public static function gateways(): Collection
     {
         return collect(static::$gateways)
             ->map(function ($gateway) {
@@ -65,8 +66,7 @@ class SimpleCommerce
                     'config'  => $gateway[1],
                     'webhook_url'     => Str::finish(config('app.url'), '/') . config('statamic.routes.action') . '/simple-commerce/gateways/' . $handle . '/webhook',
                 ];
-            })
-            ->toArray();
+            });
     }
 
     public static function registerGateway(string $gateway, array $config = [])

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -22,7 +22,7 @@ class CheckoutTags extends SubTag
         $data = $cart->data()->toArray();
 
         if ($cart->grandTotal() > 0) {
-            collect(SimpleCommerce::gateways())
+            SimpleCommerce::gateways()
                 ->filter(function ($gateway) {
                     if ($specifiedGateway = $this->params->get('gateway')) {
                         return $gateway['handle'] === $specifiedGateway;
@@ -65,7 +65,7 @@ class CheckoutTags extends SubTag
         $cart = $this->getCart();
         $gatewayHandle = last(explode(':', $tag));
 
-        $gateway = collect(SimpleCommerce::gateways())
+        $gateway = SimpleCommerce::gateways()
             ->where('handle', $gatewayHandle)
             ->first();
 

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -3,7 +3,6 @@
 namespace DoubleThreeDigital\SimpleCommerce\Tags;
 
 use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayDoesNotExist;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayException;
 use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;

--- a/src/Tags/GatewayTags.php
+++ b/src/Tags/GatewayTags.php
@@ -8,18 +8,18 @@ class GatewayTags extends SubTag
 {
     public function index()
     {
-        return SimpleCommerce::gateways();
+        return SimpleCommerce::gateways()->toArray();
     }
 
     public function count()
     {
-        return count(SimpleCommerce::gateways());
+        return SimpleCommerce::gateways()->count();
     }
 
     // {{ sc:gateways:stripe }}
     public function wildcard(string $tag)
     {
-        return collect(SimpleCommerce::gateways())
+        return SimpleCommerce::gateways()
             ->where('handle', $tag)
             ->first();
     }

--- a/tests/Fieldtypes/GatewayFieldtypeTest.php
+++ b/tests/Fieldtypes/GatewayFieldtypeTest.php
@@ -107,7 +107,7 @@ class GatewayFieldtypeTest extends TestCase
         $this->assertArrayHasKey('formatted_class', $augment);
         $this->assertArrayHasKey('display', $augment);
         $this->assertArrayHasKey('checkoutRules', $augment);
-        $this->assertArrayHasKey('gateway-config', $augment);
+        $this->assertArrayHasKey('config', $augment);
         $this->assertArrayHasKey('webhook_url', $augment);
         $this->assertArrayHasKey('data', $augment);
     }

--- a/tests/Tags/CheckoutTagTest.php
+++ b/tests/Tags/CheckoutTagTest.php
@@ -60,7 +60,7 @@ class CheckoutTagTest extends TestCase
 
             {{ sc:gateways }}
                 ---
-                {{ name }} - Duncan Cool ({{ gateway-config:is-duncan-cool }}) - Haggis - Tatties
+                {{ name }} - Duncan Cool ({{ config:is-duncan-cool }}) - Haggis - Tatties
                 ---
             {{ /sc:gateways }}
         ');


### PR DESCRIPTION
It did return an array but we wrapped it in `collect` everywhere we used it so it made sense for it to be a collection in the first place.
