### PR TITLE
Tweak 'Coupon Code' field

### DIFF
--- a/resources/js/components/Fieldtypes/CouponCodeFieldtype.vue
+++ b/resources/js/components/Fieldtypes/CouponCodeFieldtype.vue
@@ -1,0 +1,24 @@
+<template>
+    <text-fieldtype
+        :meta="meta"
+        :config="{
+            classes: 'uppercase font-mono',
+            focus: 'code',
+            autoselect: true,
+            input_type: 'text',
+        }"
+        :value="value"
+        @input="updateDebounced"
+        @keydown.native.space.prevent
+    />
+</template>
+
+<script>
+export default {
+    name: 'CouponCodeFieldtype',
+
+    mixins: [Fieldtype],
+
+    props: ['meta'],
+}
+</script>

--- a/resources/js/cp.js
+++ b/resources/js/cp.js
@@ -1,5 +1,6 @@
 // Fieldtypes
 
+import CouponCodeFieldtype from './components/Fieldtypes/CouponCodeFieldtype.vue'
 import CouponValueFieldtype from './components/Fieldtypes/CouponValueFieldtype.vue'
 import GatewayFieldtype from './components/Fieldtypes/GatewayFieldtype.vue'
 import MoneyFieldtype from './components/Fieldtypes/MoneyFieldtype.vue'
@@ -10,6 +11,7 @@ import PaymentStatusIndexFieldtype from './components/Fieldtypes/PaymentStatusIn
 import ProductVariantFieldtype from './components/Fieldtypes/ProductVariantFieldtype.vue'
 import ProductVariantsFildtype from './components/Fieldtypes/ProductVariantsFieldtype.vue'
 
+Statamic.$components.register('coupon-code-fieldtype', CouponCodeFieldtype)
 Statamic.$components.register('coupon-value-fieldtype', CouponValueFieldtype)
 Statamic.$components.register('gateway-fieldtype', GatewayFieldtype)
 Statamic.$components.register('money-fieldtype', MoneyFieldtype)

--- a/src/Coupons/CouponBlueprint.php
+++ b/src/Coupons/CouponBlueprint.php
@@ -50,14 +50,13 @@ class CouponBlueprint
                 'display' => 'Main',
                 'fields' => [
                     'code' => [
-                        'type' => 'text',
-                        'localizable' => true,
-                        'generate' => true,
+                        'type' => 'coupon_code',
                         'display' => __('Coupon Code'),
                         'validate' => [
                             'required',
                         ],
                         'listable' => true,
+                        'instructions' => __('Customers will use this code to redeem the coupon.'),
                     ],
                     'description' => [
                         'type' => 'textarea',

--- a/src/Fieldtypes/CouponCodeFieldtype.php
+++ b/src/Fieldtypes/CouponCodeFieldtype.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+
+use Illuminate\Support\Str;
+use Statamic\Fieldtypes\Text;
+
+class CouponCodeFieldtype extends Text
+{
+    protected $selectable = false;
+
+    protected $component = 'coupon-code';
+
+    public function process($data)
+    {
+        return Str::of($data)->upper()->__toString();
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -38,9 +38,10 @@ class ServiceProvider extends AddonServiceProvider
     ];
 
     protected $fieldtypes = [
-        Fieldtypes\CouponValueFieldtype::class,
         Fieldtypes\CountryFieldtype::class,
+        Fieldtypes\CouponCodeFieldtype::class,
         Fieldtypes\CouponFieldtype::class,
+        Fieldtypes\CouponValueFieldtype::class,
         Fieldtypes\GatewayFieldtype::class,
         Fieldtypes\MoneyFieldtype::class,
         Fieldtypes\OrderStatusFieldtype::class,


### PR DESCRIPTION
This pull request tweaks the 'Coupon Code' field when creating/editing coupons, enforcing the following constraints:

* No spaces
* Should be uppercase

To achieve this, I've created a new 'Coupon Code' fieldtype which extends the existing Text fieldtype just with some extra classes & ensuring codes are made uppercase when saved.