### PR TITLE
v5.0: Some more refactoring of the Checkout Pipeline

### DIFF
--- a/src/Exceptions/CheckoutProductHasNoStockException.php
+++ b/src/Exceptions/CheckoutProductHasNoStockException.php
@@ -3,29 +3,13 @@
 namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
 
 use DoubleThreeDigital\SimpleCommerce\Contracts\Product;
-use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
 
-class CheckoutProductHasNoStockException extends \Exception
+class CheckoutProductHasNoStockException extends PreventCheckout
 {
-    public $product;
-
-    public $variant;
-
-    public function __construct(Product $product, $variant = null)
+    public function __construct(string $message, public Product $product, public $variant = null)
     {
         $this->product = $product;
         $this->variant = $variant;
-
-        if ($product->purchasableType() === ProductType::Product) {
-            $message = __('Product :product does not have any available stock.', ['product' => $product->id()]);
-        }
-
-        if ($product->purchasableType() === ProductType::Variant) {
-            $message = __('Variant :variant on :product does not have any available stock.', [
-                'variant' => $variant->key(),
-                'product' => $product->id(),
-            ]);
-        }
 
         parent::__construct($message);
     }

--- a/src/Exceptions/CheckoutProductHasNoStockException.php
+++ b/src/Exceptions/CheckoutProductHasNoStockException.php
@@ -21,7 +21,7 @@ class CheckoutProductHasNoStockException extends \Exception
         }
 
         if ($product->purchasableType() === ProductType::Variant) {
-            $message = __('Variant :variant on :product does not have any available stock', [
+            $message = __('Variant :variant on :product does not have any available stock.', [
                 'variant' => $variant->key(),
                 'product' => $product->id(),
             ]);

--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -136,7 +136,9 @@ abstract class BaseGateway
         ]);
 
         if ($this->isOffsiteGateway()) {
-            $order = CheckoutPipeline::run($order, true);
+            $order = app(CheckoutPipeline::class)
+                ->send($order)
+                ->thenReturn();
 
             $order->updateOrderStatus(OrderStatus::Placed);
             $order->updatePaymentStatus(PaymentStatus::Paid);

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -46,8 +46,8 @@ class CheckoutController extends BaseActionController
                 ->handleAdditionalValidation()
                 ->handleCustomerDetails()
                 ->handleCoupon()
-                ->handleCheckoutValidation()
                 ->handleRemainingData()
+                ->handleCheckoutValidation()
                 ->handlePayment()
                 ->postCheckout();
         } catch (CheckoutProductHasNoStockException $e) {
@@ -194,15 +194,6 @@ class CheckoutController extends BaseActionController
         return $this;
     }
 
-    protected function handleCheckoutValidation(): self
-    {
-        $this->order = app(CheckoutValidationPipeline::class)
-            ->send($this->order)
-            ->thenReturn();
-
-        return $this;
-    }
-
     protected function handleRemainingData(): self
     {
         $data = [];
@@ -223,6 +214,15 @@ class CheckoutController extends BaseActionController
 
             $this->order = $this->order->fresh();
         }
+
+        return $this;
+    }
+
+    protected function handleCheckoutValidation(): self
+    {
+        $this->order = app(CheckoutValidationPipeline::class)
+            ->send($this->order)
+            ->thenReturn();
 
         return $this;
     }

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -4,7 +4,6 @@ namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers;
 
 use DoubleThreeDigital\SimpleCommerce\Events\PostCheckout;
 use DoubleThreeDigital\SimpleCommerce\Events\PreCheckout;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CheckoutProductHasNoStockException;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayNotProvided;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\PreventCheckout;
@@ -50,15 +49,6 @@ class CheckoutController extends BaseActionController
                 ->handleCheckoutValidation()
                 ->handlePayment()
                 ->postCheckout();
-        } catch (CheckoutProductHasNoStockException $e) {
-            $lineItem = $this->order->lineItems()->filter(function ($lineItem) use ($e) {
-                return $lineItem->product()->id() === $e->product->id();
-            })->first();
-
-            $this->order->removeLineItem($lineItem->id());
-            $this->order->save();
-
-            return $this->withErrors($this->request, __('Checkout failed. A product in your cart has no stock left. The product has been removed from your cart.'));
         } catch (PreventCheckout $e) {
             return $this->withErrors($this->request, $e->getMessage());
         }

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -15,10 +15,10 @@ use DoubleThreeDigital\SimpleCommerce\Http\Requests\AcceptsFormRequests;
 use DoubleThreeDigital\SimpleCommerce\Http\Requests\Checkout\StoreRequest;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use DoubleThreeDigital\SimpleCommerce\Orders\Checkout\CheckoutPipeline;
