### PR TITLE
Runway: Add `HasRunwayResource` trait & install as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,11 +40,12 @@
     },
     "require-dev": {
         "doctrine/dbal": "^3.3",
+        "doublethreedigital/runway": "^5.0",
         "orchestra/testbench": "^8.0",
-        "spatie/ray": "^1.17",
-        "spatie/test-time": "^1.3",
         "pestphp/pest": "^2.2",
-        "pestphp/pest-plugin-laravel": "^2.0"
+        "pestphp/pest-plugin-laravel": "^2.0",
+        "spatie/ray": "^1.17",
+        "spatie/test-time": "^1.3"
     },
     "scripts": {
         "lint": [

--- a/src/Customers/CustomerModel.php
+++ b/src/Customers/CustomerModel.php
@@ -2,8 +2,8 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Customers;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
 use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
+use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;

--- a/src/Customers/CustomerModel.php
+++ b/src/Customers/CustomerModel.php
@@ -3,13 +3,14 @@
 namespace DoubleThreeDigital\SimpleCommerce\Customers;
 
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
+use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class CustomerModel extends Model
 {
-    use HasFactory;
+    use HasFactory, HasRunwayResource;
 
     protected $table = 'customers';
 

--- a/src/Orders/OrderModel.php
+++ b/src/Orders/OrderModel.php
@@ -2,8 +2,8 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Orders;
 
-use DoubleThreeDigital\SimpleCommerce\Customers\CustomerModel;
 use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
+use DoubleThreeDigital\SimpleCommerce\Customers\CustomerModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;

--- a/src/Orders/OrderModel.php
+++ b/src/Orders/OrderModel.php
@@ -3,13 +3,14 @@
 namespace DoubleThreeDigital\SimpleCommerce\Orders;
 
 use DoubleThreeDigital\SimpleCommerce\Customers\CustomerModel;
+use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class OrderModel extends Model
 {
-    use HasFactory;
+    use HasFactory, HasRunwayResource;
 
     protected $table = 'orders';
 


### PR DESCRIPTION
This pull request adds the `HasRunwayResource` trait to the Order & Customer models included in Simple Commerce. 

It also pulls in `doublethreedigital/runway` as a dev dependency so tests can keep on passing locally.

Fixes #876