### PR TITLE
v5.0: Improve order numbers for database orders

### DIFF
--- a/docs/cart-and-orders.md
+++ b/docs/cart-and-orders.md
@@ -144,10 +144,6 @@ class YourDriver implements CartDriver
 
 ### Order Numbers
 
-:::note Note!
-This only applies when storing orders as entries. If you're [storing orders in a database](/database-orders), the order number will be automaticaly generated from the order's ID in the database.
-:::
-
 When an order is created, a unique order number will be assigned. It'll often be formatted like so: `#1234`.
 
 By default, order numbers will start at `#2000` and will continue endlessly. If you wish for order numbers to start at say, `#5000`, you can configure that in your `config/simple-commerce.php` config file.

--- a/docs/upgrade-guides/v4-x-to-v5-0.md
+++ b/docs/upgrade-guides/v4-x-to-v5-0.md
@@ -147,6 +147,12 @@ Simple Commerce has dropped support for Statamic 3.3, leaving only Statamic 3.4 
 
 To upgrade to Statamic 3.4, you should follow the steps outlined in the official [Upgrade Guide](https://statamic.dev/upgrade-guide/3-3-to-3-4).
 
+### Medium: New `order_number` column for database orders
+
+Previously, when storing orders in the database, Simple Commerce has used the `id` column as order numbers. This meant order numbers started in the single digits and it wasn't possible to set a minimum order number (eg. 1000) like you can with entry orders.
+
+In v5, Simple Commerce has introduced a separate `order_number` column. During the update process, a migration will be published & your existing orders will be updated.
+
 ### Medium: Changes to Gateway API
 
 As part of improving the developer experience in Simple Commerce, there has been some changes to the Gateways API. If you're using a custom gateway in your project, you will need to make some manual changes, as detailed below.

--- a/src/Console/Commands/stubs/create_orders_table.php
+++ b/src/Console/Commands/stubs/create_orders_table.php
@@ -15,6 +15,7 @@ class CreateOrdersTable extends Migration
     {
         Schema::create('orders', function (Blueprint $table) {
             $table->id();
+            $table->bigInteger('order_number')->unique();
             $table->string('order_status')->default('cart');
             $table->string('payment_status')->default('unpaid');
             $table->json('items')->nullable();

--- a/src/Console/Commands/stubs/create_orders_table.php
+++ b/src/Console/Commands/stubs/create_orders_table.php
@@ -15,7 +15,7 @@ class CreateOrdersTable extends Migration
     {
         Schema::create('orders', function (Blueprint $table) {
             $table->id();
-            $table->bigInteger('order_number')->unique();
+            $table->bigInteger('order_number')->unique()->nullable();
             $table->string('order_status')->default('cart');
             $table->string('payment_status')->default('unpaid');
             $table->json('items')->nullable();

--- a/src/Console/Commands/stubs/runway_order_blueprint.yaml
+++ b/src/Console/Commands/stubs/runway_order_blueprint.yaml
@@ -14,6 +14,7 @@ sections:
           antlers: false
           read_only: true
           width: 50
+          listable: true
       - handle: customer_id
         field:
           max_items: 1
@@ -22,7 +23,7 @@ sections:
           display: Customer
           type: belongs_to
           icon: belongs_to
-          listable: hidden
+          listable: true
           instructions_position: above
           width: 50
           read_only: true

--- a/src/Orders/EloquentOrderRepository.php
+++ b/src/Orders/EloquentOrderRepository.php
@@ -18,12 +18,11 @@ class EloquentOrderRepository implements RepositoryContract
     protected $model;
 
     protected $knownColumns = [
-        'id', 'order_status', 'payment_status', 'items', 'grand_total', 'items_total', 'tax_total',
-        'shipping_total', 'coupon_total', 'shipping_name', 'shipping_address', 'shipping_address_line2',
-        'shipping_city', 'shipping_postal_code', 'shipping_region', 'shipping_country', 'billing_name',
-        'billing_address', 'billing_address_line2', 'billing_city', 'billing_postal_code', 'billing_region',
-        'billing_country', 'use_shipping_address_for_billing', 'customer_id', 'coupon', 'gateway', 'data',
-        'created_at', 'updated_at',
+        'id', 'order_number', 'order_status', 'payment_status', 'items', 'grand_total', 'items_total', 'tax_total',
+        'shipping_total', 'coupon_total', 'shipping_name', 'shipping_address', 'shipping_address_line2', 'shipping_city',
+        'shipping_postal_code', 'shipping_region', 'shipping_country', 'billing_name', 'billing_address', 'billing_address_line2',
+        'billing_city', 'billing_postal_code', 'billing_region', 'billing_country', 'use_shipping_address_for_billing', 'customer_id',
+        'coupon', 'gateway', 'data', 'created_at', 'updated_at',
     ];
 
     public function __construct()

--- a/src/Orders/EloquentOrderRepository.php
+++ b/src/Orders/EloquentOrderRepository.php
@@ -226,6 +226,10 @@ class EloquentOrderRepository implements RepositoryContract
             ->orderBy('order_number', 'DESC')
             ->value('order_number');
 
+        if (! $lastOrderNumber) {
+            return config('simple-commerce.minimum_order_number', 1000);
+        }
+
         return $lastOrderNumber + 1;
     }
 

--- a/src/Orders/OrderModel.php
+++ b/src/Orders/OrderModel.php
@@ -16,6 +16,7 @@ class OrderModel extends Model
     protected $guarded = [];
 
     protected $casts = [
+        'order_number' => 'integer',
         'items' => 'json',
         'grand_total' => 'integer',
         'items_total' => 'integer',
@@ -27,21 +28,8 @@ class OrderModel extends Model
         'data' => 'json',
     ];
 
-    protected $appends = [
-        'order_number',
-    ];
-
     public function customer(): BelongsTo
     {
         return $this->belongsTo(CustomerModel::class);
-    }
-
-    public function getOrderNumberAttribute()
-    {
-        if (array_key_exists('title', $this->data ?? [])) {
-            return $this->data['title'];
-        }
-
-        return "#{$this->id}";
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -105,6 +105,7 @@ class ServiceProvider extends AddonServiceProvider
     protected $updateScripts = [
         UpdateScripts\v4_0\MigrateCouponsToStache::class,
 
+        UpdateScripts\v5_0\MigrateDatabaseOrderNumbers::class,
         UpdateScripts\v5_0\MigrateOrderStatuses::class,
         UpdateScripts\v5_0\SetDefaultNavPreferences::class,
         UpdateScripts\v5_0\UpdateNotificationsConfig::class,

--- a/src/Support/Runway.php
+++ b/src/Support/Runway.php
@@ -8,7 +8,7 @@ class Runway
 {
     public static function customerModel()
     {
-        $orderModel = SimpleCommerce::orderDriver()['model'];
+        $orderModel = SimpleCommerce::customerDriver()['model'];
 
         return \DoubleThreeDigital\Runway\Runway::findResourceByModel(new $orderModel);
     }

--- a/src/UpdateScripts/v5_0/MigrateDatabaseOrderNumbers.php
+++ b/src/UpdateScripts/v5_0/MigrateDatabaseOrderNumbers.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v5_0;
+
+use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
+use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Statamic\UpdateScripts\UpdateScript;
+
+class MigrateDatabaseOrderNumbers extends UpdateScript
+{
+    protected $stubsPath = __DIR__ . '/stubs';
+
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('5.0.0-beta.1');
+    }
+
+    public function update()
+    {
+        // Skip if the site's not using the EloquentOrderRepository
+        if (! $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EloquentOrderRepository::class)) {
+            return;
+        }
+
+        if (count(File::glob(database_path('migrations').'/*_add_order_number_column_to_orders_table.php')) < 1) {
+            File::copy($this->stubsPath.'/add_order_number_column_to_orders_table.php', database_path('migrations/'.date('Y_m_d_His').'_add_order_number_column_to_orders_table.php'));
+
+            Artisan::call('migrate');
+        }
+
+        OrderModel::query()
+            ->select('id', 'data')
+            ->chunk(200, function ($orders) {
+                $orders->each(function (OrderModel $order) {
+                    $orderNumber = $order->id;
+
+                    if (array_key_exists('title', $order->data)) {
+                        $orderNumber = (int) str_replace('#', '', $order->data['title']);
+                    }
+
+                    $order->updateQuietly([
+                        'order_number' => $orderNumber,
+                    ]);
+                });
+            });
+    }
+
+    protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool
+    {
+        return is_subclass_of($class, $classToCheckAgainst)
+            || $class === $classToCheckAgainst;
+    }
+}

--- a/src/UpdateScripts/v5_0/MigrateDatabaseOrderNumbers.php
+++ b/src/UpdateScripts/v5_0/MigrateDatabaseOrderNumbers.php
@@ -11,7 +11,7 @@ use Statamic\UpdateScripts\UpdateScript;
 
 class MigrateDatabaseOrderNumbers extends UpdateScript
 {
-    protected $stubsPath = __DIR__ . '/stubs';
+    protected $stubsPath = __DIR__.'/stubs';
 
     public function shouldUpdate($newVersion, $oldVersion)
     {

--- a/src/UpdateScripts/v5_0/stubs/add_order_number_column_to_orders_table.php
+++ b/src/UpdateScripts/v5_0/stubs/add_order_number_column_to_orders_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->bigInteger('order_number')->unique()->after('id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn('order_number');
+        });
+    }
+};

--- a/tests/Customers/EloquentCustomerRepositoryTest.php
+++ b/tests/Customers/EloquentCustomerRepositoryTest.php
@@ -9,7 +9,7 @@ use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
 
-class EloquentCustomerTest extends TestCase
+class EloquentCustomerRepositoryTest extends TestCase
 {
     use RefreshDatabase, UseDatabaseContentDrivers;
 

--- a/tests/Orders/EloquentOrderRepositoryTest.php
+++ b/tests/Orders/EloquentOrderRepositoryTest.php
@@ -13,7 +13,7 @@ use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
 
-class EloquentOrderTest extends TestCase
+class EloquentOrderRepositoryTest extends TestCase
 {
     use SetupCollections, RefreshDatabase, UseDatabaseContentDrivers;
 

--- a/tests/__fixtures__/database/migrations/create_orders_table.php
+++ b/tests/__fixtures__/database/migrations/create_orders_table.php
@@ -15,6 +15,7 @@ class CreateOrdersTable extends Migration
     {
         Schema::create('orders', function (Blueprint $table) {
             $table->id();
+            $table->bigInteger('order_number')->unique();
             $table->string('order_status')->default('cart');
             $table->string('payment_status')->default('unpaid');
             $table->json('items')->nullable();

--- a/tests/__fixtures__/database/migrations/create_orders_table.php
+++ b/tests/__fixtures__/database/migrations/create_orders_table.php
@@ -15,7 +15,7 @@ class CreateOrdersTable extends Migration
     {
         Schema::create('orders', function (Blueprint $table) {
             $table->id();
-            $table->bigInteger('order_number')->unique();
+            $table->bigInteger('order_number')->unique()->nullable();
             $table->string('order_status')->default('cart');
             $table->string('payment_status')->default('unpaid');
             $table->json('items')->nullable();


### PR DESCRIPTION
This pull request makes some changes to how order numbers are handled when using Database Orders.

Previously, when storing orders in the database, Simple Commerce has used the `id` column as order numbers. This meant order numbers started in the single digits and it wasn't possible to set a minimum order number (eg. 1000) like you can with entry orders.

With this PR, I've introduced a separate `order_number` column to store order numbers so they can be different.

### A couple of notes

* Order numbers for orders will be generated when creating orders
* During the upgrade process, a migration will be published & existing orders will be updated.