### PR TITLE
Coupon Value fieldtype

### DIFF
--- a/resources/js/components/Fieldtypes/CouponValueFieldtype.vue
+++ b/resources/js/components/Fieldtypes/CouponValueFieldtype.vue
@@ -1,0 +1,93 @@
+<template>
+    <div>
+        <money-fieldtype
+            v-if="mode === 'fixed'"
+            v-model="couponValue"
+            :meta="meta.meta.money"
+            :config="meta.config.money"
+        />
+        <integer-fieldtype
+            v-else-if="mode === 'percentage'"
+            v-model="couponValue"
+            :meta="meta.meta.integer"
+            :config="meta.config.integer"
+        />
+
+        <div v-if="errors">
+            <small v-for="error in errors" class="help-block text-red-500 mt-2 mb-0">{{ error }}</small>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'CouponValueFieldtype',
+
+    mixins: [Fieldtype],
+
+    props: ['meta'],
+
+    data() {
+        return {
+            mode: null,
+            couponValue: null,
+        };
+    },
+
+    computed: {
+        // Statamic won't show error messages, unless they're for the top-level field.
+        // So, we'll show the error message ourselves.
+        errors() {
+            let errors = this.$store.state.publish.base.errors;
+
+            return errors[`value.mode`] || errors[`value.value`];
+        },
+    },
+
+    mounted() {
+        this.hideValueField();
+
+        this.mode = this.$store.state.publish.base.values.type;
+        this.couponValue = this.value;
+
+        if (this.mode !== null) {
+            this.showValueField();
+        }
+
+        this.$store.watch(
+            (state) => state.publish.base.values.type,
+            (type) => {
+                this.mode = type;
+                this.couponValue = null;
+
+                if (this.mode !== null) {
+                    this.showValueField();
+                }
+            },
+            { immediate: false }
+        )
+    },
+
+    methods: {
+        hideValueField() {
+            document.querySelectorAll('.coupon-value-fieldtype').forEach((el) => el.classList.add('hidden'))
+        },
+
+        showValueField() {
+            document.querySelectorAll('.coupon-value-fieldtype').forEach((el) => el.classList.remove('hidden'))
+        },
+    },
+
+    watch: {
+        couponValue(couponValue) {
+            let value = {
+                mode: this.mode,
+                value: couponValue,
+            }
+
+            this.value = value;
+            this.$emit('input', value);
+        },
+    },
+}
+</script>

--- a/resources/js/components/Listings/CouponListing.vue
+++ b/resources/js/components/Listings/CouponListing.vue
@@ -120,7 +120,6 @@
                             >
                                 <dropdown-list
                                     v-if="
-                                        canViewRow(row) ||
                                         canEditRow(row) ||
                                         row.actions.length
                                     "

--- a/resources/js/cp.js
+++ b/resources/js/cp.js
@@ -1,5 +1,6 @@
 // Fieldtypes
 
+import CouponValueFieldtype from './components/Fieldtypes/CouponValueFieldtype.vue'
 import GatewayFieldtype from './components/Fieldtypes/GatewayFieldtype.vue'
 import MoneyFieldtype from './components/Fieldtypes/MoneyFieldtype.vue'
 import OrderStatusFieldtype from './components/Fieldtypes/OrderStatusFieldtype.vue'
@@ -9,6 +10,7 @@ import PaymentStatusIndexFieldtype from './components/Fieldtypes/PaymentStatusIn
 import ProductVariantFieldtype from './components/Fieldtypes/ProductVariantFieldtype.vue'
 import ProductVariantsFildtype from './components/Fieldtypes/ProductVariantsFieldtype.vue'
 
+Statamic.$components.register('coupon-value-fieldtype', CouponValueFieldtype)
 Statamic.$components.register('gateway-fieldtype', GatewayFieldtype)
 Statamic.$components.register('money-fieldtype', MoneyFieldtype)
 Statamic.$components.register('order-status-fieldtype', OrderStatusFieldtype)

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -226,7 +226,7 @@ class Coupon implements Contract
             'id' => $this->id,
             'code' => $this->code,
             'value' => $this->value,
-            'type' => optional($this->type)->value,
+            'type' => $this->type,
             'enabled' => $this->enabled,
         ]);
     }

