### PR TITLE
Rollback tax calculation fix from the other day

### DIFF
--- a/src/Tax/Standard/TaxEngine.php
+++ b/src/Tax/Standard/TaxEngine.php
@@ -38,8 +38,8 @@ class TaxEngine implements Contract
             }
         }
 
-        $taxAmount = $lineItem->total() * ($taxRate->rate() / 100);
-        $itemTax = (int) round($taxAmount);
+        $taxAmount = ($lineItem->total() / 100) * ($taxRate->rate() / (100 + $taxRate->rate()));
+        $itemTax = (int) round($taxAmount * 100);
 
         return new TaxCalculation($itemTax, $taxRate->rate(), $taxRate->includeInPrice());
     }
@@ -111,8 +111,8 @@ class TaxEngine implements Contract
             }
         }
 
-        $taxAmount = $order->shippingTotal() * ($taxRate->rate() / 100);
-        $itemTax = (int) round($taxAmount);
+        $taxAmount = ($order->shippingTotal() / 100) * ($taxRate->rate() / (100 + $taxRate->rate()));
+        $itemTax = (int) round($taxAmount * 100);
 
         return new TaxCalculation($itemTax, $taxRate->rate(), $taxRate->includeInPrice());
     }

--- a/tests/Tax/StandardTaxEngineTest.php
+++ b/tests/Tax/StandardTaxEngineTest.php
@@ -93,13 +93,13 @@ test('can correctly calculate line item tax rate based on country', function () 
 
     // Ensure tax on line items are right
     $this->assertSame($recalculate->lineItems()->first()->tax(), [
-        'amount' => 200,
+        'amount' => 167,
         'rate' => 20,
         'price_includes_tax' => false,
     ]);
 
     // Ensure global order tax is right
-    expect(200)->toBe($recalculate->taxTotal());
+    expect(167)->toBe($recalculate->taxTotal());
 });
 
 test('can correctly calculate line item tax rate based on region', function () {
@@ -162,13 +162,13 @@ test('can correctly calculate line item tax rate based on region', function () {
 
     // Ensure tax on line items are right
     $this->assertSame($recalculate->lineItems()->first()->tax(), [
-        'amount' => 150,
+        'amount' => 130,
         'rate' => 15,
         'price_includes_tax' => false,
     ]);
 
     // Ensure global order tax is right
-    expect(150)->toBe($recalculate->taxTotal());
+    expect(130)->toBe($recalculate->taxTotal());
 });
 
 test('can calculate line item tax rate when included in price', function () {
@@ -229,13 +229,13 @@ test('can calculate line item tax rate when included in price', function () {
 
     // Ensure tax on line items are right
     $this->assertSame($recalculate->lineItems()->first()->tax(), [
-        'amount' => 200,
+        'amount' => 167,
         'rate' => 20,
         'price_includes_tax' => true,
     ]);
 
     // Ensure global order tax is right
-    expect(200)->toBe($recalculate->taxTotal());
+    expect(167)->toBe($recalculate->taxTotal());
 });
 
 test('can use default line item tax rate if no rate available', function () {
@@ -289,7 +289,7 @@ test('can use default line item tax rate if no rate available', function () {
     expect(12)->toBe($recalculate->lineItems()->first()->tax()['rate']);
 
     // Ensure global order tax is right
-    expect(120)->toBe($recalculate->taxTotal());
+    expect(107)->toBe($recalculate->taxTotal());
 });
 
 test('throws prevent checkout exception if no rate available', function () {
@@ -400,7 +400,7 @@ test('uses default address if no address provided', function () {
     expect(99)->toBe($recalculate->lineItems()->first()->tax()['rate']);
 
     // Ensure global order tax is right
-    expect(990)->toBe($recalculate->taxTotal());
+    expect(497)->toBe($recalculate->taxTotal());
 });
 
 test('throws prevent checkout exception if no address provided', function () {
@@ -525,8 +525,8 @@ test('can use default shipping tax rate if no rate available', function () {
     $recalculate = $order->recalculate();
 
     // Ensure 10% is deducted from shipping_total (500 -> 450)
-    expect($recalculate->shippingTotal())->toBe(450);
+    expect($recalculate->shippingTotal())->toBe(455);
 
     // Ensure tax total is 50
-    expect($recalculate->taxTotal())->toBe(50);
+    expect($recalculate->taxTotal())->toBe(45);
 });


### PR DESCRIPTION
This pull request rolls back 218a5fa4ab8447fa2fd1813114004c84815947e3 which I committed the other day as part of #880.

I thought I had found an issue with the calculation used for figuring out tax. However, it seems not and my 'fix' had broken things instead.