### PR TITLE
[5.x] When deciding post-checkout cart handling, check the full URL too

### DIFF
--- a/src/Orders/Cart/Drivers/CartDriver.php
+++ b/src/Orders/Cart/Drivers/CartDriver.php
@@ -57,7 +57,10 @@ trait CartDriver
             }
 
             // Is the user on the redirect URL? If not, use normal cart driver.
-            if (request()->path() !== ltrim($checkoutSuccess['url'], '/')) {
+            if (
+                request()->path() !== ltrim($checkoutSuccess['url'], '/')
+                && request()->fullUrl() !== ltrim($checkoutSuccess['url'].'/', '/')
+            ) {
                 return resolve(CartDriverContract::class);
             }
 


### PR DESCRIPTION
This pull request fixes an issue I just ran into where you could *sometimes* end up with an empty cart on the 'checkout complete' page, even though Simple Commerce should be persisting the completed cart for you.

In my case, we're returning a route as the redirect parameter on the checkout form which I think is causing this.