--- a/src/Coupons/CouponBlueprint.php
+++ b/src/Coupons/CouponBlueprint.php
@@ -86,8 +86,7 @@ class CouponBlueprint
                         'max_items' => 1,
                     ],
                     'value' => [
-                        'input_type' => 'text',
-                        'type' => 'text',
+                        'type' => 'coupon_value',
                         'display' => __('Value'),
                         'width' => 50,
                         'validate' => [

--- a/src/Fieldtypes/CouponValueFieldtype.php
+++ b/src/Fieldtypes/CouponValueFieldtype.php
@@ -8,6 +8,7 @@ use Statamic\Fields\Fieldtype;
 class CouponValueFieldtype extends Fieldtype
 {
     protected $selectable = false;
+
     protected $component = 'coupon-value';
 
     public function preload()

--- a/src/Fieldtypes/CouponValueFieldtype.php
+++ b/src/Fieldtypes/CouponValueFieldtype.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+
+use Statamic\Fields\Field;
+use Statamic\Fields\Fieldtype;
+
+class CouponValueFieldtype extends Fieldtype
+{
+    protected $selectable = false;
+    protected $component = 'coupon-value';
+
+    public function preload()
+    {
+        return [
+            'meta' => [
+                'money' => $this->resolveValueField('fixed')->fieldtype()->preload(),
+                'integer' => $this->resolveValueField('percentage')->fieldtype()->preload(),
+            ],
+            'config' => [
+                'money' => $this->resolveValueField('fixed')->config(),
+                'integer' => $this->resolveValueField('percentage')->config(),
+            ],
+        ];
+    }
+
+    public function preProcess($data)
+    {
+        if (! $data) {
+            return null;
+        }
+
+        return $this->resolveValueField($this->field->parent()->type()->value)->fieldtype()->preProcess($data);
+    }
+
+    public function process($data)
+    {
+        return $this->resolveValueField($data['mode'])->fieldtype()->process($data['value']);
+    }
+
+    public function augment($value)
+    {
+        if (! $value) {
+            return null;
+        }
+
+        return $this->resolveValueField($this->field->parent()->type()->value)->fieldtype()->augment($value);
+    }
+
+    public function preProcessIndex($value)
+    {
+        if (! $value) {
+            return null;
+        }
+
+        return $this->resolveValueField($this->field->parent()->type()->value)->fieldtype()->preProcessIndex($value);
+    }
+
+    protected function resolveValueField(string $mode): ?Field
+    {
+        if ($mode === 'fixed') {
+            return new Field('coupon_value', [
+                'type' => 'money',
+            ]);
+        }
+
+        if ($mode === 'percentage') {
+            return new Field('coupon_value', [
+                'append' => '%',
+                'type' => 'integer',
+            ]);
+        }
+
+        return null;
+    }
+}

--- a/src/Http/Controllers/CP/Coupons/CouponController.php
+++ b/src/Http/Controllers/CP/Coupons/CouponController.php
@@ -95,7 +95,7 @@ class CouponController
         $blueprint = CouponBlueprint::getBlueprint();
 
         $fields = $blueprint->fields();
-        $fields = $fields->addValues($coupon->toArray());
+        $fields = $fields->addValues($coupon->toArray())->setParent($coupon);
         $fields = $fields->preProcess();
 
         return view('simple-commerce::cp.coupons.edit', [

--- a/src/Http/Requests/CP/Coupon/StoreRequest.php
+++ b/src/Http/Requests/CP/Coupon/StoreRequest.php
@@ -36,11 +36,20 @@ class StoreRequest extends FormRequest
             ],
             'value' => [
                 'required',
-                'numeric',
+                'array',
+            ],
+            'value.mode' => [
+                'required',
+                'string',
+                Rule::in(['fixed', 'percentage']),
+            ],
+            'value.value' => [
+                'required',
                 'min:0',
+                'numeric',
                 function ($attribute, $value, $fail) {
                     if ($this->type === 'percentage' && $value > 100) {
-                        $fail(__('Percentage value cannot be over 100.'));
+                        $fail(__("For percentage coupons, the value can not be over 100."));
                     }
                 },
             ],

--- a/src/Http/Requests/CP/Coupon/StoreRequest.php
+++ b/src/Http/Requests/CP/Coupon/StoreRequest.php
@@ -49,7 +49,7 @@ class StoreRequest extends FormRequest
                 'numeric',
                 function ($attribute, $value, $fail) {
                     if ($this->type === 'percentage' && $value > 100) {
-                        $fail(__("For percentage coupons, the value can not be over 100."));
+                        $fail(__('For percentage coupons, the value can not be over 100.'));
                     }
                 },
             ],

--- a/src/Http/Requests/CP/Coupon/UpdateRequest.php
+++ b/src/Http/Requests/CP/Coupon/UpdateRequest.php
@@ -43,7 +43,7 @@ class UpdateRequest extends FormRequest
                 'numeric',
                 function ($attribute, $value, $fail) {
                     if ($this->type === 'percentage' && $value > 100) {
-                        $fail(__("For percentage coupons, the value can not be over 100."));
+                        $fail(__('For percentage coupons, the value can not be over 100.'));
                     }
                 },
             ],

--- a/src/Http/Requests/CP/Coupon/UpdateRequest.php
+++ b/src/Http/Requests/CP/Coupon/UpdateRequest.php
@@ -67,7 +67,14 @@ class UpdateRequest extends FormRequest
             ],
             'expires_at' => [
                 'nullable',
+                'array',
+            ],
+            'expires_at.date' => [
+                'nullable',
                 'date',
+            ],
+            'expires_at.time' => [
+                'nullable',
             ],
             'enabled' => [
                 'required',

--- a/src/Http/Requests/CP/Coupon/UpdateRequest.php
+++ b/src/Http/Requests/CP/Coupon/UpdateRequest.php
@@ -30,11 +30,20 @@ class UpdateRequest extends FormRequest
             ],
             'value' => [
                 'required',
-                'numeric',
+                'array',
+            ],
+            'value.mode' => [
+                'required',
+                'string',
+                Rule::in(['fixed', 'percentage']),
+            ],
+            'value.value' => [
+                'required',
                 'min:0',
+                'numeric',
                 function ($attribute, $value, $fail) {
                     if ($this->type === 'percentage' && $value > 100) {
-                        $fail(__('Percentage value cannot be over 100.'));
+                        $fail(__("For percentage coupons, the value can not be over 100."));
                     }
                 },
             ],

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -38,6 +38,7 @@ class ServiceProvider extends AddonServiceProvider
     ];
 
     protected $fieldtypes = [
+        Fieldtypes\CouponValueFieldtype::class,
         Fieldtypes\CountryFieldtype::class,
         Fieldtypes\CouponFieldtype::class,
         Fieldtypes\GatewayFieldtype::class,

--- a/tests/Http/Controllers/CP/CouponControllerTest.php
+++ b/tests/Http/Controllers/CP/CouponControllerTest.php
@@ -23,7 +23,10 @@ test('can store coupon', function () {
         ->post('/cp/simple-commerce/coupons', [
             'code' => 'thursday-thirty',
             'type' => 'percentage',
-            'value' => 30,
+            'value' => [
+                'mode' => 'percentage',
+                'value' => 30,
+            ],
             'description' => '30% discount on a Thursday!',
             'minimum_cart_value' => '65.00',
             'enabled' => true,
@@ -60,7 +63,10 @@ test('cant store coupon where a coupon already exists with the provided code', f
         ->post('/cp/simple-commerce/coupons', [
             'code' => 'tuesday-subway',
             'type' => 'percentage',
-            'value' => 30,
+            'value' => [
+                'mode' => 'percentage',
+                'value' => 30,
+            ],
             'description' => '30% discount on a Tuesday!',
         ])
         ->assertSessionHasErrors('code');
@@ -119,7 +125,10 @@ test('can update coupon', function () {
         ->post('/cp/simple-commerce/coupons/random-id', [
             'code' => 'fifty-friday',
             'type' => 'percentage',
-            'value' => 51,
+            'value' => [
+                'mode' => 'percentage',
+                'value' => 51,
+            ],
             'description' => 'You can actually get a 51% discount on Friday!',
             'enabled' => false,
             'minimum_cart_value' => '76.00',
@@ -156,10 +165,13 @@ test('cant update coupon if type is percentage and value is greater than 100', f
         ->post('/cp/simple-commerce/coupons/random-id', [
             'code' => 'fifty-friday',
             'type' => 'percentage',
-            'value' => 110,
+            'value' => [
+                'mode' => 'percentage',
+                'value' => 110,
+            ],
             'description' => 'You can actually get a 51% discount on Friday!',
         ])
-        ->assertSessionHasErrors('value');
+        ->assertSessionHasErrors('value.value');
 
     $coupon->fresh();
 

--- a/tests/Http/Controllers/CP/CouponControllerTest.php
+++ b/tests/Http/Controllers/CP/CouponControllerTest.php
@@ -51,7 +51,10 @@ test('can store coupon with expiry date', function () {
         ->post('/cp/simple-commerce/coupons', [
             'code' => 'thursday-thirty-two',
             'type' => 'percentage',
-            'value' => 32,
+            'value' => [
+                'mode' => 'percentage',
+                'value' => 32,
+            ],
             'description' => '30% discount on a Thursday!',
             'minimum_cart_value' => '65.00',
             'enabled' => true,
@@ -190,7 +193,10 @@ test('can update coupon with expriry date', function () {
         ->post('/cp/simple-commerce/coupons/random-id', [
             'code' => 'fifty-friday',
             'type' => 'percentage',
-            'value' => 51,
+            'value' => [
+                'mode' => 'percentage',
+                'value' => 51,
+            ],
             'description' => 'You can actually get a 51% discount on Friday!',
             'enabled' => false,
             'minimum_cart_value' => '76.00',


### PR DESCRIPTION
This pull request implements a new 'Coupon Value' fieldtype, improving the UX around creating coupons. The input field will react to the coupon type, showing % or £ formatting. 

https://github.com/duncanmcclean/simple-commerce/assets/19637309/684299a0-f782-4e76-bd48-f0cdb7a307ed

Ignore the validation error at the end 🙈 