### PR TITLE
Fix coupon expiry date

### DIFF
--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -226,7 +226,7 @@ class Coupon implements Contract
             'id' => $this->id,
             'code' => $this->code,
             'value' => $this->value,
-            'type' => optional($this->type)->value,
+            'type' => $this->type,
             'enabled' => $this->enabled,
         ]);
     }

--- a/src/Http/Requests/CP/Coupon/UpdateRequest.php
+++ b/src/Http/Requests/CP/Coupon/UpdateRequest.php
@@ -58,7 +58,14 @@ class UpdateRequest extends FormRequest
             ],
             'expires_at' => [
                 'nullable',
+                'array',
+            ],
+            'expires_at.date' => [
+                'nullable',
                 'date',
+            ],
+            'expires_at.time' => [
+                'nullable',
             ],
             'enabled' => [
                 'required',

--- a/tests/Http/Controllers/CP/CouponControllerTest.php
+++ b/tests/Http/Controllers/CP/CouponControllerTest.php
@@ -46,9 +46,9 @@ test('can store coupon with expiry date', function () {
     $this
         ->actingAs(user())
         ->post('/cp/simple-commerce/coupons', [
-            'code' => 'thursday-thirty',
+            'code' => 'thursday-thirty-two',
             'type' => 'percentage',
-            'value' => 30,
+            'value' => 32,
             'description' => '30% discount on a Thursday!',
             'minimum_cart_value' => '65.00',
             'enabled' => true,
@@ -62,7 +62,7 @@ test('can store coupon with expiry date', function () {
         ])
         ->assertSessionHasNoErrors();
 
-    $coupon = Coupon::findByCode('thursday-thirty');
+    $coupon = Coupon::findByCode('thursday-thirty-two');
 
     expect($coupon->get('expires_at'))->toBe('2024-01-01');
 });

--- a/tests/Http/Controllers/CP/CouponControllerTest.php
+++ b/tests/Http/Controllers/CP/CouponControllerTest.php
@@ -42,6 +42,31 @@ test('can store coupon', function () {
     expect(6500)->toBe($coupon->get('minimum_cart_value'));
 });
 
+test('can store coupon with expiry date', function () {
+    $this
+        ->actingAs(user())
+        ->post('/cp/simple-commerce/coupons', [
+            'code' => 'thursday-thirty',
+            'type' => 'percentage',
+            'value' => 30,
+            'description' => '30% discount on a Thursday!',
+            'minimum_cart_value' => '65.00',
+            'enabled' => true,
+            'expires_at' => [
+                'date' => '2024-01-01',
+                'time' => null,
+            ],
+        ])
+        ->assertJsonStructure([
+            'redirect',
+        ])
+        ->assertSessionHasNoErrors();
+
+    $coupon = Coupon::findByCode('thursday-thirty');
+
+    expect($coupon->get('expires_at'))->toBe('2024-01-01');
+});
+
 test('cant store coupon where a coupon already exists with the provided code', function () {
     Coupon::make()
         ->id('random-id')
@@ -135,6 +160,43 @@ test('can update coupon', function () {
     expect(false)->toBe($coupon->enabled());
     expect('You can actually get a 51% discount on Friday!')->toBe($coupon->get('description'));
     expect(7600)->toBe($coupon->get('minimum_cart_value'));
+});
+
+test('can update coupon with expriry date', function () {
+    $coupon = Coupon::make()
+        ->id('random-id')
+        ->code('fifty-friday')
+        ->value(50)
+        ->type('percentage')
+        ->data([
+            'description' => 'Fifty Friday',
+            'redeemed' => 0,
+            'minimum_cart_value' => null,
+        ]);
+
+    $coupon->save();
+
+    $this
+        ->actingAs(user())
+        ->post('/cp/simple-commerce/coupons/random-id', [
+            'code' => 'fifty-friday',
+            'type' => 'percentage',
+            'value' => 51,
+            'description' => 'You can actually get a 51% discount on Friday!',
+            'enabled' => false,
+            'minimum_cart_value' => '76.00',
+            'expires_at' => [
+                'date' => '2024-01-01',
+                'time' => null,
+            ],
+        ])
+        ->assertJsonStructure([
+            'coupon',
+        ]);
+
+    $coupon->fresh();
+
+    expect($coupon->get('expires_at'))->toBe('2024-01-01');
 });
 
 test('cant update coupon if type is percentage and value is greater than 100', function () {


### PR DESCRIPTION
This pull request fixes an issue that would crop up when trying to create/update a coupon since it was expecting `expires_at` to be a date. 

However, from v4 onwards, the Date fieldtype sends an array with `date` & `time` keys.

I fixed this for new coupons in #885 but this PR fixes it for updating coupons and also adds test cases to cover it.