### PR TITLE
Exclude webhook routes from CSRF protection

### DIFF
--- a/docs/payment-gateways/custom-gateways.md
+++ b/docs/payment-gateways/custom-gateways.md
@@ -106,14 +106,6 @@ When anything changes payment-wise on the order, the off-site gateway will send 
 
 Webhook URLs look a little something like this: `/!/simple-commerce/gateways/YOUR_GATEWAY_NAME/webhook`
 
-And for each webhook, you'll need to add an exception to the CSRF middleware, found in `app/Http/Middleware/VerifyCsrfToken.php`.
-
-```php
-protected $except = [
-  '/!/simple-commerce/gateways/mollie/webhook',
-];
-```
-
 :::note Note!
 When you're going through the payment flow in your development environment, you will need to use something like Expose or Ngrok to proxy request to your local server. Otherwise, Mollie wouldn't be able to hit the webhook. You will also need to update the `APP_URL` in your `.env`.
 :::

--- a/docs/payment-gateways/mollie.md
+++ b/docs/payment-gateways/mollie.md
@@ -44,14 +44,6 @@ However, bear in mind that where-ever you use that tag, the customer will be red
 
 The Mollie gateway has a webhook which is hit by Mollie whenever a payment is made.
 
-Simple Commerce will configure the webhook on Mollie's end. However, you'll need to add the webhook URL to your list of CSRF exceptions, found in `app/Http/Middleware/VerifyCsrfToken.php`.
-
-```php
-protected $except = [
-  '/!/simple-commerce/gateways/mollie/webhook',
-];
-```
-
 :::note Note!
 When you're going through the payment flow in your development environment, you will need to use something like Expose or Ngrok to proxy request to your local server. Otherwise, Mollie wouldn't be able to hit the webhook. You will also need to update the `APP_URL` in your `.env`.
 :::

--- a/docs/payment-gateways/paypal.md
+++ b/docs/payment-gateways/paypal.md
@@ -104,14 +104,6 @@ Unfortunatley, PayPal offers no way for Simple Commerce to configure the webhook
 4. The Webhook URL should be: `https://example.com/!/simple-commerce/gateways/paypal/webhook`
 5. Under 'Event types', you should select 'All events'. You can then save the webhook.
 
-You will also need to add the webhook's URL to your list of CSRF exceptions, which can be found in `app/Http/Middleware/VerifyCsrfToken.php`.
-
-```php
-protected $except = [
-  '/!/simple-commerce/gateways/paypal/webhook',
-];
-```
-
 :::note Note!
 When you're going through the payment flow in your development environment, you will need to use something like Expose or Ngrok to proxy request to your local server. Otherwise, Mollie wouldn't be able to hit the webhook. You will also need to update the `APP_URL` in your `.env`.
 :::

--- a/docs/payment-gateways/stripe.md
+++ b/docs/payment-gateways/stripe.md
@@ -151,14 +151,6 @@ You'll need to configure the webhook in the Stripe Dashboard:
         - `payment_intent.failed`
         - `charge.refunded`
 
-You will also need to add the webhook's URL to your list of CSRF exceptions, which can be found in `app/Http/Middleware/VerifyCsrfToken.php`.
-
-```php
-protected $except = [
-  '/!/simple-commerce/gateways/stripe/webhook',
-];
-```
-
 :::note Note!
 When you're going through the payment flow in your development environment, you will need to use something like Expose or Ngrok to proxy request to your local server. Otherwise, Stripe wouldn't be able to hit the webhook. You will also need to update the `APP_URL` in your `.env`.
 :::

--- a/routes/actions.php
+++ b/routes/actions.php
@@ -8,6 +8,7 @@ use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CustomerController;
 use DoubleThreeDigital\SimpleCommerce\Http\Controllers\GatewayCallbackController;
 use DoubleThreeDigital\SimpleCommerce\Http\Controllers\GatewayWebhookController;
 use DoubleThreeDigital\SimpleCommerce\Http\Middleware\EnsureFormParametersArriveIntact;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Support\Facades\Route;
 
 Route::namespace('\DoubleThreeDigital\SimpleCommerce\Http\Controllers\Actions')->name('simple-commerce.')->group(function () {
@@ -31,5 +32,8 @@ Route::namespace('\DoubleThreeDigital\SimpleCommerce\Http\Controllers\Actions')-
     });
 
     Route::get('/gateways/{gateway}/callback', [GatewayCallbackController::class, 'index'])->name('gateways.callback');
-    Route::post('/gateways/{gateway}/webhook', [GatewayWebhookController::class, 'index'])->name('gateways.webhook');
+
+    Route::post('/gateways/{gateway}/webhook', [GatewayWebhookController::class, 'index'])
+        ->name('gateways.webhook')
+        ->withoutMiddleware([VerifyCsrfToken::class]);
 });


### PR DESCRIPTION
This pull request excludes gateway webhook routes from Laravel's CSRF protection middleware.

Currently, it's recommended that users add gateway URLs to the `VerifyCsrfToken` middleware in their app. However, we can do this inside Simple Commerce so no action is required by the user.