### PR TITLE
Fix 'Coupon Code' fieldtype showing as selectable in forms

### DIFF
--- a/src/Fieldtypes/CouponCodeFieldtype.php
+++ b/src/Fieldtypes/CouponCodeFieldtype.php
@@ -9,6 +9,8 @@ class CouponCodeFieldtype extends Text
 {
     protected $selectable = false;
 
+    protected $selectableInForms = false;
+
     protected $component = 'coupon-code';
 
     public function process($data)


### PR DESCRIPTION
This pull request fixes a small issue I spotted where the new 'Coupon Code' fieldtype introduced in #889 is showing in the list of available fieldtypes on a form blueprint.