### PR TITLE
Improve performance of "Top Customers" Overview widget when using Eloquent user repository

### DIFF
--- a/src/Overview.php
+++ b/src/Overview.php
@@ -203,7 +203,7 @@ class Overview
 
                     $query = $userModel::query()
                         ->where('orders', '!=', null)
-                        ->orderBy(function($query) {
+                        ->orderBy(function ($query) {
                             $query->selectRaw('JSON_ARRAY_LENGTH(orders)');
                         }, 'desc')
                         ->limit(5)

--- a/src/Overview.php
+++ b/src/Overview.php
@@ -197,16 +197,32 @@ class Overview
                     });
                 }
 
-                $query = User::all()
-                    ->where('orders', '!=', null)
-                    ->sortByDesc(function ($customer) {
-                        return count($customer->get('orders', []));
-                    })
-                    ->take(5)
-                    ->map(function ($user) {
-                        return Customer::find($user->id());
-                    })
-                    ->values();
+                if (config('statamic.users.repository') === 'eloquent') {
+                    $userModelClass = config('auth.providers.users.model');
+                    $userModel = new $userModelClass;
+
+                    $query = $userModel::query()
+                        ->where('orders', '!=', null)
+                        ->orderBy(function($query) {
+                            $query->selectRaw('JSON_ARRAY_LENGTH(orders)');
+                        }, 'desc')
+                        ->limit(5)
+                        ->get()
+                        ->map(function ($model) {
+                            return User::fromUser($model);
+                        });
+                } else {
+                    $query = User::all()
+                        ->where('orders', '!=', null)
+                        ->sortByDesc(function ($customer) {
+                            return count($customer->get('orders', []));
+                        })
+                        ->take(5)
+                        ->map(function ($user) {
+                            return Customer::find($user->id());
+                        })
+                        ->values();
+                }
 
                 return $query->map(function ($customer) {
                     return [


### PR DESCRIPTION
This pull request improves the performance of the "Top Customers" overview widget significantly when using the Eloquent user repository.

Previously, we used the same query whether users were flat-file or in the database. However, for users in the database, we can do database queries which will way better for sites with lots of users.