### PR TITLE
Fix issue with translations on payment descriptions

### DIFF
--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -40,7 +40,7 @@ class MollieGateway extends BaseGateway implements Gateway
                 'currency' => Currency::get(Site::current())['code'],
                 'value' => (string) substr_replace($order->grandTotal(), '.', -2, 0),
             ],
-            'description' => __('Order :orderNumber', ['order' => $order->orderNumber()]),
+            'description' => __('Order :orderNumber', ['orderNumber' => $order->orderNumber()]),
             'redirectUrl' => $this->callbackUrl([
                 '_order_id' => $data->order()->id(),
             ]),

--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -55,7 +55,7 @@ class PayPalGateway extends BaseGateway implements Gateway
                         'value' => (string) substr_replace($order->grandTotal(), '.', -2, 0),
                         'currency_code' => Currency::get(Site::current())['code'],
                     ],
-                    'description' => __('Order :orderNumber', ['order' => $order->orderNumber()]),
+                    'description' => __('Order :orderNumber', ['orderNumber' => $order->orderNumber()]),
                     'custom_id' => $order->id(),
                 ],
             ],

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -44,7 +44,7 @@ class StripeGateway extends BaseGateway implements Gateway
         $intentData = [
             'amount' => $order->grandTotal(),
             'currency' => Currency::get(Site::current())['code'],
-            'description' => __('Order :orderNumber', ['order' => $order->orderNumber()]),
+            'description' => __('Order :orderNumber', ['orderNumber' => $order->orderNumber()]),
             'setup_future_usage' => 'off_session',
         ];
 


### PR DESCRIPTION
This pull request fixes a small issue I've just seen where payment descriptions that we passed along to payment gateways were incorrect:

Instead of being `Order #1234`, it was being sent as `Order #1234Number`.