### PR TITLE
Shipping Tax

### DIFF
--- a/docs/tax.md
+++ b/docs/tax.md
@@ -30,7 +30,9 @@ As explained above, the Basic Tax Engine simply lets you define a flat tax rate 
 
 If you have a product which is exempt from tax, you may add a Toggle field to your Product blueprint, called `exempt_from_tax`. Then, you may turn the toggle on for the product.
 
-You may optionally enable taxes for shipping - simply flick the toggle in your Simple Commerce config:
+### Shipping Tax
+
+If you wish to enable tax for shipping costs, simply flick the toggle in your Simple Commerce config:
 
 ```php
 // config/simple-commerce.php
@@ -40,6 +42,8 @@ You may optionally enable taxes for shipping - simply flick the toggle in your S
     'shipping_taxes' => true,
 ],
 ```
+
+Now, the tax rate you have set for all products will also be applied to shipping costs.
 
 ## Standard Tax Engine
 
@@ -79,11 +83,13 @@ After enabling the tax engine, you will also want to go ahead and setup your Rat
 
 > If you'd like your client (or other non-super user) to be able to access these pages, you may give them access via [Permissions](https://statamic.dev/users#permissions).
 
-### Shipping Taxes
+### Shipping Tax
 
-Simple Commerce will automatically create a 'Default - Shipping' tax category. This category will be used when Simple Commerce is figuring out if/what tax should be applied to shipping.
+Simple Commerce will automatically create a 'Default - Shipping' tax category when you enable the Standard Tax Engine.
 
-You may associate tax rates & zones to this category like normal. They'll be picked up when Simple Commerce calculates taxes after a shipping method has been selected.
+This tax category will be used when Simple Commerce is figuring out what tax (if any) should be applied to shipping costs.
+
+Similar to products, you may associate tax rates with the shipping category. Then tax will be applied to shipping in the user's cart.
 
 ### Edge Cases
 

--- a/docs/tax.md
+++ b/docs/tax.md
@@ -30,6 +30,17 @@ As explained above, the Basic Tax Engine simply lets you define a flat tax rate 
 
 If you have a product which is exempt from tax, you may add a Toggle field to your Product blueprint, called `exempt_from_tax`. Then, you may turn the toggle on for the product.
 
+You may optionally enable taxes for shipping - simply flick the toggle in your Simple Commerce config:
+
+```php
+// config/simple-commerce.php
+
+'tax_engine_config' => [
+    // ...
+    'shipping_taxes' => true,
+],
+```
+
 ## Standard Tax Engine
 
 The Standard Tax Engine is enabled by default in new Simple Commerce sites. You may enable it if you're on an older site like so:
@@ -67,6 +78,12 @@ There's three main concepts you'll want to be familuar with before you begin:
 After enabling the tax engine, you will also want to go ahead and setup your Rates, Categories and Zones. Each of these have sections in the Control Panel.
 
 > If you'd like your client (or other non-super user) to be able to access these pages, you may give them access via [Permissions](https://statamic.dev/users#permissions).
+
+### Shipping Taxes
+
+Simple Commerce will automatically create a 'Default - Shipping' tax category. This category will be used when Simple Commerce is figuring out if/what tax should be applied to shipping.
+
+You may associate tax rates & zones to this category like normal. They'll be picked up when Simple Commerce calculates taxes after a shipping method has been selected.
 
 ### Edge Cases
 

--- a/resources/views/cp/tax-categories/index.blade.php
+++ b/resources/views/cp/tax-categories/index.blade.php
@@ -37,7 +37,7 @@
                                         <dropdown-item :text="__('Edit')" redirect="{{ $taxCategory->editUrl() }}"></dropdown-item>
                                     @endif
 
-                                    @if($taxCategory->id() !== 'default' && auth()->user()->can('delete tax categories'))
+                                    @if($taxCategory->id() !== 'default' && $taxCategory->id() !== 'shipping' && auth()->user()->can('delete tax categories'))
                                         <dropdown-item :text="__('Delete')" class="warning" @click="$refs.deleter.confirm()">
                                             <resource-deleter
                                                 ref="deleter"

