### PR TITLE
Throw validation error when variant is missing

### DIFF
--- a/src/Http/Requests/CartItem/StoreRequest.php
+++ b/src/Http/Requests/CartItem/StoreRequest.php
@@ -2,11 +2,14 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CartItem;
 
+use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Http\Requests\AcceptsFormRequests;
 use DoubleThreeDigital\SimpleCommerce\Orders\Order as EntryOrder;
+use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
 use DoubleThreeDigital\SimpleCommerce\Rules\ProductExists;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreRequest extends FormRequest
 {
@@ -20,20 +23,39 @@ class StoreRequest extends FormRequest
     public function rules()
     {
         $rules = [
-            'product' => ['required', 'string'],
-            'variant' => ['nullable', 'string'],
-            'quantity' => ['required', 'numeric', 'gt:0'],
-
-            'email' => ['nullable', 'email', function ($attribute, $value, $fail) {
-                if (preg_match('/^\S*$/u', $value) === 0) {
-                    return $fail(__('Your email may not contain any spaces.'));
+            'product' => [
+                'required',
+                'string',
+            ],
+            'variant' => [
+                Rule::requiredIf(function () {
+                    return Product::find($this->product)->purchasableType() === ProductType::Variant;
+                }),
+                'string',
+            ],
+            'quantity' => [
+                'required',
+                'numeric',
+                'gt:0'
+            ],
+            'email' => [
+                'nullable',
+                'email',
+                function ($attribute, $value, $fail) {
+                    if (preg_match('/^\S*$/u', $value) === 0) {
+                        return $fail(__('Your email may not contain any spaces.'));
+                    }
                 }
-            }],
-            'customer.email' => ['nullable', 'email', function ($attribute, $value, $fail) {
-                if (preg_match('/^\S*$/u', $value) === 0) {
-                    return $fail(__('Your email may not contain any spaces.'));
+            ],
+            'customer.email' => [
+                'nullable',
+                'email',
+                function ($attribute, $value, $fail) {
+                    if (preg_match('/^\S*$/u', $value) === 0) {
+                        return $fail(__('Your email may not contain any spaces.'));
+                    }
                 }
-            }],
+            ],
         ];
 
         if ($formRequest = $this->get('_request')) {

--- a/src/Http/Requests/CartItem/StoreRequest.php
+++ b/src/Http/Requests/CartItem/StoreRequest.php
@@ -36,7 +36,7 @@ class StoreRequest extends FormRequest
             'quantity' => [
                 'required',
                 'numeric',
-                'gt:0'
+                'gt:0',
             ],
             'email' => [
                 'nullable',
@@ -45,7 +45,7 @@ class StoreRequest extends FormRequest
                     if (preg_match('/^\S*$/u', $value) === 0) {
                         return $fail(__('Your email may not contain any spaces.'));
                     }
-                }
+                },
             ],
             'customer.email' => [
                 'nullable',
@@ -54,7 +54,7 @@ class StoreRequest extends FormRequest
                     if (preg_match('/^\S*$/u', $value) === 0) {
                         return $fail(__('Your email may not contain any spaces.'));
                     }
-                }
+                },
             ],
         ];
 


### PR DESCRIPTION
This pull request addresses #867 by throwing a validation error when adding a variant product to the cart without passing in the `variant` parameter. 