### PR TITLE
Prevent empty arrays from being saved when variants & variant options are empty

### DIFF
--- a/src/Fieldtypes/ProductVariantsFieldtype.php
+++ b/src/Fieldtypes/ProductVariantsFieldtype.php
@@ -79,7 +79,7 @@ class ProductVariantsFieldtype extends Fieldtype
 
     public function process($data)
     {
-        return [
+        $process = [
             'variants' => $this->processInsideFields(
                 $data['variants'],
                 $this->preload()['variant_fields'],
@@ -91,6 +91,12 @@ class ProductVariantsFieldtype extends Fieldtype
                 'process'
             ),
         ];
+
+        if (count($process['variants']) === 0 && count($process['options']) === 0) {
+            return null;
+        }
+
+        return $process;
     }
 
     public static function title()
@@ -115,7 +121,7 @@ class ProductVariantsFieldtype extends Fieldtype
         ];
     }
 
-    protected function processInsideFields(array $fieldValues, array $fields, string $method)
+    protected function processInsideFields(array $fieldValues, array $fields, string $method): array
     {
         return collect($fieldValues)
             ->map(function ($optionAttributeValues) use ($fields, $method) {


### PR DESCRIPTION
This pull request prevents empty arrays from being saved in product entries when the variants & variant options are empty. 

This is helpful if you want to have both a Product Variants field and a normal Price field in the same blueprint. Currently, if you do that, it'll presume it's a variant product because the `product_variants` field has a value (albeit empty arrays).

Closes #892