### PR TITLE
Ignore appended attributes when saving database users

### DIFF
--- a/src/Customers/UserCustomerRepository.php
+++ b/src/Customers/UserCustomerRepository.php
@@ -6,6 +6,7 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Customer;
 use DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository as RepositoryContract;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Schema;
 use Statamic\Facades\User;
 
 class UserCustomerRepository implements RepositoryContract
@@ -60,8 +61,14 @@ class UserCustomerRepository implements RepositoryContract
             $user->email($customer->email());
         }
 
+        $ignoredKeys = ['id', 'email', 'roles', 'groups'];
+
+        if ($user instanceof \Statamic\Auth\Eloquent\User) {
+            $ignoredKeys = array_merge($ignoredKeys, $user->model()->getAppends());
+        }
+
         $user->data(
-            Arr::except($customer->data(), ['id', 'email'])
+            Arr::except($customer->data(), $ignoredKeys)
         );
 
         $user->save();

--- a/src/Customers/UserCustomerRepository.php
+++ b/src/Customers/UserCustomerRepository.php
@@ -6,7 +6,6 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Customer;
 use DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository as RepositoryContract;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Schema;
 use Statamic\Facades\User;
 
 class UserCustomerRepository implements RepositoryContract


### PR DESCRIPTION
This pull request fixes an issue when using the Users Customer repository & storing users in the database.

Essentially, if you have your own attributes set in `$appends`, on save, Simple Commerce will try and update columns using the names of the appended attributes.

However, obviously that won't work since they don't have physical columns in the database. This PR aims to workaround that.