### PR TITLE
Add Pagination to Coupon & Tax listing tables

### DIFF
--- a/resources/views/cp/coupons/index.blade.php
+++ b/resources/views/cp/coupons/index.blade.php
@@ -65,6 +65,10 @@
                 </tbody>
             </table>
         </div>
+
+        <div class="my-2">
+            {{ $coupons->links('simple-commerce::cp.partials.pagination') }}
+        </div>
     @else
         @include('statamic::partials.create-first', [
             'resource' => __('Coupon'),

--- a/resources/views/cp/partials/pagination.blade.php
+++ b/resources/views/cp/partials/pagination.blade.php
@@ -1,0 +1,90 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="{{ __('Pagination Navigation') }}" class="flex items-center justify-between">
+        <div class="flex justify-between flex-1 sm:hidden">
+            @if ($paginator->onFirstPage())
+                <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-grey-50 bg-white border border-grey-30 cursor-default leading-5 rounded-md">
+                    {!! __('pagination.previous') !!}
+                </span>
+            @else
+                <a href="{{ $paginator->previousPageUrl() }}" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-grey-100 bg-white border border-grey-30 leading-5 rounded-md hover:text-grey-50 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-grey-10 active:text-grey-100 transition ease-in-out duration-150">
+                    {!! __('pagination.previous') !!}
+                </a>
+            @endif
+
+            @if ($paginator->hasMorePages())
+                <a href="{{ $paginator->nextPageUrl() }}" class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-grey-100 bg-white border border-grey-30 leading-5 rounded-md hover:text-grey-50 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-grey-10 active:text-grey-100 transition ease-in-out duration-150">
+                    {!! __('pagination.next') !!}
+                </a>
+            @else
+                <span class="relative inline-flex items-center px-4 py-2 ml-3 text-sm font-medium text-grey-50 bg-white border border-grey-30 cursor-default leading-5 rounded-md">
+                    {!! __('pagination.next') !!}
+                </span>
+            @endif
+        </div>
+
+        <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-center">
+            <div>
+                <span class="relative z-0 inline-flex shadow rounded-md">
+                    {{-- Previous Page Link --}}
+                    @if ($paginator->onFirstPage())
+                        <span aria-disabled="true" aria-label="{{ __('pagination.previous') }}">
+                            <span class="relative inline-flex items-center px-1.5 py-1 text-sm font-medium text-grey-50 bg-white border border-grey-30 cursor-default rounded-l-md leading-5" aria-hidden="true">
+                                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                                </svg>
+                            </span>
+                        </span>
+                    @else
+                        <a href="{{ $paginator->previousPageUrl() }}" rel="prev" class="relative inline-flex items-center px-1.5 py-1 text-sm font-medium text-grey-50 bg-white border border-grey-30 rounded-l-md leading-5 hover:text-grey-40 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-grey-10 active:text-grey-50 transition ease-in-out duration-150" aria-label="{{ __('pagination.previous') }}">
+                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                            </svg>
+                        </a>
+                    @endif
+
+                    {{-- Pagination Elements --}}
+                    @foreach ($elements as $element)
+                        {{-- "Three Dots" Separator --}}
+                        @if (is_string($element))
+                            <span aria-disabled="true">
+                                <span class="relative inline-flex items-center px-1.5 py-1 -ml-px text-sm font-medium text-grey-100 bg-white border border-grey-30 cursor-default leading-5">{{ $element }}</span>
+                            </span>
+                        @endif
+
+                        {{-- Array Of Links --}}
+                        @if (is_array($element))
+                            @foreach ($element as $page => $url)
+                                @if ($page == $paginator->currentPage())
+                                    <span aria-current="page">
+                                        <span class="relative inline-flex items-center px-1.5 py-1 -ml-px h-full text-sm font-medium text-primary bg-white border border-grey-30 cursor-default leading-5">{{ $page }}</span>
+                                    </span>
+                                @else
+                                    <a href="{{ $url }}" class="relative inline-flex items-center px-1.5 py-1 -ml-px text-sm font-medium text-grey-100 bg-white border border-grey-30 leading-5 hover:text-grey-50 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-grey-10 active:text-grey-100 transition ease-in-out duration-150" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
+                                        {{ $page }}
+                                    </a>
+                                @endif
+                            @endforeach
+                        @endif
+                    @endforeach
+
+                    {{-- Next Page Link --}}
+                    @if ($paginator->hasMorePages())
+                        <a href="{{ $paginator->nextPageUrl() }}" rel="next" class="relative inline-flex items-center px-1.5 py-1 -ml-px text-sm font-medium text-grey-50 bg-white border border-grey-30 rounded-r-md leading-5 hover:text-grey-40 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-grey-10 active:text-grey-50 transition ease-in-out duration-150" aria-label="{{ __('pagination.next') }}">
+                            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                            </svg>
+                        </a>
+                    @else
+                        <span aria-disabled="true" aria-label="{{ __('pagination.next') }}">
+                            <span class="relative inline-flex items-center px-1.5 py-1 -ml-px text-sm font-medium text-grey-50 bg-white border border-grey-30 cursor-default rounded-r-md leading-5" aria-hidden="true">
+                                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                                </svg>
+                            </span>
+                        </span>
+                    @endif
+                </span>
+            </div>
+        </div>
+    </nav>
+@endif

--- a/resources/views/cp/tax-categories/index.blade.php
+++ b/resources/views/cp/tax-categories/index.blade.php
@@ -55,6 +55,10 @@
                 </tbody>
             </table>
         </div>
+
+        <div class="my-2">
+            {{ $taxCategories->links('simple-commerce::cp.partials.pagination') }}
+        </div>
     @else
         @include('statamic::partials.create-first', [
             'resource' => __('Tax Category'),

--- a/resources/views/cp/tax-rates/index.blade.php
+++ b/resources/views/cp/tax-rates/index.blade.php
@@ -78,6 +78,10 @@
                 </tbody>
             </table>
         </div>
+
+        <div class="my-2">
+            {{ $taxRates->links('simple-commerce::cp.partials.pagination') }}
+        </div>
     @else
         @include('statamic::partials.create-first', [
             'resource' => __('Tax Rate'),

--- a/resources/views/cp/tax-zones/index.blade.php
+++ b/resources/views/cp/tax-zones/index.blade.php
@@ -63,6 +63,10 @@
                 </tbody>
             </table>
         </div>
+
+        <div class="my-2">
+            {{ $taxZones->links('simple-commerce::cp.partials.pagination') }}
+        </div>
     @else
         @include('statamic::partials.create-first', [
             'resource' => __('Tax Zone'),

--- a/src/Http/Controllers/CP/CouponController.php
+++ b/src/Http/Controllers/CP/CouponController.php
@@ -18,7 +18,7 @@ class CouponController
     public function index(IndexRequest $request)
     {
         return view('simple-commerce::cp.coupons.index', [
-            'coupons' => Coupon::all(),
+            'coupons' => Coupon::query()->paginate(50),
         ]);
     }
 

--- a/src/Http/Controllers/CP/CouponController.php
+++ b/src/Http/Controllers/CP/CouponController.php
@@ -18,7 +18,7 @@ class CouponController
     public function index(IndexRequest $request)
     {
         return view('simple-commerce::cp.coupons.index', [
-            'coupons' => Coupon::query()->paginate(50),
+            'coupons' => Coupon::query()->paginate(config('statamic.cp.pagination_size', 50)),
         ]);
     }
 

--- a/src/Http/Controllers/CP/TaxCategoryController.php
+++ b/src/Http/Controllers/CP/TaxCategoryController.php
@@ -16,7 +16,7 @@ class TaxCategoryController
     public function index(IndexRequest $request)
     {
         return view('simple-commerce::cp.tax-categories.index', [
-            'taxCategories' => TaxCategory::all(),
+            'taxCategories' => TaxCategory::query()->paginate(config('statamic.cp.pagination_size', 50)),
         ]);
     }
 

--- a/src/Http/Controllers/CP/TaxRateController.php
+++ b/src/Http/Controllers/CP/TaxRateController.php
@@ -18,7 +18,7 @@ class TaxRateController
     public function index(IndexRequest $request)
     {
         return view('simple-commerce::cp.tax-rates.index', [
-            'taxRates' => TaxRate::all(),
+            'taxRates' => TaxRate::query()->paginate(config('statamic.cp.pagination_size', 50)),
             'taxCategories' => TaxCategory::all(),
         ]);
     }

--- a/src/Http/Controllers/CP/TaxZoneController.php
+++ b/src/Http/Controllers/CP/TaxZoneController.php
@@ -17,7 +17,7 @@ class TaxZoneController
     public function index(IndexRequest $request)
     {
         return view('simple-commerce::cp.tax-zones.index', [
-            'taxZones' => TaxZone::all(),
+            'taxZones' => TaxZone::query()->paginate(config('statamic.cp.pagination_size', 50)),
         ]);
     }
 


### PR DESCRIPTION
This pull request adds in pagination to the listing tables for coupons/tax categories/tax zones/tax rates. 

I noticed this while working on a site with over 5k coupons where the coupons page too ages to load. As soon as I introduced pagination it was snappy.

This is a temporary fix before we likely introduce *proper* Vue listing tables in Simple Commerce 5 (post-release). 