### PR TITLE
Fix order status labels not being translatable

### DIFF
--- a/resources/js/components/Fieldtypes/OrderStatusFieldtype.vue
+++ b/resources/js/components/Fieldtypes/OrderStatusFieldtype.vue
@@ -48,7 +48,7 @@ export default {
         },
 
         statusName() {
-            return this.meta.statuses[this.value]
+            return __(this.meta.statuses[this.value])
         },
     },
 }

--- a/resources/js/components/Fieldtypes/OrderStatusIndexFieldtype.vue
+++ b/resources/js/components/Fieldtypes/OrderStatusIndexFieldtype.vue
@@ -34,10 +34,10 @@ export default {
         },
 
         statusName() {
-            return (
+            return __((
                 this.value.charAt(0).toUpperCase() +
                 this.value.substr(1).toLowerCase()
-            )
+            ))
         },
     },
 }

--- a/resources/js/components/Fieldtypes/PaymentStatusFieldtype.vue
+++ b/resources/js/components/Fieldtypes/PaymentStatusFieldtype.vue
@@ -45,7 +45,7 @@ export default {
         },
 
         statusName() {
-            return this.meta.statuses[this.value]
+            return __(this.meta.statuses[this.value])
         },
     },
 }

--- a/resources/js/components/Fieldtypes/PaymentStatusIndexFieldtype.vue
+++ b/resources/js/components/Fieldtypes/PaymentStatusIndexFieldtype.vue
@@ -31,10 +31,10 @@ export default {
         },
 
         statusName() {
-            return (
+            return __((
                 this.value.charAt(0).toUpperCase() +
                 this.value.substr(1).toLowerCase()
-            )
+            ))
         },
     },
 }


### PR DESCRIPTION
This pull request fixes an issue where you couldn't translate the labels of order & payment statuses.

Fixes #883.