### PR TITLE
PHP 8.1 Compatability

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2]
+        php: [8.2, 8.1]
         laravel: [10.*]
         statamic: [^4.0]
         testbench: [8.*]

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "laravel/framework": "^10.0",
         "mollie/mollie-api-php": "^2.30.0",
         "moneyphp/money": "^4.0",


### PR DESCRIPTION
This pull request brings back PHP 8.1 support to Simple Commerce, after it was dropped for v5. 