### PR TITLE
Fix updating variant line items

### DIFF
--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -217,7 +217,7 @@ class CartItemController extends BaseActionController
         } elseif ($product->purchasableType() === ProductType::Variant) {
             $variant = $request->has('variant')
                 ? $product->variant($request->get('variant'))
-                : $product->variant($lineItem->variant());
+                : $product->variant($lineItem->variant()['variant']);
 
             if ($variant !== null && is_int($variant->stock()) && $variant->stock() < $request->quantity) {
                 return $this->withErrors($request, __("There's not enough stock to fulfil the quantity you selected. Please try again later."));

--- a/tests/Http/Controllers/CartItemControllerTest.php
+++ b/tests/Http/Controllers/CartItemControllerTest.php
@@ -1902,7 +1902,10 @@ class CartItemControllerTest extends TestCase
                 [
                     'id' => Stache::generateId(),
                     'product' => $product->id,
-                    'variant' => 'Red_Small',
+                    'variant' => [
+                        'variant' => 'Red_Small',
+                        'product' => $product->id,
+                    ],
                     'quantity' => 1,
                     'total' => 1000,
                 ],
@@ -2009,7 +2012,10 @@ class CartItemControllerTest extends TestCase
                 [
                     'id' => Stache::generateId(),
                     'product' => $product->id,
-                    'variant' => 'Red_Small',
+                    'variant' => [
+                        'variant' => 'Red_Small',
+                        'product' => $product->id,
+                    ],
                     'quantity' => 1,
                     'total' => 1000,
                 ],


### PR DESCRIPTION
This pull request fixes a bug where line items with variant products couldn't be updated - an error was being thrown.

It was happening as the controller was expecting `$lineItem->variant()` to be a string (the key of the variant) but it was returning an array like this:

```php
[
    'product' => 'id-of-the-product',
    'variant' => 'Red_Large',
]
```

From what I can tell, `$lineItem->variant()` hasn't been returning a string since v2.1 (97737d2) - I'm surprised it hasn't been brought up before now to be honest 😅 

The tests haven't picked this issue up as the line items data was still using the old format (a string) which worked for the code. I've adjusted the tests, they failed & I've fixed the bug.

Fixes #844