### PR TITLE
v5.0: Support for Stripe Payment Elements

### DIFF
--- a/docs/payment-gateways/stripe.md
+++ b/docs/payment-gateways/stripe.md
@@ -2,10 +2,6 @@
 title: Stripe Payment Gateway
 ---
 
-:::note Note!
-Simple Commerce currently only supports the ['Card Element' integration](https://stripe.com/docs/payments/accept-card-payments?platform=web&ui=elements) with Stripe. The new 'Payment Element' integration is on the roadmap for later this year.
-:::
-
 ## Configuration
 
 First, you'll need to add Stripe to your `simple-commerce.php` config file. You will also need to pass in a `key` and `secret` file.
@@ -23,58 +19,157 @@ You can obtain [your API keys](https://dashboard.stripe.com/test/apikeys) from t
 
 > It's best practice to use `.env` file for any API keys you need, rather than referencing them directly in your config file. [Review Statamic Docs](https://statamic.dev/configuration#environment-variables).
 
-## Payment Form
+## Payment flow
 
-Stripe recommend using their Elements library to capture credit card information as it means your customers' card information never touches your server, which is good for a whole load of reasons.
+Since v5.x, Stripe is considered an off-site gateway, which means after the customer has entered their payment details, they're redirected (by Stripe) to a 'checkout success' page. Here's a quick run down of how the whole process works:
 
-The payment form should be included inside your `{{ sc:checkout }}` form, and any Stripe Elements magic should also be wrapped in the `{{ sc:gateways }}` tag to ensure you can make full use of your gateway's configuration values.
+1. On your "Checkout" page, the customer enters their payment information
+2. When the user submits the checkout page, their payment is confirmed by Stripe
+3. Stripe sends a webhook to the server, letting Simple Commerce know the payment has taken place.
+4. The customer is then redirected (by Stripe) to a Simple Commerce URL which then redirects the user to a 'checkout success' page.
 
-A rough example of a Stripe Elements implementation is provided below.
+## Checkout page
+
+Stripe recommends using their [Stripe Elements](https://stripe.com/en-gb/payments/elements) library to capture payment information. It means that your customer's payment details never touch your server, only Stripe's.
+
+On your checkout page, you'll want to loop through `{{ sc:gateways }}`. When it's Stripe, you'll want to display the Stripe Payment Element on your page, like so:
 
 ```antlers
 <div>
-    <label for="card-element">Card Details</label>
-    <div id="card-element"></div>
+    <div id="payment-element">
+        <!--Stripe.js injects the Payment Element-->
+    </div>
+    <div id="payment-message" class="hidden"></div>
 </div>
 
 <input id="stripePaymentMethod" type="hidden" name="payment_method">
-<input type="hidden" name="gateway" value="DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway">
 
 <script src="https://js.stripe.com/v3/"></script>
 <script>
-    var stripe = Stripe('{{ stripe:config:key }}')
-    var elements = stripe.elements()
+    var stripe = Stripe('{{ stripe:config:key }}');
 
-    const card = elements.create('card')
-    card.mount('#card-element')
+    let elements;
 
-    card.addEventListener('change', ({error}) => {
-        // Deal with errors
-    })
+    checkStatus();
 
-    function confirmPayment() {
-        stripe.confirmCardPayment('{{ stripe:client_secret }}', {
-            payment_method: { card: card },
-        }).then(function (result) {
-          	if (result.paymentIntent.status === 'succeeded') {
-            	document.getElementById('stripePaymentMethod').value = result.paymentIntent.payment_method
-            	document.getElementById('checkout-form').submit()
-            } else if (result.error) {
-             	// Deal with errors
-            }
-        })
+    elements = stripe.elements({
+        clientSecret: '{{ stripe:client_secret }}'
+    });
+
+    const paymentElementOptions = {
+        layout: "tabs",
+    };
+
+    const paymentElement = elements.create("payment", paymentElementOptions);
+    paymentElement.mount("#payment-element");
+
+    async function confirmPayment() {
+        const {
+            error
+        } = await stripe.confirmPayment({
+            elements,
+            confirmParams: {
+                return_url: "{{ stripe:callback_url }}",
+            },
+        });
+
+        // This point will only be reached if there is an immediate error when
+        // confirming the payment. Otherwise, your customer will be redirected to
+        // your `return_url`. For some payment methods like iDEAL, your customer will
+        // be redirected to an intermediate site first to authorize the payment, then
+        // redirected to the `return_url`.
+        if (error.type === "card_error" || error.type === "validation_error") {
+            showMessage(error.message);
+        } else {
+            showMessage("An unexpected error occurred.");
+        }
     }
 
-    document.getElementById('checkout-form').addEventListener('submit', (e) => {
-        e.preventDefault()
-	confirmPayment()
-    })
+    // Fetches the payment intent status after payment submission
+    async function checkStatus() {
+        const clientSecret = new URLSearchParams(window.location.search).get(
+            "payment_intent_client_secret"
+        );
+
+        if (!clientSecret) {
+            return;
+        }
+
+        const {
+            paymentIntent
+        } = await stripe.retrievePaymentIntent(clientSecret);
+
+        switch (paymentIntent.status) {
+            case "succeeded":
+                showMessage("Payment succeeded!");
+                break;
+            case "processing":
+                showMessage("Your payment is processing.");
+                break;
+            case "requires_payment_method":
+                showMessage("Your payment was not successful, please try again.");
+                break;
+            default:
+                showMessage("Something went wrong.");
+                break;
+        }
+    }
+
+    // ------- UI helpers -------
+
+    function showMessage(messageText) {
+        const messageContainer = document.querySelector("#payment-message");
+
+        messageContainer.classList.remove("hidden");
+        messageContainer.textContent = messageText;
+
+        setTimeout(function() {
+            messageContainer.classList.add("hidden");
+            messageText.textContent = "";
+        }, 4000);
+    }
 </script>
 ```
 
-Bearing in mind, you will need to use that inside of a `{{ sc:gateways }}` tag in order to use any values from your gateway config.
+When using the above example, you'll want to hit the `confirmPayment` function whenever your customer submits the checkout form.
 
-## Payment Intent
+### Handling Stripe's webhook
+
+Whenever a payment is made with Stripe, it needs to be able to communicate that with Simple Commerce. It does this using 'webhooks', which are essentially `POST` requests sent by Stripe to your server that provide details about the payment.
+
+You'll need to configure the webhook in the Stripe Dashboard:
+
+1. Navigate to the 'Developers' section (top right)
+2. If you're in development, ensure you have the 'test mode' toggle enabled (also in the top right)
+3. On the left hand side, click on 'Webhooks'
+4. Click 'Add an endpoint'
+5. You'll now be asked to enter details about your new webhook:
+    - Endpoint URL: This will be the URL of the webhook, like `https://example.com/!/simple-commerce/gateways/stripe/webhook` (ensure that URL is reachable by Stripe - see note below)
+    - Version: Select the latest version available
+    - Select events to listen to:
+        - `payment_intent.succeeded`
+        - `payment_intent.failed`
+        - `charge.refunded`
+
+You will also need to add the webhook's URL to your list of CSRF exceptions, which can be found in `app/Http/Middleware/VerifyCsrfToken.php`.
+
+```php
+protected $except = [
+  '/!/simple-commerce/gateways/stripe/webhook',
+];
+```
+
+:::note Note!
+When you're going through the payment flow in your development environment, you will need to use something like Expose or Ngrok to proxy request to your local server. Otherwise, Stripe wouldn't be able to hit the webhook. You will also need to update the `APP_URL` in your `.env`.
+:::
+
+## Testing
+
+Stripe provides ways to test different scenarios, depending on your payment method. You can review [Stripe's documentation](https://stripe.com/docs/testing) for more details.
+
+## Customisation
+
+### Payment Intent
 
 During the 'prepare' stage, Simple Commerce creates a [Stripe Payment Intent](https://stripe.com/docs/payments/payment-intents#creating-a-paymentintent). The Payment Intent generates a 'client secret' which is later given to Stripe Elements to render the payment fields.
 
@@ -100,4 +195,6 @@ You may do this easily by providing a closure in the Stripe gateway config:
 
 The closure should accept an `$order` parameter and should then return an array which will be merged with the defaults.
 
-It's worth nothing that Laravel doesn't support using closures in config files alongside config caching.
+:::warning Warning!
+Laravel doesn't support using closures inside config files when using config caching.
+:::

--- a/docs/upgrade-guides/v4-x-to-v5-0.md
+++ b/docs/upgrade-guides/v4-x-to-v5-0.md
@@ -99,6 +99,40 @@ Due to the format changing, you may need to update code in your checkout form.
 3. If you're getting the callback URL for a gateway, you should get it from that gateway's array:
     - `{{ callback_url }}` -> `{{ stripe:callback_url }}`
 
+### High: Stripe Gateway now defaults to Payment Elements integration
+
+By default, Simple Commerce now takes advantage of Stripe's Payment Elements integration. This allows for customers to pick the payment methods that work for them - the payment methods are localised based on the user's location.
+
+Any existing sites though will be using Card Elements, which just gives you a basic card payment form. To continue using in Card Elements, you'll need to specify a `mode` in your Gateways config.
+
+```php
+// config/simple-commerce.php
+
+/*
+|--------------------------------------------------------------------------
+| Payment Gateways
+|--------------------------------------------------------------------------
+|
+| This is where you configure the payment gateways you wish to use across
+| your site. You may configure as many as you like.
+|
+| https://simple-commerce.duncanmcclean.com/gateways
+|
+*/
+
+'gateways' => [
+    \DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway::class => [ // [tl! focus]
+        'key' => env('STRIPE_KEY'), // [tl! focus]
+        'secret' => env('STRIPE_SECRET'), // [tl! focus]
+        'mode' => 'card_elements',  // [tl! add] [tl! focus]
+    ], // [tl! focus]
+
+    \DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\DummyGateway::class => [
+        'display' => 'Card',
+    ],
+],
+```
+
 ### Medium: Support for Statamic 3.3 has been dropped
 
 Simple Commerce has dropped support for Statamic 3.3, leaving only Statamic 3.4 the only current version supported.

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -220,4 +220,14 @@ class StripeGateway extends BaseGateway implements Gateway
 
         $this->isUsingTestMode = str_contains($this->config()->get('secret'), 'sk_test_');
     }
+
+    protected function inCardElementsMode(): bool
+    {
+        return $this->config()->get('mode', 'payment_elements') === 'card_elements';
+    }
+
+    protected function inPaymentElementsMode(): bool
+    {
+        return $this->config()->get('mode', 'payment_elements') === 'payment_elements';
+    }
 }

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -160,7 +160,7 @@ class StripeGateway extends BaseGateway implements Gateway
         if ($method === 'handlePaymentIntentSucceeded') {
             $order = Order::find($data['metadata']['order_id']);
 
-            $order->updatePaymentStatus(PaymentStatus::Paid);
+            $this->markOrderAsPaid($order);
 
             return new Response('Webhook handled', 200);
         }

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -32,6 +32,11 @@ class StripeGateway extends BaseGateway implements Gateway
         return __('Stripe');
     }
 
+    public function isOffsiteGateway(): bool
+    {
+        return $this->inPaymentElementsMode();
+    }
+
     public function prepare(Request $request, OrderContract $order): array
     {
         $this->setUpWithStripe();
@@ -80,6 +85,10 @@ class StripeGateway extends BaseGateway implements Gateway
 
     public function checkout(Request $request, OrderContract $order): array
     {
+        if ($this->inPaymentElementsMode()) {
+            return parent::checkout($request, $order);
+        }
+
         $this->setUpWithStripe();
 
         $paymentIntent = PaymentIntent::retrieve($order->get('stripe')['intent']);

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -8,6 +8,7 @@ use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway;
+use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
 use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
 use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\RefreshContent;
 use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
@@ -486,9 +487,14 @@ class StripeGatewayTest extends TestCase
             ],
         ];
 
-        $webhook = $this->cardElementsGateway->webhook(new Request([], [], [], [], [], [], json_encode($payload)));
+        $webhook = $this->paymentElementsGateway->webhook(new Request([], [], [], [], [], [], json_encode($payload)));
 
         $this->assertTrue($webhook instanceof Response);
+
+        $order->fresh();
+
+        $this->assertSame($order->status(), OrderStatus::Placed);
+        $this->assertSame($order->paymentStatus(), PaymentStatus::Paid);
     }
 
     /** @test */

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -22,7 +22,7 @@ class StripeGatewayTest extends TestCase
 {
     use SetupCollections, RefreshContent;
 
-    public StripeGateway $gateway;
+    public StripeGateway $cardElementsGateway;
 
     public function setUp(): void
     {
@@ -30,15 +30,16 @@ class StripeGatewayTest extends TestCase
 
         $this->setupCollections();
 
-        $this->gateway = new StripeGateway([
+        $this->cardElementsGateway = new StripeGateway([
             'secret' => env('STRIPE_SECRET'),
+            'mode' => 'card_elements',
         ]);
     }
 
     /** @test */
     public function has_a_name()
     {
-        $name = $this->gateway->name();
+        $name = $this->cardElementsGateway->name();
 
         $this->assertIsString($name);
         $this->assertSame('Stripe', $name);
@@ -73,7 +74,7 @@ class StripeGatewayTest extends TestCase
 
         $order->save();
 
-        $prepare = $this->gateway->prepare(
+        $prepare = $this->cardElementsGateway->prepare(
             new Request(),
             $order
         );
@@ -123,7 +124,7 @@ class StripeGatewayTest extends TestCase
 
         $order->save();
 
-        $prepare = $this->gateway->prepare(
+        $prepare = $this->cardElementsGateway->prepare(
             new Request(),
             $order
         );
@@ -165,7 +166,7 @@ class StripeGatewayTest extends TestCase
         $customer = Customer::make()->email('george@example.com')->data(['name' => 'George']);
         $customer->save();
 
-        $this->gateway->setConfig([
+        $this->cardElementsGateway->setConfig([
             'secret' => env('STRIPE_SECRET'),
             'receipt_email' => true,
         ]);
@@ -184,7 +185,7 @@ class StripeGatewayTest extends TestCase
 
         $order->save();
 
-        $prepare = $this->gateway->prepare(
+        $prepare = $this->cardElementsGateway->prepare(
             new Request(),
             $order
         );
@@ -215,7 +216,7 @@ class StripeGatewayTest extends TestCase
             $this->markTestSkipped('Skipping, no Stripe Secret has been defined for this environment.');
         }
 
-        $this->gateway->setConfig([
+        $this->cardElementsGateway->setConfig([
             'secret' => env('STRIPE_SECRET'),
             'payment_intent_data' => function (ContractsOrder $order) {
                 return [
@@ -249,7 +250,7 @@ class StripeGatewayTest extends TestCase
 
         $order->save();
 
-        $prepare = $this->gateway->prepare(
+        $prepare = $this->cardElementsGateway->prepare(
             new Request(),
             $order
         );
@@ -268,7 +269,7 @@ class StripeGatewayTest extends TestCase
         $this->assertNull($paymentIntent->customer);
         $this->assertNull($paymentIntent->receipt_email);
 
-        $this->gateway->setConfig([
+        $this->cardElementsGateway->setConfig([
             'secret' => env('STRIPE_SECRET'),
         ]);
     }
@@ -326,7 +327,7 @@ class StripeGatewayTest extends TestCase
 
         $request = new Request(['payment_method' => $paymentMethod->id]);
 
-        $checkout = $this->gateway->checkout($request, $order);
+        $checkout = $this->cardElementsGateway->checkout($request, $order);
 
         $this->assertIsArray($checkout);
 
@@ -389,7 +390,7 @@ class StripeGatewayTest extends TestCase
             'payment_method' => $paymentMethod->id,
         ]);
 
-        $refund = $this->gateway->refund($order);
+        $refund = $this->cardElementsGateway->refund($order);
 
         $this->assertIsArray($refund);
 
@@ -415,7 +416,7 @@ class StripeGatewayTest extends TestCase
             ],
         ];
 
-        $webhook = $this->gateway->webhook(new Request([], [], [], [], [], [], json_encode($payload)));
+        $webhook = $this->cardElementsGateway->webhook(new Request([], [], [], [], [], [], json_encode($payload)));
 
         $this->assertTrue($webhook instanceof Response);
     }
@@ -429,7 +430,7 @@ class StripeGatewayTest extends TestCase
 
         Stripe::setApiKey(env('STRIPE_SECRET'));
 
-        $fieldtypeDisplay = $this->gateway->fieldtypeDisplay([
+        $fieldtypeDisplay = $this->cardElementsGateway->fieldtypeDisplay([
             'use' => StripeGateway::class,
             'data' => [
                 'payment_intent' => $paymentIntent = PaymentIntent::create([
@@ -450,7 +451,7 @@ class StripeGatewayTest extends TestCase
     /** @test */
     public function does_not_return_array_from_payment_display_if_no_payment_intent_is_set()
     {
-        $fieldtypeDisplay = $this->gateway->fieldtypeDisplay([
+        $fieldtypeDisplay = $this->cardElementsGateway->fieldtypeDisplay([
             'use' => StripeGateway::class,
             'data' => [],
         ]);


### PR DESCRIPTION
This pull request makes the changes necessary for Simple Commerce to work with Stripe's *new* [Payment Elements](https://stripe.com/docs/payments/payment-element) solution.

Up until now, the Stripe Gateway has only supported Card Elements which are now no longer recommended by Stripe for new projects.

It also means stores will be able to accept more payment methods than just card - like Klarna, Apple Pay and other local payment methods.

Due to the way Payment Elements work, Stripe will now be considered an 'off-site' gateway since the customer never actually submits the `{{ sc:checkout }}` form. 

## Existing sites

Everything will continue to work exactly the same way for existing sites using the Card Elements implementation.

However, when you update, a `mode` setting will be added to the Stripe gateway's config. 

## To Do

* [x] Mention specifying a `mode` in the upgrade guide
* [x] Re-write documentation for Stripe Gateway
* [x] Make changes to the Starter Kit