### PR TITLE
[5.x] Multisite Improvements

### DIFF
--- a/docs/guides/multisite.md
+++ b/docs/guides/multisite.md
@@ -62,7 +62,7 @@ If you're using subdirectories for your multi-sites, it's recommended you provid
 
 It's pretty simple to do - loop through your sites & provide a route prefix.
 
-```
+```php
 // routes/web.php
 
 foreach (Site::all() as $site) {
@@ -76,6 +76,8 @@ foreach (Site::all() as $site) {
     });
 }
 ```
+
+If you're using different domains for each of your sites, replace `Route::prefix($site->url())` with `Route::domain($site->url())` in the above code snippet.
 
 ### Using the same cart between sites
 

--- a/src/Customers/EntryCustomerRepository.php
+++ b/src/Customers/EntryCustomerRepository.php
@@ -76,7 +76,7 @@ class EntryCustomerRepository implements RepositoryContract
         }
 
         if ($customer->get('site')) {
-            $entry->site($customer->get('site'));
+            $entry->locale($customer->get('site'));
         }
 
         if ($customer->get('slug')) {

--- a/src/Http/Controllers/CartController.php
+++ b/src/Http/Controllers/CartController.php
@@ -157,17 +157,17 @@ class CartController extends BaseActionController
             return Site::get($site);
         }
 
-        foreach (Site::all() as $site) {
-            if (Str::contains(request()->url(), $site->url())) {
-                return $site;
-            }
-        }
-
         if ($referer = request()->header('referer')) {
             foreach (Site::all() as $site) {
                 if (Str::contains($referer, $site->url())) {
                     return $site;
                 }
+            }
+        }
+
+        foreach (Site::all() as $site) {
+            if (Str::contains(request()->url(), $site->url())) {
+                return $site;
             }
         }
 

--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -259,17 +259,17 @@ class CartItemController extends BaseActionController
             return Site::get($site);
         }
 
-        foreach (Site::all() as $site) {
-            if (Str::contains(request()->url(), $site->url())) {
-                return $site;
-            }
-        }
-
         if ($referer = request()->header('referer')) {
             foreach (Site::all() as $site) {
                 if (Str::contains($referer, $site->url())) {
                     return $site;
                 }
+            }
+        }
+
+        foreach (Site::all() as $site) {
+            if (Str::contains(request()->url(), $site->url())) {
+                return $site;
             }
         }
 

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -273,17 +273,17 @@ class CheckoutController extends BaseActionController
             return Site::get($site);
         }
 
-        foreach (Site::all() as $site) {
-            if (Str::contains(request()->url(), $site->url())) {
-                return $site;
-            }
-        }
-
         if ($referer = request()->header('referer')) {
             foreach (Site::all() as $site) {
                 if (Str::contains($referer, $site->url())) {
                     return $site;
                 }
+            }
+        }
+
+        foreach (Site::all() as $site) {
+            if (Str::contains(request()->url(), $site->url())) {
+                return $site;
             }
         }
 

--- a/src/Orders/Cart/Drivers/CookieDriver.php
+++ b/src/Orders/Cart/Drivers/CookieDriver.php
@@ -49,6 +49,7 @@ class CookieDriver implements CartDriver
     public function makeCart(): Order
     {
         $cart = OrderAPI::make();
+        $cart->set('site', $this->guessSiteFromRequest()->handle());
         $cart->save();
 
         Cookie::queue($this->getKey(), $cart->id);

--- a/src/Orders/Cart/Drivers/CookieDriver.php
+++ b/src/Orders/Cart/Drivers/CookieDriver.php
@@ -84,17 +84,17 @@ class CookieDriver implements CartDriver
             return Site::get($site);
         }
 
-        foreach (Site::all()->reverse() as $site) {
-            if (Str::contains(request()->url(), $site->url())) {
-                return $site;
-            }
-        }
-
         if ($referer = request()->header('referer')) {
             foreach (Site::all()->reverse() as $site) {
                 if (Str::contains($referer, $site->url())) {
                     return $site;
                 }
+            }
+        }
+
+        foreach (Site::all()->reverse() as $site) {
+            if (Str::contains(request()->url(), $site->url())) {
+                return $site;
             }
         }
 

--- a/src/Orders/Cart/Drivers/SessionDriver.php
+++ b/src/Orders/Cart/Drivers/SessionDriver.php
@@ -39,6 +39,7 @@ class SessionDriver implements CartDriver
     public function makeCart(): Order
     {
         $cart = OrderAPI::make();
+        $cart->set('site', $this->guessSiteFromRequest());
         $cart->save();
 
         Session::put($this->getKey(), $cart->id);

--- a/src/Orders/Cart/Drivers/SessionDriver.php
+++ b/src/Orders/Cart/Drivers/SessionDriver.php
@@ -67,17 +67,17 @@ class SessionDriver implements CartDriver
             return Site::get($site);
         }
 
-        foreach (Site::all() as $site) {
-            if (Str::contains(request()->url(), $site->url())) {
-                return $site;
-            }
-        }
-
         if ($referer = request()->header('referer')) {
             foreach (Site::all() as $site) {
                 if (Str::contains($referer, $site->url())) {
                     return $site;
                 }
+            }
+        }
+
+        foreach (Site::all() as $site) {
+            if (Str::contains(request()->url(), $site->url())) {
+                return $site;
             }
         }
 

--- a/src/Orders/EntryOrderRepository.php
+++ b/src/Orders/EntryOrderRepository.php
@@ -92,7 +92,7 @@ class EntryOrderRepository implements RepositoryContract
         }
 
         if ($order->get('site')) {
-            $entry->site($order->get('site'));
+            $entry->locale($order->get('site'));
         }
 
         if ($order->get('slug')) {

--- a/tests/Orders/Calculator/CalculatorTest.php
+++ b/tests/Orders/Calculator/CalculatorTest.php
@@ -11,8 +11,9 @@ use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
 use DoubleThreeDigital\SimpleCommerce\Tests\Orders\Helpers\Postage;
 use Illuminate\Support\Facades\Config;
-use function PHPUnit\Framework\assertTrue;
 use Statamic\Facades\Site;
+
+use function PHPUnit\Framework\assertTrue;
 
 uses(SetupCollections::class);
 


### PR DESCRIPTION
This pull request fixes #899, by ensuring that the current site is always used when the built-in cart drivers create orders. It also ensures that the `EntryOrderRepository` correctly sets the site on the `Entry` when it's created.

This PR also makes a slight tweak to the docs page after #893.