### PR TITLE
Database Orders: Add `is_array` check before checking array has key

### DIFF
--- a/src/Orders/OrderModel.php
+++ b/src/Orders/OrderModel.php
@@ -42,7 +42,7 @@ class OrderModel extends Model
 
     public function getOrderNumberAttribute()
     {
-        if (array_key_exists('title', $this->data)) {
+        if (is_array($this->data) && array_key_exists('title', $this->data)) {
             return $this->data['title'];
         }
 


### PR DESCRIPTION
This pull request fixes an issue you might run into when using database orders when the `data` column is `null` instead of being an array of data.

## Error

```
array_key_exists(): Argument #2 ($array) must be of type array, null given (View: /Users/<home>/Sites/<site_name>/vendor/doublethreedigital/runway/resources/views/edit.blade.php)
```

Related Discord conversation: https://discord.com/channels/489818810157891584/489862989101662218/1083456989394387065