+use DoubleThreeDigital\SimpleCommerce\Orders\Checkout\CheckoutValidationPipeline;
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
 use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
 use DoubleThreeDigital\SimpleCommerce\Rules\ValidCoupon;
-use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Statamic\Facades\Site;
@@ -46,12 +46,10 @@ class CheckoutController extends BaseActionController
                 ->handleAdditionalValidation()
                 ->handleCustomerDetails()
                 ->handleCoupon()
-                ->handleStock()
+                ->handleCheckoutValidation()
                 ->handleRemainingData()
                 ->handlePayment()
                 ->postCheckout();
-
-            $this->order->updateOrderStatus(OrderStatus::Placed);
         } catch (CheckoutProductHasNoStockException $e) {
             $lineItem = $this->order->lineItems()->filter(function ($lineItem) use ($e) {
                 return $lineItem->product()->id() === $e->product->id();
@@ -182,24 +180,6 @@ class CheckoutController extends BaseActionController
         return $this;
     }
 
-    /**
-     * We need to handle the stock here, before we handle the payment. This is in
-     * case we don't have any stock left for a product in the customer's cart, we can
-     * throw an error and not worry about the customer being charged for a product that
-     * they can't get.
-     */
-    protected function handleStock(): self
-    {
-        $this->order = app(Pipeline::class)
-            ->send($this->order)
-            ->through([
-                \DoubleThreeDigital\SimpleCommerce\Orders\Checkout\HandleStock::class,
-            ])
-            ->thenReturn();
-
-        return $this;
-    }
-
     protected function handleCoupon(): self
     {
         if ($coupon = $this->request->get('coupon')) {
@@ -210,6 +190,15 @@ class CheckoutController extends BaseActionController
 
             $this->excludedKeys[] = 'coupon';
         }
+
+        return $this;
+    }
+
+    protected function handleCheckoutValidation(): self
+    {
+        $this->order = app(CheckoutValidationPipeline::class)
+            ->send($this->order)
+            ->thenReturn();
 
         return $this;
     }
@@ -267,7 +256,9 @@ class CheckoutController extends BaseActionController
 
     protected function postCheckout(): self
     {
-        $this->order = CheckoutPipeline::run($this->order);
+        $this->order = app(CheckoutPipeline::class)
+            ->send($this->order)
+            ->thenReturn();
 
         if (
             ! $this->request->has('gateway')
@@ -276,6 +267,8 @@ class CheckoutController extends BaseActionController
         ) {
             $this->order->updatePaymentStatus(PaymentStatus::Paid);
         }
+
+        $this->order->updateOrderStatus(OrderStatus::Placed);
 
         $this->forgetCart();
 

--- a/src/Orders/Checkout/CheckoutValidationPipeline.php
+++ b/src/Orders/Checkout/CheckoutValidationPipeline.php
@@ -4,11 +4,9 @@ namespace DoubleThreeDigital\SimpleCommerce\Orders\Checkout;
 
 use Illuminate\Pipeline\Pipeline;
 
-class CheckoutPipeline extends Pipeline
+class CheckoutValidationPipeline extends Pipeline
 {
     protected $pipes = [
-        StoreCustomerOrders::class,
-        RedeemCoupon::class,
-        UpdateProductStock::class,
+        ValidateProductStock::class,
     ];
 }

--- a/src/Orders/Checkout/UpdateProductStock.php
+++ b/src/Orders/Checkout/UpdateProductStock.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Orders\Checkout;
+
+use Closure;
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DoubleThreeDigital\SimpleCommerce\Events\StockRunningLow;
+use DoubleThreeDigital\SimpleCommerce\Events\StockRunOut;
+use DoubleThreeDigital\SimpleCommerce\Exceptions\CheckoutProductHasNoStockException;
+use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
+use DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository;
+use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+
+class UpdateProductStock
+{
+    public function handle(Order $order, Closure $next)
+    {
+        $order->lineItems()
+            ->each(function (LineItem $item) {
+                $product = $item->product();
+
+                // Multi-site: Is the Stock field not localised? If so, we want the origin
+                // version of the product for stock purposes.
+                if (
+                    $this->isOrExtendsClass(SimpleCommerce::productDriver()['repository'], EntryProductRepository::class)
+                    && $product->resource()->hasOrigin()
+                    && $product->resource()->blueprint()->hasField('stock')
+                    && ! $product->resource()->blueprint()->field('stock')->isLocalizable()
+                ) {
+                    $product = Product::find($product->resource()->origin()->id());
+                }
+
+                if ($product->purchasableType() === ProductType::Product) {
+                    if (is_int($product->stock())) {
+                        $stock = $product->stock() - $item->quantity();
+
+                        $product->stock(
+                            $stock = $product->stock() - $item->quantity()
+                        );
+
+                        $product->save();
+
+                        if ($stock <= 0) {
+                            event(new StockRunOut(
+                                product: $product,
+                                variant: null,
+                                stock: $stock,
+                            ));
+                        }
+
+                        if ($stock <= config('simple-commerce.low_stock_threshold', 10)) {
+                            event(new StockRunningLow(
+                                product: $product,
+                                variant: null,
+                                stock: $stock,
+                            ));
+                        }
+                    }
+                }
+
+                if ($product->purchasableType() === ProductType::Variant) {
+                    $variant = $product->variant($item->variant()['variant'] ?? $item->variant());
+
+                    if ($variant !== null && is_int($variant->stock())) {
+                        $stock = $variant->stock() - $item->quantity();
+
+                        $variant->stock(
+                            $stock = $variant->stock() - $item->quantity()
+                        );
+
+                        $variant->save();
+
+                        if ($stock <= 0) {
+                            event(new StockRunOut(
+                                product: $product,
+                                variant: $variant,
+                                stock: $stock,
+                            ));
+                        }
+
+                        if ($stock <= config('simple-commerce.low_stock_threshold', 10)) {
+                            event(new StockRunningLow(
+                                product: $product,
+                                variant: $variant,
+                                stock: $stock,
+                            ));
+                        }
+                    }
+                }
+            });
+
+        return $next($order);
+    }
+
+    protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool
+    {
+        return is_subclass_of($class, $classToCheckAgainst)
+            || $class === $classToCheckAgainst;
+    }
+}

--- a/src/Orders/Checkout/UpdateProductStock.php
+++ b/src/Orders/Checkout/UpdateProductStock.php
@@ -6,7 +6,6 @@ use Closure;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use DoubleThreeDigital\SimpleCommerce\Events\StockRunningLow;
 use DoubleThreeDigital\SimpleCommerce\Events\StockRunOut;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CheckoutProductHasNoStockException;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
 use DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository;

--- a/src/Orders/Checkout/UpdateProductStock.php
+++ b/src/Orders/Checkout/UpdateProductStock.php
@@ -17,8 +17,8 @@ class UpdateProductStock
     public function handle(Order $order, Closure $next)
     {
         $order->lineItems()
-            ->each(function (LineItem $item) {
-                $product = $item->product();
+            ->each(function (LineItem $lineItem) {
+                $product = $lineItem->product();
 
                 // Multi-site: Is the Stock field not localised? If so, we want the origin
                 // version of the product for stock purposes.
@@ -33,10 +33,10 @@ class UpdateProductStock
 
                 if ($product->purchasableType() === ProductType::Product) {
                     if (is_int($product->stock())) {
-                        $stock = $product->stock() - $item->quantity();
+                        $stock = $product->stock() - $lineItem->quantity();
 
                         $product->stock(
-                            $stock = $product->stock() - $item->quantity()
+                            $stock = $product->stock() - $lineItem->quantity()
                         );
 
                         $product->save();
@@ -60,13 +60,13 @@ class UpdateProductStock
                 }
 
                 if ($product->purchasableType() === ProductType::Variant) {
-                    $variant = $product->variant($item->variant()['variant'] ?? $item->variant());
+                    $variant = $product->variant($lineItem->variant()['variant'] ?? $lineItem->variant());
 
                     if ($variant !== null && is_int($variant->stock())) {
-                        $stock = $variant->stock() - $item->quantity();
+                        $stock = $variant->stock() - $lineItem->quantity();
 
                         $variant->stock(
-                            $stock = $variant->stock() - $item->quantity()
+                            $stock = $variant->stock() - $lineItem->quantity()
                         );
 
                         $variant->save();

--- a/src/Orders/Checkout/ValidateProductStock.php
+++ b/src/Orders/Checkout/ValidateProductStock.php
@@ -16,8 +16,8 @@ class ValidateProductStock
     public function handle(Order $order, Closure $next)
     {
         $order->lineItems()
-            ->each(function (LineItem $item) use (&$order) {
-                $product = $item->product();
+            ->each(function (LineItem $lineItem) use (&$order) {
+                $product = $lineItem->product();
 
                 // Multi-site: Is the Stock field not localised? If so, we want the origin
                 // version of the product for stock purposes.
@@ -32,10 +32,10 @@ class ValidateProductStock
 
                 if ($product->purchasableType() === ProductType::Product) {
                     if (is_int($product->stock())) {
-                        $stock = $product->stock() - $item->quantity();
+                        $stock = $product->stock() - $lineItem->quantity();
 
                         if ($stock < 0) {
-                            $order->removeLineItem($item->id());
+                            $order->removeLineItem($lineItem->id());
                             $order->save();
 
                             throw new CheckoutProductHasNoStockException(
@@ -47,13 +47,13 @@ class ValidateProductStock
                 }
 
                 if ($product->purchasableType() === ProductType::Variant) {
-                    $variant = $product->variant($item->variant()['variant'] ?? $item->variant());
+                    $variant = $product->variant($lineItem->variant()['variant'] ?? $lineItem->variant());
 
                     if ($variant !== null && is_int($variant->stock())) {
-                        $stock = $variant->stock() - $item->quantity();
+                        $stock = $variant->stock() - $lineItem->quantity();
 
                         if ($stock < 0) {
-                            $order->removeLineItem($item->id());
+                            $order->removeLineItem($lineItem->id());
                             $order->save();
 
                             throw new CheckoutProductHasNoStockException(

--- a/src/Orders/Checkout/ValidateProductStock.php
+++ b/src/Orders/Checkout/ValidateProductStock.php
@@ -13,7 +13,7 @@ use DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository;
 use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 
-class HandleStock
+class ValidateProductStock
 {
     public function handle(Order $order, Closure $next)
     {
@@ -36,29 +36,8 @@ class HandleStock
                     if (is_int($product->stock())) {
                         $stock = $product->stock() - $item->quantity();
 
-                        // Need to do this check before actually setting the stock
                         if ($stock < 0) {
-                            event(new StockRunOut(
-                                product: $product,
-                                variant: null,
-                                stock: $stock,
-                            ));
-
                             throw new CheckoutProductHasNoStockException($product);
-                        }
-
-                        $product->stock(
-                            $stock = $product->stock() - $item->quantity()
-                        );
-
-                        $product->save();
-
-                        if ($stock <= config('simple-commerce.low_stock_threshold', 10)) {
-                            event(new StockRunningLow(
-                                product: $product,
-                                variant: null,
-                                stock: $stock,
-                            ));
                         }
                     }
                 }
@@ -69,29 +48,8 @@ class HandleStock
                     if ($variant !== null && is_int($variant->stock())) {
                         $stock = $variant->stock() - $item->quantity();
 
-                        // Need to do this check before actually setting the stock
                         if ($stock < 0) {
-                            event(new StockRunOut(
-                                product: $product,
-                                variant: $variant,
-                                stock: $stock,
-                            ));
-
                             throw new CheckoutProductHasNoStockException($product, $variant);
-                        }
-
-                        $variant->stock(
-                            $stock = $variant->stock() - $item->quantity()
-                        );
-
-                        $variant->save();
-
-                        if ($stock <= config('simple-commerce.low_stock_threshold', 10)) {
-                            event(new StockRunningLow(
-                                product: $product,
-                                variant: $variant,
-                                stock: $stock,
-                            ));
                         }
                     }
                 }

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Tags;
 
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CheckoutProductHasNoStockException;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayDoesNotExist;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\PreventCheckout;
 use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
@@ -83,16 +82,6 @@ class CheckoutTags extends SubTag
             $cart = app(CheckoutValidationPipeline::class)
                 ->send($cart)
                 ->thenReturn();
-        } catch (CheckoutProductHasNoStockException $e) {
-            // TODO: Refactor this code & the exception to just use the PreventCheckout exception
-            $lineItem = $cart->lineItems()->filter(function ($lineItem) use ($e) {
-                return $lineItem->product()->id() === $e->product->id();
-            })->first();
-
-            $cart->removeLineItem($lineItem->id());
-            $cart->save();
-
-            return Redirect::back()->withErrors(__('Checkout failed. A product in your cart has no stock left. The product has been removed from your cart.'));
         } catch (PreventCheckout $e) {
             return Redirect::back()->withErrors($e->getMessage());
         }

--- a/tests/Http/Controllers/CheckoutControllerTest.php
+++ b/tests/Http/Controllers/CheckoutControllerTest.php
@@ -1409,12 +1409,11 @@ class CheckoutControllerTest extends TestCase
         $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
         $this->assertNull($order->statusLog('paid'));
 
-        // Assert stock has been reduced
+        // Asset the stock is the same (it hasn't been reduced yet because the
+        // checkout failed at the validation stage)
         $product->fresh();
-        $this->assertSame($product->stock(), 0);
 
-        Event::assertNotDispatched(StockRunningLow::class);
-        Event::assertDispatched(StockRunOut::class);
+        $this->assertSame($product->stock(), 0);
 
         // Finally, assert order is no longer attached to the users' session
         $this->assertTrue(session()->has('simple-commerce-cart'));
@@ -1472,7 +1471,7 @@ class CheckoutControllerTest extends TestCase
         $this->assertSame($product->fresh()->stock(), 0);
 
         Event::assertDispatched(StockRunningLow::class);
-        Event::assertNotDispatched(StockRunOut::class);
+        Event::assertDispatched(StockRunOut::class);
 
         // Finally, assert order is no longer attached to the users' session
         $this->assertFalse(session()->has('simple-commerce-cart'));
@@ -1712,11 +1711,9 @@ class CheckoutControllerTest extends TestCase
         $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
         $this->assertNull($order->statusLog('paid'));
 
-        // Assert stock has been reduced
+        // Asset the stock is the same (it hasn't been reduced yet because the
+        // checkout failed at the validation stage)
         $this->assertSame($product->fresh()->variant('Red_Small')->stock(), 0);
-
-        Event::assertNotDispatched(StockRunningLow::class);
-        Event::assertDispatched(StockRunOut::class);
 
         // Finally, assert order is no longer attached to the users' session
         $this->assertTrue(session()->has('simple-commerce-cart'));
@@ -1798,7 +1795,7 @@ class CheckoutControllerTest extends TestCase
         $this->assertSame($product->fresh()->variant('Red_Small')->stock(), 0);
 
         Event::assertDispatched(StockRunningLow::class);
-        Event::assertNotDispatched(StockRunOut::class);
+        Event::assertDispatched(StockRunOut::class);
 
         // Finally, assert order is no longer attached to the users' session
         $this->assertFalse(session()->has('simple-commerce-cart'));

--- a/tests/Orders/Checkout/UpdateProductStockTest.php
+++ b/tests/Orders/Checkout/UpdateProductStockTest.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Orders;
+namespace DoubleThreeDigital\SimpleCommerce\Tests\Orders\Checkout;
 
 use DoubleThreeDigital\SimpleCommerce\Events\StockRunningLow;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CheckoutProductHasNoStockException;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\Checkout\HandleStock;
+use DoubleThreeDigital\SimpleCommerce\Orders\Checkout\UpdateProductStock;
 use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
 use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
 use Illuminate\Pipeline\Pipeline;
@@ -17,7 +16,7 @@ use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 
-class HandleStockTest extends TestCase
+class UpdateProductStockTest extends TestCase
 {
     use SetupCollections;
 
@@ -45,52 +44,12 @@ class HandleStockTest extends TestCase
 
         app(Pipeline::class)
             ->send($order)
-            ->through([HandleStock::class])
+            ->through([UpdateProductStock::class])
             ->thenReturn();
 
         $product->fresh();
 
         $this->assertSame(7, $product->stock());
-    }
-
-    /** @test */
-    public function cant_decrease_stock_for_standard_product_when_product_has_no_stock()
-    {
-        $product = Product::make()
-            ->price(1200)
-            ->stock(0)
-            ->data([
-                'title' => 'Medium Jumper',
-            ]);
-
-        $product->save();
-
-        $order = Order::make()
-            ->lineItems([
-                [
-                    'product' => $product->id(),
-                    'quantity' => 1,
-                ],
-            ]);
-
-        $order->save();
-
-        $this->expectException(CheckoutProductHasNoStockException::class);
-
-        app(Pipeline::class)
-            ->send($order)
-            ->through([HandleStock::class])
-            ->thenReturn();
-
-        $product->fresh();
-
-        $this->assertSame(0, $product->stock());
-    }
-
-    /** @test */
-    public function cant_decrease_stock_for_standard_product_when_quantity_is_greater_than_stock()
-    {
-        $this->markTestIncomplete('TODO');
     }
 
     /** @test */
@@ -121,7 +80,7 @@ class HandleStockTest extends TestCase
 
         app(Pipeline::class)
             ->send($order)
-            ->through([HandleStock::class])
+            ->through([UpdateProductStock::class])
             ->thenReturn();
 
         $product->fresh();
@@ -191,7 +150,7 @@ class HandleStockTest extends TestCase
 
         app(Pipeline::class)
             ->send($order)
-            ->through([HandleStock::class])
+            ->through([UpdateProductStock::class])
             ->thenReturn();
 
         $englishProduct->fresh();
@@ -240,70 +199,13 @@ class HandleStockTest extends TestCase
 
         app(Pipeline::class)
             ->send($order)
-            ->through([HandleStock::class])
+            ->through([UpdateProductStock::class])
             ->thenReturn();
 
         $product->fresh();
 
         $this->assertNull($product->stock());
         $this->assertSame(7, $product->variant('Yellow_Large')->stock());
-    }
-
-    /** @test */
-    public function cant_decrease_stock_for_variant_product_when_product_has_no_stock()
-    {
-        $product = Product::make()
-            ->productVariants([
-                'variants' => [
-                    [
-                        'name' => 'Colour',
-                        'values' => ['Yellow'],
-                    ],
-                    [
-                        'name' => 'Size',
-                        'values' => ['Large'],
-                    ],
-                ],
-                'options' => [
-                    [
-                        'key' => 'Yellow_Large',
-                        'variant' => 'Yellow, Large',
-                        'price' => 1500,
-                        'stock' => 0,
-                    ],
-                ],
-            ]);
-
-        $product->save();
-
-        $order = Order::make()
-            ->lineItems([
-                [
-                    'product' => $product->id(),
-                    'variant' => 'Yellow_Large',
-                    'quantity' => 3,
-                ],
-            ]);
-
-        $order->save();
-
-        $this->expectException(CheckoutProductHasNoStockException::class);
-
-        app(Pipeline::class)
-            ->send($order)
-            ->through([HandleStock::class])
-            ->thenReturn();
-
-        $product->fresh();
-
-        $this->assertNull($product->stock());
-        $this->assertSame(0, $product->variant('Yellow_Large')->stock());
-    }
-
-    /** @test */
-    public function cant_decrease_stock_for_variant_product_when_quantity_is_greater_than_stock()
-    {
-        $this->markTestIncomplete('TODO');
     }
 
     /** @test */
@@ -356,7 +258,7 @@ class HandleStockTest extends TestCase
 
         app(Pipeline::class)
             ->send($order)
-            ->through([HandleStock::class])
+            ->through([UpdateProductStock::class])
             ->thenReturn();
 
         $product->fresh();

--- a/tests/Orders/Checkout/ValidateProductStockTest.php
+++ b/tests/Orders/Checkout/ValidateProductStockTest.php
@@ -79,7 +79,7 @@ class ValidateProductStockTest extends TestCase
 
             $this->fail('Validation passed when it should have failed.');
         } catch (CheckoutProductHasNoStockException $e) {
-            $this->assertTrue($e->getMessage() === "Product {$product->id()} does not have any available stock.");
+            $this->assertTrue($order->lineItems()->count() === 0);
         }
     }
 
@@ -113,7 +113,7 @@ class ValidateProductStockTest extends TestCase
 
             $this->fail('Validation passed when it should have failed.');
         } catch (CheckoutProductHasNoStockException $e) {
-            $this->assertTrue($e->getMessage() === "Product {$product->id()} does not have any available stock.");
+            $this->assertTrue($order->lineItems()->count() === 0);
         }
     }
 
@@ -214,7 +214,7 @@ class ValidateProductStockTest extends TestCase
 
             $this->fail('Validation passed when it should have failed.');
         } catch (CheckoutProductHasNoStockException $e) {
-            $this->assertTrue($e->getMessage() === "Variant Yellow_Large on {$product->id()} does not have any available stock.");
+            $this->assertTrue($order->lineItems()->count() === 0);
         }
     }
 
@@ -264,7 +264,7 @@ class ValidateProductStockTest extends TestCase
 
             $this->fail('Validation passed when it should have failed.');
         } catch (CheckoutProductHasNoStockException $e) {
-            $this->assertTrue($e->getMessage() === "Variant Yellow_Large on {$product->id()} does not have any available stock.");
+            $this->assertTrue($order->lineItems()->count() === 0);
         }
     }
 }

--- a/tests/Orders/Checkout/ValidateProductStockTest.php
+++ b/tests/Orders/Checkout/ValidateProductStockTest.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Tests\Orders\Checkout;
+
+use DoubleThreeDigital\SimpleCommerce\Exceptions\CheckoutProductHasNoStockException;
+use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use DoubleThreeDigital\SimpleCommerce\Orders\Checkout\ValidateProductStock;
+use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
+use Illuminate\Pipeline\Pipeline;
+
+class ValidateProductStockTest extends TestCase
+{
+    use SetupCollections;
+
+    /** @test */
+    public function can_pass_validation_for_standard_product_with_enough_stock()
+    {
+        $product = Product::make()
+            ->price(1200)
+            ->stock(10)
+            ->data([
+                'title' => 'Medium Jumper',
+            ]);
+
+        $product->save();
+
+        $order = Order::make()
+            ->lineItems([
+                [
+                    'product' => $product->id(),
+                    'quantity' => 3,
+                ],
+            ]);
+
+        $order->save();
+
+        try {
+            app(Pipeline::class)
+                ->send($order)
+                ->through([ValidateProductStock::class])
+                ->thenReturn();
+
+            // No exception was thrown, so we're good.
+            $this->assertTrue(true);
+        } catch (CheckoutProductHasNoStockException $e) {
+            $this->fail('Validation failed when it should have passed.');
+        }
+    }
+
+    /** @test */
+    public function cant_pass_validation_for_standard_product_without_enough_stock_to_fulfill_order()
+    {
+        $product = Product::make()
+            ->price(1200)
+            ->stock(5)
+            ->data([
+                'title' => 'Giant Jumper',
+            ]);
+
+        $product->save();
+
+        $order = Order::make()
+            ->lineItems([
+                [
+                    'product' => $product->id(),
+                    'quantity' => 20,
+                ],
+            ]);
+
+        $order->save();
+
+        try {
+            app(Pipeline::class)
+                ->send($order)
+                ->through([ValidateProductStock::class])
+                ->thenReturn();
+
+            $this->fail('Validation passed when it should have failed.');
+        } catch (CheckoutProductHasNoStockException $e) {
+            $this->assertTrue($e->getMessage() === "Product {$product->id()} does not have any available stock.");
+        }
+    }
+
+    /** @test */
+    public function cant_pass_validation_for_standard_product_with_no_stock()
+    {
+        $product = Product::make()
+            ->price(1200)
+            ->stock(0)
+            ->data([
+                'title' => 'Tiny Jumper',
+            ]);
+
+        $product->save();
+
+        $order = Order::make()
+            ->lineItems([
+                [
+                    'product' => $product->id(),
+                    'quantity' => 5,
+                ],
+            ]);
+
+        $order->save();
+
+        try {
+            app(Pipeline::class)
+                ->send($order)
+                ->through([ValidateProductStock::class])
+                ->thenReturn();
+
+            $this->fail('Validation passed when it should have failed.');
+        } catch (CheckoutProductHasNoStockException $e) {
+            $this->assertTrue($e->getMessage() === "Product {$product->id()} does not have any available stock.");
+        }
+    }
+
+    /** @test */
+    public function can_pass_validation_for_variant_product_with_enough_stock()
+    {
+        $product = Product::make()
+            ->productVariants([
+                'variants' => [
+                    [
+                        'name' => 'Colour',
+                        'values' => ['Yellow'],
+                    ],
+                    [
+                        'name' => 'Size',
+                        'values' => ['Large'],
+                    ],
+                ],
+                'options' => [
+                    [
+                        'key' => 'Yellow_Large',
+                        'variant' => 'Yellow, Large',
+                        'price' => 1500,
+                        'stock' => 10,
+                    ],
+                ],
+            ]);
+
+        $product->save();
+
+        $order = Order::make()
+            ->lineItems([
+                [
+                    'product' => $product->id(),
+                    'variant' => 'Yellow_Large',
+                    'quantity' => 3,
+                ],
+            ]);
+
+        $order->save();
+
+        try {
+            app(Pipeline::class)
+                ->send($order)
+                ->through([ValidateProductStock::class])
+                ->thenReturn();
+
+            // No exception was thrown, so we're good.
+            $this->assertTrue(true);
+        } catch (CheckoutProductHasNoStockException $e) {
+            $this->fail('Validation failed when it should have passed.');
+        }
+    }
+
+    /** @test */
+    public function cant_pass_validation_for_variant_product_without_enough_stock_to_fulfill_order()
+    {
+        $product = Product::make()
+            ->productVariants([
+                'variants' => [
+                    [
+                        'name' => 'Colour',
+                        'values' => ['Yellow'],
+                    ],
+                    [
+                        'name' => 'Size',
+                        'values' => ['Large'],
+                    ],
+                ],
+                'options' => [
+                    [
+                        'key' => 'Yellow_Large',
+                        'variant' => 'Yellow, Large',
+                        'price' => 1500,
+                        'stock' => 10,
+                    ],
+                ],
+            ]);
+
+        $product->save();
+
+        $order = Order::make()
+            ->lineItems([
+                [
+                    'product' => $product->id(),
+                    'variant' => 'Yellow_Large',
+                    'quantity' => 25,
+                ],
+            ]);
+
+        $order->save();
+
+        try {
+            app(Pipeline::class)
+                ->send($order)
+                ->through([ValidateProductStock::class])
+                ->thenReturn();
+
+            $this->fail('Validation passed when it should have failed.');
+        } catch (CheckoutProductHasNoStockException $e) {
+            $this->assertTrue($e->getMessage() === "Variant Yellow_Large on {$product->id()} does not have any available stock.");
+        }
+    }
+
+    /** @test */
+    public function cant_pass_validation_for_variant_product_with_no_stock()
+    {
+        $product = Product::make()
+            ->productVariants([
+                'variants' => [
+                    [
+                        'name' => 'Colour',
+                        'values' => ['Yellow'],
+                    ],
+                    [
+                        'name' => 'Size',
+                        'values' => ['Large'],
+                    ],
+                ],
+                'options' => [
+                    [
+                        'key' => 'Yellow_Large',
+                        'variant' => 'Yellow, Large',
+                        'price' => 1500,
+                        'stock' => 0,
+                    ],
+                ],
+            ]);
+
+        $product->save();
+
+        $order = Order::make()
+            ->lineItems([
+                [
+                    'product' => $product->id(),
+                    'variant' => 'Yellow_Large',
+                    'quantity' => 5,
+                ],
+            ]);
+
+        $order->save();
+
+        try {
+            app(Pipeline::class)
+                ->send($order)
+                ->through([ValidateProductStock::class])
+                ->thenReturn();
+
+            $this->fail('Validation passed when it should have failed.');
+        } catch (CheckoutProductHasNoStockException $e) {
+            $this->assertTrue($e->getMessage() === "Variant Yellow_Large on {$product->id()} does not have any available stock.");
+        }
+    }
+}


### PR DESCRIPTION
This pull request makes some further changes to the way the 'checkout pipeline' works, after my previous set of changes in #832.

Essentially, we now have two pipelines:

* `CheckoutValidationPipeline` which is responsible for handing anything validation-y (like checking the stock of items in the cart) before the payment happens.
* `CheckoutPipeline` which is responsible for handing anything after payment happens (like updating stock, redeeming coupons, etc)

The aim for abstracting stuff like this out into Laravel Pipelines is to allow for less code duplication between the two different checkout flows we have: on-site using the `{{ sc:checkout }}` form and off-site where the user is redirected to the payment gateway to complete the order.

Incidentally, this PR also fixes a bug which was reported yesterday, #842 where we weren't checking the stock of items in the cart before redirecting customers to the off-site gateway. 