### PR TITLE
Resolve tax calculation issues

### DIFF
--- a/src/Orders/Calculator/Calculator.php
+++ b/src/Orders/Calculator/Calculator.php
@@ -12,6 +12,7 @@ class Calculator implements Contract
     {
         return Pipeline::send($order)
             ->through([
+                ResetTotals::class,
                 LineItemCalculator::class,
                 LineItemTaxCalculator::class,
                 CalculateItemsTotal::class,

--- a/src/Orders/Calculator/LineItemTaxCalculator.php
+++ b/src/Orders/Calculator/LineItemTaxCalculator.php
@@ -19,7 +19,9 @@ class LineItemTaxCalculator
                 $lineItem->tax($taxCalculation->toArray());
 
                 if ($taxCalculation->priceIncludesTax()) {
-                    $lineItem->total($taxCalculation->amount());
+                    $lineItem->total(
+                        $lineItem->total() - $taxCalculation->amount()
+                    );
 
                     $order->taxTotal(
                         $order->taxTotal() + $taxCalculation->amount()

--- a/src/Orders/Calculator/ResetTotals.php
+++ b/src/Orders/Calculator/ResetTotals.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
+
+use Closure;
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
+
+class ResetTotals
+{
+    public function handle(Order $order, Closure $next)
+    {
+        $order->grandTotal(0);
+        $order->itemsTotal(0);
+        $order->taxTotal(0);
+        $order->shippingTotal(0);
+        $order->couponTotal(0);
+
+        $order->lineItems()->transform(function (LineItem $lineItem) {
+            $lineItem->total(0);
+
+            return $lineItem;
+        });
+
+        return $next($order);
+    }
+}

--- a/src/Tax/Standard/TaxEngine.php
+++ b/src/Tax/Standard/TaxEngine.php
@@ -111,7 +111,7 @@ class TaxEngine implements Contract
             }
         }
 
-        $taxAmount = $order->shippingTotal() / 100 * $taxRate->rate();
+        $taxAmount =  $order->shippingTotal() * ($taxRate->rate() / 100);
         $itemTax = (int) round($taxAmount);
 
         return new TaxCalculation($itemTax, $taxRate->rate(), $taxRate->includeInPrice());

--- a/src/Tax/Standard/TaxEngine.php
+++ b/src/Tax/Standard/TaxEngine.php
@@ -111,7 +111,7 @@ class TaxEngine implements Contract
             }
         }
 
-        $taxAmount =  $order->shippingTotal() * ($taxRate->rate() / 100);
+        $taxAmount = $order->shippingTotal() * ($taxRate->rate() / 100);
         $itemTax = (int) round($taxAmount);
 
         return new TaxCalculation($itemTax, $taxRate->rate(), $taxRate->includeInPrice());

--- a/src/Tax/Standard/TaxEngine.php
+++ b/src/Tax/Standard/TaxEngine.php
@@ -38,8 +38,8 @@ class TaxEngine implements Contract
             }
         }
 
-        $taxAmount = ($lineItem->total() / 100) * ($taxRate->rate() / (100 + $taxRate->rate()));
-        $itemTax = (int) round($taxAmount * 100);
+        $taxAmount = $lineItem->total() * ($taxRate->rate() / 100);
+        $itemTax = (int) round($taxAmount);
 
         return new TaxCalculation($itemTax, $taxRate->rate(), $taxRate->includeInPrice());
     }

--- a/tests/Tax/StandardTaxEngineTest.php
+++ b/tests/Tax/StandardTaxEngineTest.php
@@ -93,13 +93,13 @@ test('can correctly calculate line item tax rate based on country', function () 
 
     // Ensure tax on line items are right
     $this->assertSame($recalculate->lineItems()->first()->tax(), [
-        'amount' => 167,
+        'amount' => 200,
         'rate' => 20,
         'price_includes_tax' => false,
     ]);
 
     // Ensure global order tax is right
-    expect(167)->toBe($recalculate->taxTotal());
+    expect(200)->toBe($recalculate->taxTotal());
 });
 
 test('can correctly calculate line item tax rate based on region', function () {
@@ -162,13 +162,13 @@ test('can correctly calculate line item tax rate based on region', function () {
 
     // Ensure tax on line items are right
     $this->assertSame($recalculate->lineItems()->first()->tax(), [
-        'amount' => 130,
+        'amount' => 150,
         'rate' => 15,
         'price_includes_tax' => false,
     ]);
 
     // Ensure global order tax is right
-    expect(130)->toBe($recalculate->taxTotal());
+    expect(150)->toBe($recalculate->taxTotal());
 });
 
 test('can calculate line item tax rate when included in price', function () {
@@ -229,13 +229,13 @@ test('can calculate line item tax rate when included in price', function () {
 
     // Ensure tax on line items are right
     $this->assertSame($recalculate->lineItems()->first()->tax(), [
-        'amount' => 167,
+        'amount' => 200,
         'rate' => 20,
         'price_includes_tax' => true,
     ]);
 
     // Ensure global order tax is right
-    expect(167)->toBe($recalculate->taxTotal());
+    expect(200)->toBe($recalculate->taxTotal());
 });
 
 test('can use default line item tax rate if no rate available', function () {
@@ -289,7 +289,7 @@ test('can use default line item tax rate if no rate available', function () {
     expect(12)->toBe($recalculate->lineItems()->first()->tax()['rate']);
 
     // Ensure global order tax is right
-    expect(107)->toBe($recalculate->taxTotal());
+    expect(120)->toBe($recalculate->taxTotal());
 });
 
 test('throws prevent checkout exception if no rate available', function () {
@@ -400,7 +400,7 @@ test('uses default address if no address provided', function () {
     expect(99)->toBe($recalculate->lineItems()->first()->tax()['rate']);
 
     // Ensure global order tax is right
-    expect(497)->toBe($recalculate->taxTotal());
+    expect(990)->toBe($recalculate->taxTotal());
 });
 
 test('throws prevent checkout exception if no address provided', function () {


### PR DESCRIPTION
This pull request aims to resolve some tax calculation issues, many of which were introduced as part of #873 and #874.

This PR resolves the following issues:

* Totals weren't being reset at the start of the calculation process - this caused issues when updating existing orders (eg. updating a line item quantity) 
* Standard Tax Engine: Fixed an issue where the line item total was being set to the tax calculation amount, rather than 'line item total - tax calculation amount' when price includes tax.
* Standard Tax Engine: Fixed an issue where the tax calculation wasn't correct.