### PR TITLE
[5.x] Prevent "Are you sure you want to leave this page?" when using Money fieldtype

### DIFF
--- a/resources/js/components/Fieldtypes/MoneyFieldtype.vue
+++ b/resources/js/components/Fieldtypes/MoneyFieldtype.vue
@@ -22,7 +22,6 @@ export default {
     data() {
         return {
             symbol: this.meta.symbol,
-            formattedValue: this.value,
         }
     },
 
@@ -30,12 +29,6 @@ export default {
         inputType() {
             return this.show
         },
-    },
-
-    mounted() {
-        if (isNaN(parseFloat(this.value)) == false) {
-            this.$emit('input', parseFloat(this.value).toFixed(2))
-        }
     },
 }
 </script>

--- a/src/Fieldtypes/MoneyFieldtype.php
+++ b/src/Fieldtypes/MoneyFieldtype.php
@@ -28,8 +28,13 @@ class MoneyFieldtype extends Fieldtype
 
     public function preProcess($data)
     {
-        if ($data !== null) {
-            return substr_replace($data, '.', -2, 0);
+        if (! $data) {
+            return null;
+        }
+
+        // Replaces the second-last character with a decimal point
+        if (! str_contains($data, '.')) {
+            $data = substr_replace($data, '.', -2, 0);
         }
 
         return $data;
@@ -38,8 +43,6 @@ class MoneyFieldtype extends Fieldtype
     public function process($data)
     {
         if ($data === '' || $data === null) {
-            // return (int) 0000;
-
             return null;
         }
 

--- a/tests/Fieldtypes/MoneyFieldtypeTest.php
+++ b/tests/Fieldtypes/MoneyFieldtypeTest.php
@@ -29,6 +29,14 @@ test('can pre process data', function () {
     expect($process)->toBe('25.50');
 });
 
+test('can pre process data where value includes a decimal points', function () {
+    $value = '25.99';
+
+    $process = (new MoneyFieldtype())->preProcess($value);
+
+    expect($process)->toBe('25.99');
+});
+
 test('can process data', function () {
     $value = '12.65';
 


### PR DESCRIPTION
This pull request should hopefully fix the "Are you sure you want to leave this page?" warning from appearing on any of the publish forms using the Money Fieldtype.

It was being caused by the code in the `mounted` method of the fieldtype. I've removed it from there in favour of the code in the `preProcess` method on the PHP side which *looks* to be doing exactly the same thing.

Fixes #897