### PR TITLE
Create Carbon object from $model->paid_date during database migration

### DIFF
--- a/src/Console/Commands/MigrateOrderStatuses.php
+++ b/src/Console/Commands/MigrateOrderStatuses.php
@@ -122,7 +122,7 @@ class MigrateOrderStatuses extends Command
 
                         $model->data = array_merge($model->data, [
                             'status_log' => [
-                                'paid' => $model->paid_date->format('Y-m-d H:i'),
+                                'paid' => Carbon::parse($model->paid_date)->format('Y-m-d H:i'),
                             ],
                         ]);
 


### PR DESCRIPTION
This PR fixes an issue when running `php please sc:migrate-order-statuses` when upgrading from 4.x to 5.x. 

`$model->paid_date` was not augmented into a Carbon object before calling the `format` method.