### PR TITLE
[5.x] Refactor product variants fieldtype to support field conditionals

### DIFF
--- a/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
@@ -42,49 +42,30 @@
         <!-- Variant Options -->
         <div class="grid-fieldtype-container">
             <div class="grid-stacked">
-                <div
+                <VariantOptionRow
                     v-for="(option, index) in options"
                     :key="index"
-                    class="bg-grey-10 shadow-sm mb-2 rounded border variants-sortable-item"
-                >
-                    <div class="grid-item-header">
-                        {{ option.variant || __('Variants') }}
-                    </div>
-
-                    <publish-fields-container>
-                        <publish-field
-                            v-for="(
-                                optionField, optionIndex
-                            ) in meta.option_fields"
-                            :key="'option-' + optionField.handle"
-                            :config="optionField"
-                            :value="option[optionField.handle]"
-                            :meta="meta[optionField.handle]"
-                            :errors="errors(optionField.handle)"
-                            class="p-2"
-                            @input="
-                                updatedOptions(
-                                    index,
-                                    optionField.handle,
-                                    $event
-                                )
-                            "
-                            @meta-updated="metaUpdated(option.handle, $event)"
-                            @focus="$emit('focus')"
-                            @blur="$emit('blur')"
-                        />
-                    </publish-fields-container>
-                </div>
+                    :option="option"
+                    :index="index"
+                    :meta="meta"
+                    :values="value.options[index]"
+                    :fieldPathPrefix="handle + '.options.' + index"
+                    @updated="optionsUpdated"
+                    @metaUpdated="metaUpdated"
+                    @focus="$emit('focus')"
+                    @blur="$emit('blur')"
+                />
             </div>
         </div>
     </div>
 </template>
 
 <script>
