### PR TITLE
v5.0: Refactor Checkout Pipeline

### DIFF
--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -14,10 +14,10 @@ use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
 use DoubleThreeDigital\SimpleCommerce\Http\Requests\AcceptsFormRequests;
 use DoubleThreeDigital\SimpleCommerce\Http\Requests\Checkout\StoreRequest;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DoubleThreeDigital\SimpleCommerce\Orders\Checkout\CheckoutPipeline;
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
 use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
 use DoubleThreeDigital\SimpleCommerce\Rules\ValidCoupon;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -70,7 +70,7 @@ class CheckoutController extends BaseActionController
         ]);
     }
 
-    protected function handleAdditionalValidation()
+    protected function handleAdditionalValidation(): self
     {
         $rules = array_merge(
             $this->request->get('_request')
@@ -104,7 +104,7 @@ class CheckoutController extends BaseActionController
         return $this;
     }
 
-    protected function handleCustomerDetails()
+    protected function handleCustomerDetails(): self
     {
         $customerData = $this->request->has('customer')
             ? $this->request->get('customer')
@@ -180,7 +180,13 @@ class CheckoutController extends BaseActionController
         return $this;
     }
 
-    protected function handleStock()
+    /**
+     * We need to handle the stock here, before we handle the payment. This is in
+     * case we don't have any stock left for a product in the customer's cart, we can
+     * throw an error and not worry about the customer being charged for a product that
+     * they can't get.
+     */
+    protected function handleStock(): self
     {
         $this->order = app(Pipeline::class)
             ->send($this->order)
@@ -192,7 +198,7 @@ class CheckoutController extends BaseActionController
         return $this;
     }
 
-    protected function handleCoupon()
+    protected function handleCoupon(): self
     {
         if ($coupon = $this->request->get('coupon')) {
             $coupon = Coupon::findByCode($coupon);
@@ -206,7 +212,7 @@ class CheckoutController extends BaseActionController
         return $this;
     }
 
-    protected function handleRemainingData()
+    protected function handleRemainingData(): self
     {
         $data = [];
 
@@ -230,7 +236,7 @@ class CheckoutController extends BaseActionController
         return $this;
     }
 
-    protected function handlePayment()
+    protected function handlePayment(): self
     {
         $this->order = $this->order->recalculate();
 
@@ -257,25 +263,16 @@ class CheckoutController extends BaseActionController
         return $this;
     }
 
-    protected function postCheckout()
+    protected function postCheckout(): self
     {
-        if (! isset(SimpleCommerce::customerDriver()['model']) && $this->order->customer()) {
-            $this->order->customer()->merge([
-                'orders' => $this->order->customer()->orders()
-                    ->pluck('id')
-                    ->push($this->order->id())
-                    ->toArray(),
-            ]);
+        $this->order = CheckoutPipeline::run($this->order);
 
-            $this->order->customer()->save();
-        }
-
-        if (! $this->request->has('gateway') && $this->order->status() !== PaymentStatus::Paid && $this->order->grandTotal() === 0) {
+        if (
+            ! $this->request->has('gateway')
+            && $this->order->status() !== PaymentStatus::Paid
+            && $this->order->grandTotal() === 0
+        ) {
             $this->order->updatePaymentStatus(PaymentStatus::Paid);
-        }
-
-        if ($this->order->coupon()) {
-            $this->order->coupon()->redeem();
         }
 
         $this->forgetCart();

--- a/src/Orders/Checkout/CheckoutPipeline.php
+++ b/src/Orders/Checkout/CheckoutPipeline.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Orders\Checkout;
+
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use Illuminate\Pipeline\Pipeline;
+
+class CheckoutPipeline extends Pipeline
+{
+    public static function run(Order $order, bool $offsiteCheckout = false): Order
+    {
+        $pipes = [
+            \DoubleThreeDigital\SimpleCommerce\Orders\Checkout\StoreCustomerOrders::class,
+            \DoubleThreeDigital\SimpleCommerce\Orders\Checkout\RedeemCoupon::class,
+        ];
+
+        if ($offsiteCheckout) {
+            $pipes[] = \DoubleThreeDigital\SimpleCommerce\Orders\Checkout\HandleStock::class;
+        }
+
+        return app(self::class)->send($order)->through($pipes)->thenReturn();
+    }
+}

--- a/src/Orders/Checkout/RedeemCoupon.php
+++ b/src/Orders/Checkout/RedeemCoupon.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Orders\Checkout;
+
+use Closure;
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+
+class RedeemCoupon
+{
+    public function handle(Order $order, Closure $next)
+    {
+        if ($order->coupon()) {
+            $order->coupon()->redeem();
+        }
+
+        return $next($order);
+    }
+}

--- a/src/Orders/Checkout/StoreCustomerOrders.php
+++ b/src/Orders/Checkout/StoreCustomerOrders.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Orders\Checkout;
+
+use Closure;
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+
+class StoreCustomerOrders
+{
+    public function handle(Order $order, Closure $next)
+    {
+        if (! isset(SimpleCommerce::customerDriver()['model']) && $order->customer()) {
+            $order->customer()->merge([
+                'orders' => $order->customer()->orders()
+                    ->pluck('id')
+                    ->push($order->id())
+                    ->toArray(),
+            ]);
+
+            $order->customer()->save();
+        }
+
+        return $next($order);
+    }
+}


### PR DESCRIPTION
This pull request refactors the commonly used checkout logic, used for both on-site & off-site checkouts so that the code only needs to be written in a single place.

We're taking advantage of Laravel's Pipeline functionality to do this. Although, we have our own `run` method & don't have the pipes defined as a property on the `CheckoutPipeline` class. This is because the `HandleStock` pipe should only be run for off-site gateways (it is still run for on-site gateways but it's done earlier in the request). 

This PR also adds typehints to the methods in the `CheckoutController`. 

All existing tests pass which is perfect!