### PR TITLE
[5.x] Fix empty dropdowns when using Country & Region fieldtypes in Select mode

### DIFF
--- a/src/Console/Commands/MigrateOrderStatuses.php
+++ b/src/Console/Commands/MigrateOrderStatuses.php
@@ -18,7 +18,7 @@ use Statamic\Facades\Entry;
 
 class MigrateOrderStatuses extends Command
 {
-    use RunsInPlease, ConfirmableTrait;
+    use ConfirmableTrait, RunsInPlease;
 
     protected $name = 'sc:migrate-order-statuses';
 

--- a/src/Console/Commands/MigrateOrdersToDatabase.php
+++ b/src/Console/Commands/MigrateOrdersToDatabase.php
@@ -17,7 +17,7 @@ use Statamic\Facades\User;
 
 class MigrateOrdersToDatabase extends Command
 {
-    use RunsInPlease, ConfirmableTrait;
+    use ConfirmableTrait, RunsInPlease;
 
     protected $name = 'sc:migrate-to-database';
 

--- a/src/Contracts/Gateway.php
+++ b/src/Contracts/Gateway.php
@@ -24,8 +24,6 @@ interface Gateway
      *
      * If you're building an off-site gateway, you should return a `checkout_url` key with the
      * URL the user should be redirected to for checkout.
-     *
-     * @param  \DoubleThreeDigital\SimpleCommerce\Contracts\Order  $order
      */
     public function prepare(Request $request, Order $order): array;
 
@@ -36,8 +34,6 @@ interface Gateway
      * If you need to display an error message, you should throw a GatewayCheckoutFailed exception.
      *
      * If you're building an off-site gateway, you don't need to implement this method.
-     *
-     * @param  \DoubleThreeDigital\SimpleCommerce\Contracts\Order  $order
      */
     public function checkout(Request $request, Order $order): array;
 
@@ -62,7 +58,6 @@ interface Gateway
      * return an array of any data which may prove helpful in the future to track down
      * refunds (like a Refund ID).
      *
-     * @param  \DoubleThreeDigital\SimpleCommerce\Contracts\Order  $order
      * @return array|null
      */
     public function refund(Order $order): array;

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -17,7 +17,7 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class Coupon implements Contract
 {
-    use FluentlyGetsAndSets, ExistsAsFile, TracksQueriedColumns, ContainsData;
+    use ContainsData, ExistsAsFile, FluentlyGetsAndSets, TracksQueriedColumns;
 
     public $id;
 

--- a/src/Fieldtypes/CountryFieldtype.php
+++ b/src/Fieldtypes/CountryFieldtype.php
@@ -19,6 +19,7 @@ class CountryFieldtype extends Relationship
                 'id' => $country['iso'],
                 'iso' => $country['iso'],
                 'name' => __($country['name']),
+                'title' => __($country['name']),
             ];
         })->values();
     }

--- a/src/Fieldtypes/RegionFieldtype.php
+++ b/src/Fieldtypes/RegionFieldtype.php
@@ -21,6 +21,7 @@ class RegionFieldtype extends Relationship
                 'country_iso' => $region['country_iso'],
                 'country_name' => __(Countries::findByRegion($region)->first()['name']),
                 'name' => __($region['name']),
+                'title' => __($region['name']),
             ];
         })->sortBy('country_name')->values();
     }

