### PR TITLE
Rename `ReceiveGatewayWebhook` event

### DIFF
--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -1,10 +1,10 @@
 ---
-title: Overview
+title: 'Core Concepts'
 ---
 
 ## Everything's just an entry
 
-With Simple Commerce, all of your products, orders & customers are normal entries in Statamic. 
+With Simple Commerce, all of your products, orders & customers are normal entries in Statamic.
 
 This means you can take advantage of everything entries have to offer: front-end routing, multi-site localisations, fast search capabilities & more.
 
@@ -45,5 +45,4 @@ If you'd rather [use Blade instead](/blade), you can also take advantage of our 
 
 Simple Commerce has grown to support tones of features over the years.
 
-However, to its core, Simple Commerce is still *simple*. There's no bloat that'll slow you down, features to workaround, you can use what you need and nothing more.
-
+However, to its core, Simple Commerce is still _simple_. There's no bloat that'll slow you down, features to workaround, you can use what you need and nothing more.

--- a/docs/events.md
+++ b/docs/events.md
@@ -133,14 +133,14 @@ public function handle(PreCheckout $event)
 }
 ```
 
-### ReceiveGatewayWebhook
+### GatewayWebhookReceived
 
-[**`DoubleThreeDigital\SimpleCommerce\Events\ReceiveGatewayWebhook`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/ReceiveGatewayWebhook.php)
+[**`DoubleThreeDigital\SimpleCommerce\Events\GatewayWebhookReceived`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/GatewayWebhookReceived.php)
 
 This event is fired whenever a webhook request from a gateway is received.
 
 ```php
-public function handle(ReceiveGatewayWebhook $event)
+public function handle(GatewayWebhookReceived $event)
 {
 	$event->payload;
 }

--- a/src/Events/GatewayWebhookReceived.php
+++ b/src/Events/GatewayWebhookReceived.php
@@ -5,7 +5,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Events;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 
-class ReceiveGatewayWebhook
+class GatewayWebhookReceived
 {
     use Dispatchable;
     use InteractsWithSockets;

--- a/src/Http/Controllers/GatewayWebhookController.php
+++ b/src/Http/Controllers/GatewayWebhookController.php
@@ -2,7 +2,7 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers;
 
-use DoubleThreeDigital\SimpleCommerce\Events\ReceiveGatewayWebhook;
+use DoubleThreeDigital\SimpleCommerce\Events\GatewayWebhookReceived;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayDoesNotExist;
 use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
@@ -22,7 +22,7 @@ class GatewayWebhookController extends BaseActionController
             throw new GatewayDoesNotExist("Gateway [{$gatewayName}] does not exist.");
         }
 
-        event(new ReceiveGatewayWebhook($request->all()));
+        event(new GatewayWebhookReceived($request->all()));
 
         return Gateway::use($gateway['class'])->webhook($request);
     }


### PR DESCRIPTION
This pull request renames the `ReceiveGatewayWebhook` event to `GatewayWebhookReceived` because that sounds better.