### PR TITLE
Ability to customise currency symbols

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -45,6 +45,17 @@ class Currency
             $money = new Money(str_replace('.', '', (int) $amount), new MoneyCurrency(self::get($site)['code']));
 
             $numberFormatter = new NumberFormatter($site->locale(), \NumberFormatter::CURRENCY);
+
+            $currencyFormattingConfig = Config::get("simple-commerce.sites.{$site->handle()}.currency_formatting");
+
+            if (isset($currencyFormattingConfig['decimal_separator'])) {
+                $numberFormatter->setSymbol(\NumberFormatter::MONETARY_SEPARATOR_SYMBOL, $currencyFormattingConfig['decimal_separator']);
+            }
+
+            if (isset($currencyFormattingConfig['thousand_separator'])) {
+                $numberFormatter->setSymbol(\NumberFormatter::MONETARY_GROUPING_SEPARATOR_SYMBOL, $currencyFormattingConfig['thousand_separator']);
+            }
+
             $moneyFormatter = new IntlMoneyFormatter($numberFormatter, new ISOCurrencies());
 
             return $moneyFormatter->format($money);


### PR DESCRIPTION
This pull request makes it possible to customise the currency formatting symbols. 

Under the hood, Simple Commerce uses PHP's built-in `NumberFormatter` to take numbers and format them. However, there [are some cases](https://github.com/duncanmcclean/simple-commerce/discussions/849) where the formatted output it produces isn't correct for some currencies.

This PR adds two config options allowing you to customise two of the currency formatting separators. 

It's worth noting that this PR won't change the currency format used in the Money fieldtype in the Control Panel - I don't have time to implement that right now. However, I would accept a pull request if someone needs it.

## Example

Normally: **£1,234.56**

```php
// config/simple-commerce.php

'sites' => [
    'default' => [
        'currency' => 'GBP',

        'currency_formatting' => [
            'thousand_separator' => '.',
            'decimal_separator' => ',',
        ],
    ],
],
```

With the above config settings, that number turns into **£1.234,56**.