--- a/resources/views/cp/tax-rates/index.blade.php
+++ b/resources/views/cp/tax-rates/index.blade.php
@@ -60,7 +60,7 @@
                                         <dropdown-item :text="__('Edit')" redirect="{{ $taxRate->editUrl() }}"></dropdown-item>
                                     @endif
 
-                                    @if($taxRate->id() !== 'default-rate' && auth()->user()->can('delete tax rates'))
+                                    @if($taxRate->id() !== 'default-rate' && $taxRate->id() !== 'default-shipping-rate' && auth()->user()->can('delete tax rates'))
                                         <dropdown-item :text="__('Delete')" class="warning" @click="$refs.deleter.confirm()">
                                             <resource-deleter
                                                 ref="deleter"

--- a/src/Contracts/TaxEngine.php
+++ b/src/Contracts/TaxEngine.php
@@ -9,5 +9,7 @@ interface TaxEngine
 {
     public function name(): string;
 
-    public function calculate(Order $order, LineItem $lineItem): TaxCalculation;
+    public function calculateForLineItem(Order $order, LineItem $lineItem): TaxCalculation;
+
+    public function calculateForShipping(Order $order, ShippingMethod $shippingMethod): TaxCalculation;
 }

--- a/src/Orders/Calculator/Calculator.php
+++ b/src/Orders/Calculator/Calculator.php
@@ -17,6 +17,7 @@ class Calculator implements Contract
                 CalculateItemsTotal::class,
                 CouponCalculator::class,
                 ShippingCalculator::class,
+                ShippingTaxCalculator::class,
                 CalculateGrandTotal::class,
             ])
             ->thenReturn();

