### PR TITLE
v5.0: Drop PHP 8.1 support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           tools: composer:v2
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.2]
+        php: [8.2]
         laravel: [9.*]
         statamic: [3.4.*]
         os: [ubuntu-latest]

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "laravel/framework": "^9.49.0",
         "mollie/mollie-api-php": "^2.30.0",
         "moneyphp/money": "^4.0",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@ To install Simple Commerce, there's two routes you can take. You can either [ins
 
 To run Simple Commerce, your server (whether local or production) will need to meet the following requirements:
 
--   PHP 8.1+
+-   PHP 8.2
 -   Laravel 9
 -   [PHP `intl` extension](https://www.php.net/manual/en/book.intl.php)
 -   [Statamic CLI](https://github.com/statamic/cli)

--- a/docs/upgrade-guides/v4-x-to-v5-0.md
+++ b/docs/upgrade-guides/v4-x-to-v5-0.md
@@ -137,9 +137,13 @@ Any existing sites though will be using Card Elements, which just gives you a ba
 ],
 ```
 
+### Medium: Support for PHP 8.1 has been dropped
+
+Simple Commerce has dropped support for PHP 8.1, leaving only PHP 8.2 supported.
+
 ### Medium: Support for Statamic 3.3 has been dropped
 
-Simple Commerce has dropped support for Statamic 3.3, leaving only Statamic 3.4 the only current version supported.
+Simple Commerce has dropped support for Statamic 3.3, leaving only Statamic 3.4 supported.
 
 To upgrade to Statamic 3.4, you should follow the steps outlined in the official [Upgrade Guide](https://statamic.dev/upgrade-guide/3-3-to-3-4).
 


### PR DESCRIPTION
This pull request drops support for PHP 8.1 in v5. You must use PHP 8.2.