-import GridRow from '../../statamic/Row.vue'
-import SortableList from '../../../../vendor/statamic/cms/resources/js/components/sortable/SortableList.vue'
-import GridHeaderCell from '../../../../vendor/statamic/cms/resources/js/components/fieldtypes/grid/HeaderCell.vue'
-import View from '../../statamic/View.vue'
+import GridRow from '../../../statamic/Row.vue'
+import SortableList from '../../../../../vendor/statamic/cms/resources/js/components/sortable/SortableList.vue'
+import GridHeaderCell from '../../../../../vendor/statamic/cms/resources/js/components/fieldtypes/grid/HeaderCell.vue'
+import View from '../../../statamic/View.vue'
+import VariantOptionRow from './VariantOptionRow.vue'
 
 export default {
     name: 'product-variants-fieldtype',
@@ -95,6 +76,7 @@ export default {
         GridHeaderCell,
         GridRow,
         SortableList,
+        VariantOptionRow,
     },
 
     props: ['meta'],
@@ -182,8 +164,8 @@ export default {
             this.variants[variantIndex][fieldHandle] = value
         },
 
-        updatedOptions(optionIndex, fieldHandle, value) {
-            this.options[optionIndex][fieldHandle] = value
+        optionsUpdated(index, value) {
+            this.options[index] = value
         },
 
         metaUpdated(fieldHandle, event) {

--- a/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
@@ -8,7 +8,7 @@
                     :key="variantIndex"
                     class="bg-grey-10 shadow-sm mb-2 rounded border variants-sortable-item"
                 >
-                    <div class="grid-item-header">
+                    <div class="grid-item-header rounded-t">
                         {{ variant.name || 'Variant' }}
                         <button
                             v-if="variants.length > 1"

--- a/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
@@ -6,7 +6,7 @@
                 <div
                     v-for="(variant, variantIndex) in variants"
                     :key="variantIndex"
-                    class="bg-grey-10 shadow-sm mb-2 rounded border variants-sortable-item"
+                    class="bg-grey-10 shadow-sm mb-4 rounded border variants-sortable-item"
                 >
                     <div class="grid-item-header rounded-t">
                         {{ variant.name || 'Variant' }}
@@ -27,7 +27,7 @@
                             :value="variant[field.handle]"
                             :meta="meta[field.handle]"
                             :errors="errors(field.handle)"
-                            class="p-2 w-1/2"
+                            class="p-3 w-1/2"
                             @input="updated(variantIndex, field.handle, $event)"
                             @meta-updated="metaUpdated(field.handle, $event)"
                             @focus="$emit('focus')"

--- a/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
@@ -15,7 +15,9 @@
                             class="icon icon-cross cursor-pointer"
                             @click="deleteVariant(variantIndex)"
                             :aria-label="__('Delete Variant')"
-                        />
+                        >
+                            <svg-icon name="micro/trash" class="w-4 h-4 text-gray-600 group-hover:text-gray-900" />
+                        </button>
                     </div>
                     <publish-fields-container>
                         <publish-field

--- a/resources/js/components/Fieldtypes/ProductVariants/VariantOptionRow.vue
+++ b/resources/js/components/Fieldtypes/ProductVariants/VariantOptionRow.vue
@@ -1,0 +1,62 @@
+<template>
+    <div class="bg-grey-10 shadow-sm mb-2 rounded border variants-sortable-item">
+        <div class="grid-item-header">
+            {{ option.variant || __('Variants') }}
+        </div>
+
+        <publish-fields-container>
+            <publish-field
+                v-for="(optionField, optionIndex) in meta.option_fields"
+                v-show="showField(optionField, fieldPath(optionIndex, optionField.handle))"
+                :key="'option-' + optionField.handle"
+                :config="optionField"
+                :value="option[optionField.handle]"
+                :meta="meta[optionField.handle]"
+                :errors="errors(optionField.handle)"
+                :field-path-prefix="fieldPath(optionIndex, optionField.handle)"
+                class="p-2"
+                @input="updatedOptions(optionField.handle, $event)"
+                @meta-updated="metaUpdated(option.handle, $event)"
+                @focus="$emit('focus')"
+                @blur="$emit('blur')"
+            />
+        </publish-fields-container>
+    </div>
+</template>
+
+<script>
+import { ValidatesFieldConditions } from '../../../../../vendor/statamic/cms/resources/js/components/field-conditions/FieldConditions'
+
+export default {
+    mixins: [ValidatesFieldConditions],
+
+    props: {
+        option: Object,
+        index: Number,
+        meta: Object,
+        fieldPathPrefix: String,
+        values: Object,
+    },
+
+    methods: {
+        updatedOptions(fieldHandle, value) {
+            let values = this.values
+            values[fieldHandle] = value
+
+            this.$emit('updated', this.index, values)
+        },
+
+        metaUpdated(fieldHandle, event) {
+            this.$emit('metaUpdated', fieldHandle, event)
+        },
+
+        fieldPath(index, fieldHandle) {
+            return `${this.fieldPathPrefix}.${index}.${fieldHandle}`
+        },
+
+        errors(fieldHandle) {
+            //
+        },
+    },
+}
+</script>

--- a/resources/js/components/Fieldtypes/ProductVariants/VariantOptionRow.vue
+++ b/resources/js/components/Fieldtypes/ProductVariants/VariantOptionRow.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="bg-grey-10 shadow-sm mb-2 rounded border variants-sortable-item">
-        <div class="grid-item-header">
+        <div class="grid-item-header rounded-t">
             {{ option.variant || __('Variants') }}
         </div>
 

--- a/resources/js/components/Fieldtypes/ProductVariants/VariantOptionRow.vue
+++ b/resources/js/components/Fieldtypes/ProductVariants/VariantOptionRow.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="bg-grey-10 shadow-sm mb-2 rounded border variants-sortable-item">
+    <div class="bg-grey-10 shadow-sm mb-4 rounded border variants-sortable-item">
         <div class="grid-item-header rounded-t">
             {{ option.variant || __('Variants') }}
         </div>
@@ -14,7 +14,7 @@
                 :meta="meta[optionField.handle]"
                 :errors="errors(optionField.handle)"
                 :field-path-prefix="fieldPath(optionIndex, optionField.handle)"
-                class="p-2"
+                class="p-3"
                 @input="updatedOptions(optionField.handle, $event)"
                 @meta-updated="metaUpdated(option.handle, $event)"
                 @focus="$emit('focus')"

--- a/resources/js/cp.js
+++ b/resources/js/cp.js
@@ -9,7 +9,7 @@ import OrderStatusIndexFieldtype from './components/Fieldtypes/OrderStatusIndexF
 import PaymentStatusFieldtype from './components/Fieldtypes/PaymentStatusFieldtype.vue'
 import PaymentStatusIndexFieldtype from './components/Fieldtypes/PaymentStatusIndexFieldtype.vue'
 import ProductVariantFieldtype from './components/Fieldtypes/ProductVariantFieldtype.vue'
-import ProductVariantsFildtype from './components/Fieldtypes/ProductVariantsFieldtype.vue'
+import ProductVariantsFildtype from './components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue'
 
 Statamic.$components.register('coupon-code-fieldtype', CouponCodeFieldtype)
 Statamic.$components.register('coupon-value-fieldtype', CouponValueFieldtype)


### PR DESCRIPTION
This pull request refactors the Product Variants fieldtype to support field conditions. 

I spent quite a lot of time trying to make the existing one-component-for-everything setup work but in the end, once I split each of the options into its own Vue component, it was easy to make field conditionals work.

Field conditionals use a mixin called `FieldConditions`, which checks `this.value` on the component for the different fields. This obviously wouldn't work with the "mega component" we had before.

In this PR, I've also made some minor UI tweaks following Statamic 4.

Fixes #913