--- a/src/Orders/Calculator/LineItemTaxCalculator.php
+++ b/src/Orders/Calculator/LineItemTaxCalculator.php
@@ -14,7 +14,7 @@ class LineItemTaxCalculator
         $order->lineItems()
             ->transform(function (LineItem $lineItem) use ($order) {
                 $taxEngine = SimpleCommerce::taxEngine();
-                $taxCalculation = $taxEngine->calculate($order, $lineItem);
+                $taxCalculation = $taxEngine->calculateForLineItem($order, $lineItem);
 
                 $lineItem->tax($taxCalculation->toArray());
 

--- a/src/Orders/Calculator/ShippingTaxCalculator.php
+++ b/src/Orders/Calculator/ShippingTaxCalculator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
+
+use Closure;
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Statamic\Facades\Site;
+
+class ShippingTaxCalculator
+{
+    public function handle(Order $order, Closure $next)
+    {
+        $defaultShippingMethod = config('simple-commerce.sites.'.Site::current()->handle().'.shipping.default_method');
+        $shippingMethod = $order->get('shipping_method') ?? $defaultShippingMethod;
+
+        if (! $shippingMethod) {
+            return $next($order);
+        }
+
+        $taxEngine = SimpleCommerce::taxEngine();
+        $taxCalculation = $taxEngine->calculateForShipping($order, new $shippingMethod);
+
+        $order->set('shipping_tax', $taxCalculation->toArray());
+
+        if ($taxCalculation->priceIncludesTax()) {
+            $order->shippingTotal($order->shippingTotal() - $taxCalculation->amount());
+
+            $order->taxTotal(
+                $order->taxTotal() + $taxCalculation->amount()
+            );
+        } else {
+            $order->taxTotal(
+                $order->taxTotal() + $taxCalculation->amount()
+            );
+        }
+
+        return $next($order);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -110,6 +110,7 @@ class ServiceProvider extends AddonServiceProvider
         UpdateScripts\v5_0\SetDefaultNavPreferences::class,
         UpdateScripts\v5_0\UpdateNotificationsConfig::class,
         UpdateScripts\v5_0\UpdateOrderBlueprint::class,
+        UpdateScripts\v5_0\CreateShippingTaxCategory::class,
     ];
 
     protected $vite = [

--- a/src/Shipping/Manager.php
+++ b/src/Shipping/Manager.php
@@ -62,7 +62,7 @@ class Manager implements Contract
             ->first();
 
         return resolve($this->className, [
-            'config' => $shippingMethod['config'],
+            'config' => $shippingMethod['config'] ?? [],
         ]);
     }
 }

--- a/src/Tax/BasicTaxEngine.php
+++ b/src/Tax/BasicTaxEngine.php
@@ -50,6 +50,16 @@ class BasicTaxEngine implements TaxEngine
 
     public function calculateForShipping(Order $order, ShippingMethod $shippingMethod): TaxCalculation
     {
-        // TODO
+        if (config('tax_engine_config.shipping_exempt') === true)  {
+            return new TaxCalculation;
+        }
+
+        $taxAmount = $order->shippingTotal() / 100 * $this->taxRate;
+
+        return new TaxCalculation(
+            (int) round($taxAmount),
+            $this->taxRate,
+            $this->includedInPrices
+        );
     }
 }

--- a/src/Tax/BasicTaxEngine.php
+++ b/src/Tax/BasicTaxEngine.php
@@ -50,7 +50,7 @@ class BasicTaxEngine implements TaxEngine
 
     public function calculateForShipping(Order $order, ShippingMethod $shippingMethod): TaxCalculation
     {
-        if (! config('simple-commerce.tax_engine_config.shipping_taxes'))  {
+        if (! config('simple-commerce.tax_engine_config.shipping_taxes')) {
             return new TaxCalculation;
         }
 

--- a/src/Tax/BasicTaxEngine.php
+++ b/src/Tax/BasicTaxEngine.php
@@ -50,7 +50,7 @@ class BasicTaxEngine implements TaxEngine
 
     public function calculateForShipping(Order $order, ShippingMethod $shippingMethod): TaxCalculation
     {
-        if (! config('tax_engine_config.shipping_taxes'))  {
+        if (! config('simple-commerce.tax_engine_config.shipping_taxes'))  {
             return new TaxCalculation;
         }
 

--- a/src/Tax/BasicTaxEngine.php
+++ b/src/Tax/BasicTaxEngine.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\SimpleCommerce\Tax;
 
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\Contracts\TaxEngine;
 use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
 use Illuminate\Support\Facades\Config;
@@ -26,7 +27,7 @@ class BasicTaxEngine implements TaxEngine
         return __('Basic Tax Engine');
     }
 
-    public function calculate(Order $order, LineItem $lineItem): TaxCalculation
+    public function calculateForLineItem(Order $order, LineItem $lineItem): TaxCalculation
     {
         $product = $lineItem->product();
 
@@ -45,5 +46,10 @@ class BasicTaxEngine implements TaxEngine
             $this->taxRate,
             $this->includedInPrices
         );
+    }
+
+    public function calculateForShipping(Order $order, ShippingMethod $shippingMethod): TaxCalculation
+    {
+        // TODO
     }
 }

--- a/src/Tax/BasicTaxEngine.php
+++ b/src/Tax/BasicTaxEngine.php
@@ -50,7 +50,7 @@ class BasicTaxEngine implements TaxEngine
 
     public function calculateForShipping(Order $order, ShippingMethod $shippingMethod): TaxCalculation
     {
-        if (config('tax_engine_config.shipping_exempt') === true)  {
+        if (! config('tax_engine_config.shipping_taxes'))  {
             return new TaxCalculation;
         }
 

--- a/src/Tax/Standard/Stache/TaxCategory/TaxCategoryRepository.php
+++ b/src/Tax/Standard/Stache/TaxCategory/TaxCategoryRepository.php
@@ -59,8 +59,14 @@ class TaxCategoryRepository implements Contract
     {
         $this->make()
             ->id('default')
-            ->name('Default')
+            ->name(__('Default'))
             ->description(__('Will be used for all products where a category has not been assigned.'))
+            ->save();
+
+        $this->make()
+            ->id('shipping')
+            ->name(__('Shipping'))
+            ->description(__('This tax category will be automatically applied to shipping costs.'))
             ->save();
 
         TaxZone::make()
@@ -72,6 +78,14 @@ class TaxCategoryRepository implements Contract
             ->id('default-rate')
             ->name('Default')
             ->category('default')
+            ->zone('everywhere')
+            ->rate(0)
+            ->save();
+
+        TaxRate::make()
+            ->id('default-shipping-rate')
+            ->name('Default Shipping')
+            ->category('shipping')
             ->zone('everywhere')
             ->rate(0)
             ->save();

--- a/src/Tax/Standard/Stache/TaxCategory/TaxCategoryRepository.php
+++ b/src/Tax/Standard/Stache/TaxCategory/TaxCategoryRepository.php
@@ -84,7 +84,7 @@ class TaxCategoryRepository implements Contract
 
         TaxRate::make()
             ->id('default-shipping-rate')
-            ->name('Default Shipping')
+            ->name('Default - Shipping')
             ->category('shipping')
             ->zone('everywhere')
             ->rate(0)

--- a/src/Tax/Standard/TaxEngine.php
+++ b/src/Tax/Standard/TaxEngine.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard;
 
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\Contracts\TaxEngine as Contract;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\PreventCheckout;
 use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
@@ -20,7 +21,7 @@ class TaxEngine implements Contract
         return 'Standard';
     }
 
-    public function calculate(Order $order, LineItem $lineItem): TaxCalculation
+    public function calculateForLineItem(Order $order, LineItem $lineItem): TaxCalculation
     {
         $taxRate = $this->decideOnRate($order, $lineItem);
 
@@ -40,6 +41,11 @@ class TaxEngine implements Contract
         $itemTax = (int) round($taxAmount * 100);
 
         return new TaxCalculation($itemTax, $taxRate->rate(), $taxRate->includeInPrice());
+    }
+
+    public function calculateForShipping(Order $order, ShippingMethod $shippingMethod): TaxCalculation
+    {
+        // TODO
     }
 
     protected function decideOnRate(Order $order, LineItem $lineItem): ?StandardTaxRate

--- a/src/Tax/Standard/TaxEngine.php
+++ b/src/Tax/Standard/TaxEngine.php
@@ -6,6 +6,7 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\Contracts\TaxEngine as Contract;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\PreventCheckout;
+use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
 use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
 use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
 use DoubleThreeDigital\SimpleCommerce\Orders\Address;
@@ -23,7 +24,7 @@ class TaxEngine implements Contract
 
     public function calculateForLineItem(Order $order, LineItem $lineItem): TaxCalculation
     {
-        $taxRate = $this->decideOnRate($order, $lineItem);
+        $taxRate = $this->decideOnLineItemRate($order, $lineItem);
 
         if (! $taxRate) {
             $noRateAvailable = config('simple-commerce.tax_engine_config.behaviour.no_rate_available');
@@ -43,12 +44,7 @@ class TaxEngine implements Contract
         return new TaxCalculation($itemTax, $taxRate->rate(), $taxRate->includeInPrice());
     }
 
-    public function calculateForShipping(Order $order, ShippingMethod $shippingMethod): TaxCalculation
-    {
-        // TODO
-    }
-
-    protected function decideOnRate(Order $order, LineItem $lineItem): ?StandardTaxRate
+    protected function decideOnLineItemRate(Order $order, LineItem $lineItem): ?StandardTaxRate
     {
         $product = $lineItem->product();
 
@@ -72,6 +68,77 @@ class TaxEngine implements Contract
         $taxRateQuery = TaxRate::all()
             ->filter(function ($taxRate) use ($product) {
                 return $taxRate->category()->id() === $product->taxCategory()->id();
+            });
+
+        $taxZoneQuery = TaxZone::all()->where('id', '!=', 'everywhere');
+
+        if ($address->country()) {
+            $taxZoneQuery = $taxZoneQuery->filter(function ($taxZone) use ($address) {
+                return $taxZone->country() === $address->country();
+            });
+
+            if ($address->region()) {
+                $taxZoneQuery = $taxZoneQuery->filter(function ($taxZone) use ($address) {
+                    return $taxZone->region() === $address->region();
+                });
+            }
+        }
+
+        if ($taxZoneQuery->count() < 1) {
+            $taxZoneQuery = TaxZone::query()->where('id', 'everywhere')->get();
+        }
+
+        return $taxRateQuery
+            ->filter(function ($taxRate) use ($taxZoneQuery) {
+                return $taxRate->zone()->id() === $taxZoneQuery->first()->id();
+            })
+            ->first();
+    }
+
+    public function calculateForShipping(Order $order, ShippingMethod $shippingMethod): TaxCalculation
+    {
+        $taxRate = $this->decideOnShippingRate($order, $shippingMethod);
+
+        if (! $taxRate) {
+            $noRateAvailable = config('simple-commerce.tax_engine_config.behaviour.no_rate_available');
+
+            if ($noRateAvailable === 'default_rate') {
+                $taxRate = TaxRate::find('default-rate');
+            }
+
+            if ($noRateAvailable === 'prevent_checkout') {
+                throw new PreventCheckout(__('This order cannot be completed as no tax rate is available.'));
+            }
+        }
+
+        $taxAmount = $order->shippingTotal() / 100 * $taxRate->rate();
+        $itemTax = (int) round($taxAmount);
+
+        return new TaxCalculation($itemTax, $taxRate->rate(), $taxRate->includeInPrice());
+    }
+
+    protected function decideOnShippingRate(Order $order, ShippingMethod $shippingMethod): ?StandardTaxRate
+    {
+        /** @var \DoubleThreeDigital\SimpleCommerce\Orders\Address */
+        $address = config('simple-commerce.tax_engine_config.address') === 'billing'
+            ? $order->billingAddress()
+            : $order->shippingAddress();
+
+        if (! $address) {
+            $noAddressProvided = config('simple-commerce.tax_engine_config.behaviour.no_address_provided');
+
+            if ($noAddressProvided === 'default_address') {
+                $address = $this->defaultAddress();
+            }
+
+            if ($noAddressProvided === 'prevent_checkout') {
+                throw new PreventCheckout(__('This order cannot be completed as no address has been added to this order.'));
+            }
+        }
+
+        $taxRateQuery = TaxRate::all()
+            ->filter(function ($taxRate) {
+                return $taxRate->category()->id() === TaxCategory::find('shipping')->id();
             });
 
         $taxZoneQuery = TaxZone::all()->where('id', '!=', 'everywhere');

--- a/src/UpdateScripts/v5_0/CreateShippingTaxCategory.php
+++ b/src/UpdateScripts/v5_0/CreateShippingTaxCategory.php
@@ -28,7 +28,7 @@ class CreateShippingTaxCategory extends UpdateScript
 
         TaxRate::make()
             ->id('default-shipping-rate')
-            ->name('Default Shipping')
+            ->name('Default - Shipping')
             ->category('shipping')
             ->zone('everywhere')
             ->rate(0)

--- a/src/UpdateScripts/v5_0/CreateShippingTaxCategory.php
+++ b/src/UpdateScripts/v5_0/CreateShippingTaxCategory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v5_0;
+
+use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
+use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Statamic\UpdateScripts\UpdateScript;
+
+class CreateShippingTaxCategory extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('5.1.0');
+    }
+
+    public function update()
+    {
+        if (! SimpleCommerce::isUsingStandardTaxEngine()) {
+            return;
+        }
+
+        TaxCategory::make()
+            ->id('shipping')
+            ->name(__('Shipping'))
+            ->description(__('This tax category will be automatically applied to shipping costs.'))
+            ->save();
+
+        TaxRate::make()
+            ->id('default-shipping-rate')
+            ->name('Default Shipping')
+            ->category('shipping')
+            ->zone('everywhere')
+            ->rate(0)
+            ->save();
+    }
+}

--- a/tests/Tax/BasicTaxEngineTest.php
+++ b/tests/Tax/BasicTaxEngineTest.php
@@ -147,6 +147,7 @@ test('ensure round value tax is calculated correctly', function () {
 test('can calculate shipping tax when included in price', function () {
     Config::set('simple-commerce.tax_engine_config.rate', 20);
     Config::set('simple-commerce.tax_engine_config.included_in_prices', true);
+    Config::set('simple-commerce.tax_engine_config.shipping_taxes', true);
 
     $order = Order::make()
         ->status(OrderStatus::Cart)

--- a/tests/Tax/BasicTaxEngineTest.php
+++ b/tests/Tax/BasicTaxEngineTest.php
@@ -5,13 +5,14 @@ use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
 use DoubleThreeDigital\SimpleCommerce\Tax\BasicTaxEngine;
 use DoubleThreeDigital\SimpleCommerce\Tax\TaxCalculation;
+use DoubleThreeDigital\SimpleCommerce\Tests\Tax\Helpers\DummyShippingMethod;
 use Illuminate\Support\Facades\Config;
 use Statamic\Facades\Collection;
 
 /**
  * Inline with the fix suggested here: https://github.com/duncanmcclean/simple-commerce/pull/438#issuecomment-888498198
  */
-test('can calculate tax when not included in price', function () {
+test('can calculate line item tax when not included in price', function () {
     Config::set('simple-commerce.tax_engine_config.rate', 20);
     Config::set('simple-commerce.tax_engine_config.included_in_prices', false);
 
@@ -37,7 +38,7 @@ test('can calculate tax when not included in price', function () {
     expect(20)->toBe($taxCalculation->rate());
 });
 
-test('can calculate tax when included in price', function () {
+test('can calculate line item tax when included in price', function () {
     Config::set('simple-commerce.tax_engine_config.rate', 20);
     Config::set('simple-commerce.tax_engine_config.included_in_prices', true);
 
@@ -63,7 +64,7 @@ test('can calculate tax when included in price', function () {
     expect(20)->toBe($taxCalculation->rate());
 });
 
-test('can calculate tax when tax rate is decimal number', function () {
+test('can calculate line item tax when tax rate is decimal number', function () {
     Config::set('simple-commerce.tax_engine_config.rate', 10.5);
 
     Collection::make('products')->save();
@@ -91,7 +92,7 @@ test('can calculate tax when tax rate is decimal number', function () {
     expect(10.5)->toBe($taxCalculation->rate());
 });
 
-test('can calculate tax when it is nothing', function () {
+test('can calculate line item tax when it is nothing', function () {
     Config::set('simple-commerce.tax_engine_config.rate', 0);
 
     $product = Product::make()->price(1000);
@@ -116,9 +117,7 @@ test('can calculate tax when it is nothing', function () {
     expect(0)->toBe($taxCalculation->rate());
 });
 
-/**
- * Covers #430 (https://github.com/duncanmcclean/simple-commerce/pull/430)
- */
+// https://github.com/duncanmcclean/simple-commerce/pull/430
 test('ensure round value tax is calculated correctly', function () {
     Config::set('simple-commerce.tax_engine_config.rate', 20);
     Config::set('simple-commerce.tax_engine_config.included_in_prices', true);
@@ -141,6 +140,26 @@ test('ensure round value tax is calculated correctly', function () {
     expect($taxCalculation instanceof TaxCalculation)->toBeTrue();
 
     expect(1300)->toBe($taxCalculation->amount());
+    expect(true)->toBe($taxCalculation->priceIncludesTax());
+    expect(20)->toBe($taxCalculation->rate());
+});
+
+test('can calculate shipping tax when included in price', function () {
+    Config::set('simple-commerce.tax_engine_config.rate', 20);
+    Config::set('simple-commerce.tax_engine_config.included_in_prices', true);
+
+    $order = Order::make()
+        ->status(OrderStatus::Cart)
+        ->merge(['shipping_method' => DummyShippingMethod::class])
+        ->shippingTotal(500);
+
+    $order->save();
+
+    $taxCalculation = (new BasicTaxEngine)->calculateForShipping($order, new DummyShippingMethod);
+
+    expect($taxCalculation instanceof TaxCalculation)->toBeTrue();
+
+    expect(100)->toBe($taxCalculation->amount());
     expect(true)->toBe($taxCalculation->priceIncludesTax());
     expect(20)->toBe($taxCalculation->rate());
 });

--- a/tests/Tax/BasicTaxEngineTest.php
+++ b/tests/Tax/BasicTaxEngineTest.php
@@ -28,7 +28,7 @@ test('can calculate tax when not included in price', function () {
 
     $order->save();
 
-    $taxCalculation = (new BasicTaxEngine)->calculate($order, $order->lineItems()->first());
+    $taxCalculation = (new BasicTaxEngine)->calculateForLineItem($order, $order->lineItems()->first());
 
     expect($taxCalculation instanceof TaxCalculation)->toBeTrue();
 
@@ -54,7 +54,7 @@ test('can calculate tax when included in price', function () {
 
     $order->save();
 
-    $taxCalculation = (new BasicTaxEngine)->calculate($order, $order->lineItems()->first());
+    $taxCalculation = (new BasicTaxEngine)->calculateForLineItem($order, $order->lineItems()->first());
 
     expect($taxCalculation instanceof TaxCalculation)->toBeTrue();
 
@@ -82,7 +82,7 @@ test('can calculate tax when tax rate is decimal number', function () {
 
     $order->save();
 
-    $taxCalculation = (new BasicTaxEngine)->calculate($order, $order->lineItems()->first());
+    $taxCalculation = (new BasicTaxEngine)->calculateForLineItem($order, $order->lineItems()->first());
 
     expect($taxCalculation instanceof TaxCalculation)->toBeTrue();
 
@@ -107,7 +107,7 @@ test('can calculate tax when it is nothing', function () {
 
     $order->save();
 
-    $taxCalculation = (new BasicTaxEngine)->calculate($order, $order->lineItems()->first());
+    $taxCalculation = (new BasicTaxEngine)->calculateForLineItem($order, $order->lineItems()->first());
 
     expect($taxCalculation instanceof TaxCalculation)->toBeTrue();
 
@@ -136,7 +136,7 @@ test('ensure round value tax is calculated correctly', function () {
 
     $order->save();
 
-    $taxCalculation = (new BasicTaxEngine)->calculate($order, $order->lineItems()->first());
+    $taxCalculation = (new BasicTaxEngine)->calculateForLineItem($order, $order->lineItems()->first());
 
     expect($taxCalculation instanceof TaxCalculation)->toBeTrue();
 

--- a/tests/Tax/Helpers/DummyShippingMethod.php
+++ b/tests/Tax/Helpers/DummyShippingMethod.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Tests\Tax\Helpers;
+
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
+use DoubleThreeDigital\SimpleCommerce\Orders\Address;
+
+class DummyShippingMethod implements ShippingMethod
+{
+    public function name(): string
+    {
+        return 'Dummy Shipping Method';
+    }
+
+    public function description(): string
+    {
+        return 'Dummy Shipping Method Description';
+    }
+
+    public function calculateCost(Order $order): int
+    {
+        return 500;
+    }
+
+    public function checkAvailability(Order $order, Address $address): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
This pull request closes #856 by allowing for tax to be applied to shipping amounts. This was only made possible by changes to the calculator in #873.

By default, calculating tax for shipping methods is disabled (in both the Basic & Standard tax engines), however you may choose to enable them:

**Basic Tax Engine:**

To enable, you may simply flick the toggle in your Simple Commerce config:

```php
// config/simple-commerce.php

'tax_engine_config' => [
    // ...
    'shipping_taxes' => true,
],
```

Then, the tax rate you set for all other products will be applied to shipping too.

**Standard Tax Engine:**

1. Upon upgrade, you'll find a new 'Default - Shipping' tax category
2. Configure tax zones & tax rates associated with the newly created category
3. Shipping taxes will be based on the rates entered

## To Do 

* [x] Clean up documentation
* [x] Resolve failing test