--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -108,13 +108,13 @@ class CartItemController extends BaseActionController
 
         // Ensure there's enough stock to fulfill the customer's quantity
         if ($product->purchasableType() === ProductType::Product) {
-            if (is_int($product->stock()) && $product->stock() < $request->quantity) {
+            if (is_int($product->stock()) && $request->quantity > $product->stock()) {
                 return $this->withErrors($request, __("There's not enough stock to fulfil the quantity you selected. Please try again later."));
             }
         } elseif ($product->purchasableType() === ProductType::Variant) {
             $variant = $product->variant($request->get('variant'));
 
-            if ($variant !== null && is_int($variant->stock()) && $variant->stock() < $request->quantity) {
+            if ($variant !== null && is_int($variant->stock()) && $request->quantity > $variant->stock()) {
                 return $this->withErrors($request, __("There's not enough stock to fulfil the quantity you selected. Please try again later."));
             }
         }
@@ -212,7 +212,7 @@ class CartItemController extends BaseActionController
 
         // Ensure there's enough stock to fulfill the customer's quantity
         if ($product->purchasableType() === ProductType::Product) {
-            if (is_int($product->stock()) && $product->stock() < $request->quantity) {
+            if (is_int($product->stock()) && $request->quantity > $product->stock()) {
                 return $this->withErrors($request, __("There's not enough stock to fulfil the quantity you selected. Please try again later."));
             }
         } elseif ($product->purchasableType() === ProductType::Variant) {
@@ -220,7 +220,7 @@ class CartItemController extends BaseActionController
                 ? $product->variant($request->get('variant'))
                 : $product->variant($lineItem->variant()['variant']);
 
-            if ($variant !== null && is_int($variant->stock()) && $variant->stock() < $request->quantity) {
+            if ($variant !== null && is_int($variant->stock()) && $request->quantity > $variant->stock()) {
                 return $this->withErrors($request, __("There's not enough stock to fulfil the quantity you selected. Please try again later."));
             }
         }

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -26,7 +26,7 @@ use Statamic\Sites\Site as SitesSite;
 
 class CheckoutController extends BaseActionController
 {
-    use CartDriver, AcceptsFormRequests;
+    use AcceptsFormRequests, CartDriver;
 
     public $order;
 

--- a/src/Http/Requests/Cart/UpdateRequest.php
+++ b/src/Http/Requests/Cart/UpdateRequest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateRequest extends FormRequest
 {
-    use CartDriver, AcceptsFormRequests;
+    use AcceptsFormRequests, CartDriver;
 
     public function authorize()
     {

--- a/src/Listeners/EnforceEntryBlueprintFields.php
+++ b/src/Listeners/EnforceEntryBlueprintFields.php
@@ -19,16 +19,16 @@ class EnforceEntryBlueprintFields
 
         if (
             $this->isOrExtendsClass($customerDriver['repository'], EntryCustomerRepository::class)
-            && $event->blueprint->namespace() === "collections.{$customerDriver['collection']}"
+            && "collections.{$customerDriver['collection']}" === $event->blueprint->namespace()
         ) {
             return $this->enforceCustomerFields($event);
         }
 
-        if (isset($productDriver['collection']) && $event->blueprint->namespace() === "collections.{$productDriver['collection']}") {
+        if (isset($productDriver['collection']) && "collections.{$productDriver['collection']}" === $event->blueprint->namespace()) {
             return $this->enforceProductFields($event);
         }
 
-        if (isset($orderDriver['collection']) && $event->blueprint->namespace() === "collections.{$orderDriver['collection']}") {
+        if (isset($orderDriver['collection']) && "collections.{$orderDriver['collection']}" === $event->blueprint->namespace()) {
             return $this->enforceOrderFields($event);
         }
     }

--- a/src/Orders/HasLineItems.php
+++ b/src/Orders/HasLineItems.php
@@ -103,7 +103,7 @@ trait HasLineItems
     public function updateLineItem($lineItemId, array $lineItemData): LineItem
     {
         $this->lineItems = $this->lineItems->map(function ($item) use ($lineItemId, $lineItemData) {
-            if ($item->id() !== $lineItemId) {
+            if ($lineItemId !== $item->id()) {
                 return $item;
             }
 
@@ -148,7 +148,7 @@ trait HasLineItems
     public function removeLineItem($lineItemId): Collection
     {
         $this->lineItems = $this->lineItems->reject(function ($item) use ($lineItemId) {
-            return $item->id() === $lineItemId;
+            return $lineItemId === $item->id();
         })->values();
 
         $this->save();

--- a/src/Products/Product.php
+++ b/src/Products/Product.php
@@ -150,7 +150,7 @@ class Product implements Contract
     public function variant(string $optionKey): ?ProductVariant
     {
         return $this->variantOptions()->filter(function ($variant) use ($optionKey) {
-            return $variant->key() === $optionKey;
+            return $optionKey === $variant->key();
         })->first();
     }
 

--- a/src/Products/ProductVariant.php
+++ b/src/Products/ProductVariant.php
@@ -9,7 +9,7 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class ProductVariant
 {
-    use HasData, FluentlyGetsAndSets;
+    use FluentlyGetsAndSets, HasData;
 
     protected $key;
 

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -11,8 +11,8 @@ use Statamic\Facades\Site;
 
 class CartTags extends SubTag
 {
-    use Concerns\FormBuilder;
     use CartDriver;
+    use Concerns\FormBuilder;
 
     public function index()
     {

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -16,8 +16,8 @@ use Illuminate\Support\Facades\Session;
 
 class CheckoutTags extends SubTag
 {
-    use Concerns\FormBuilder;
     use CartDriver;
+    use Concerns\FormBuilder;
 
     public function index()
     {

--- a/src/Tags/CouponTags.php
+++ b/src/Tags/CouponTags.php
@@ -7,8 +7,8 @@ use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 
 class CouponTags extends SubTag
 {
-    use Concerns\FormBuilder;
     use CartDriver;
+    use Concerns\FormBuilder;
 
     public function index(): array
     {

--- a/src/Tax/Standard/TaxCategory.php
+++ b/src/Tax/Standard/TaxCategory.php
@@ -12,7 +12,7 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class TaxCategory
 {
-    use FluentlyGetsAndSets, ExistsAsFile, TracksQueriedColumns, ContainsData;
+    use ContainsData, ExistsAsFile, FluentlyGetsAndSets, TracksQueriedColumns;
 
     public $id;
 

--- a/src/Tax/Standard/TaxRate.php
+++ b/src/Tax/Standard/TaxRate.php
@@ -13,7 +13,7 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class TaxRate
 {
-    use FluentlyGetsAndSets, ExistsAsFile, TracksQueriedColumns, ContainsData;
+    use ContainsData, ExistsAsFile, FluentlyGetsAndSets, TracksQueriedColumns;
 
     public $id;
 

--- a/src/Tax/Standard/TaxZone.php
+++ b/src/Tax/Standard/TaxZone.php
@@ -14,7 +14,7 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class TaxZone
 {
-    use FluentlyGetsAndSets, ExistsAsFile, TracksQueriedColumns, ContainsData;
+    use ContainsData, ExistsAsFile, FluentlyGetsAndSets, TracksQueriedColumns;
 
     public $id;
 


### PR DESCRIPTION
This pull request fixes an issue where the dropdown options in the Country & Region fieldtypes would be missing text when used in "Select" mode.

This is because select mode expects there to be a `title` present in the array that's returned.