### PR TITLE
[5.x] Add "Save Zero Value?" option to Money fieldtype

### DIFF
--- a/resources/blueprints/collections/orders/order.yaml
+++ b/resources/blueprints/collections/orders/order.yaml
@@ -61,6 +61,7 @@ tabs:
               listable: hidden
               instructions_position: above
               visibility: read_only
+              save_zero_value: true
           - handle: coupon_total
             field:
               type: money
@@ -70,6 +71,7 @@ tabs:
               width: 33
               listable: false
               visibility: read_only
+              save_zero_value: true
           - handle: tax_total
             field:
               type: money
@@ -79,6 +81,7 @@ tabs:
               width: 33
               listable: false
               visibility: read_only
+              save_zero_value: true
           - handle: shipping_total
             field:
               type: money
@@ -88,6 +91,7 @@ tabs:
               width: 33
               listable: false
               visibility: read_only
+              save_zero_value: true
           - handle: grand_total
             field:
               type: money
@@ -98,6 +102,7 @@ tabs:
               listable: true
               instructions_position: above
               visibility: read_only
+              save_zero_value: true
       - display: "Line Items"
         fields:
           - handle: items

--- a/resources/blueprints/collections/products/product.yaml
+++ b/resources/blueprints/collections/products/product.yaml
@@ -26,3 +26,4 @@ tabs:
           localizable: false
           listable: hidden
           display: Price
+          save_zero_value: true

--- a/src/Console/Commands/stubs/runway_order_blueprint.yaml
+++ b/src/Console/Commands/stubs/runway_order_blueprint.yaml
@@ -56,6 +56,7 @@ tabs:
               listable: hidden
               instructions_position: above
               visibility: read_only
+              save_zero_value: true
           - handle: coupon_total
             field:
               type: money
@@ -65,6 +66,7 @@ tabs:
               width: 33
               listable: false
               visibility: read_only
+              save_zero_value: true
           - handle: tax_total
             field:
               type: money
@@ -74,6 +76,7 @@ tabs:
               width: 33
               listable: false
               visibility: read_only
+              save_zero_value: true
           - handle: shipping_total
             field:
               type: money
@@ -83,6 +86,7 @@ tabs:
               width: 33
               listable: false
               visibility: read_only
+              save_zero_value: true
           - handle: grand_total
             field:
               type: money
@@ -93,6 +97,7 @@ tabs:
               listable: true
               instructions_position: above
               visibility: read_only
+              save_zero_value: true
       - display: "Line Items"
         fields:
           - handle: items

--- a/src/Fieldtypes/MoneyFieldtype.php
+++ b/src/Fieldtypes/MoneyFieldtype.php
@@ -18,6 +18,12 @@ class MoneyFieldtype extends Fieldtype
                 'instructions' => __('Should this field be read only?'),
                 'width' => 50,
             ],
+            'save_zero_value' => [
+                'type' => 'toggle',
+                'display' => __('Save Zero Value?'),
+                'instructions' => __('When the value is zero, should it be saved as zero or be left empty?'),
+                'width' => 50,
+            ],
         ];
     }
 
@@ -29,7 +35,9 @@ class MoneyFieldtype extends Fieldtype
     public function preProcess($data)
     {
         if (! $data) {
-            return null;
+            return $this->config('save_zero_value', false)
+                ? 0
+                : null;
         }
 
         // Replaces the second-last character with a decimal point
@@ -43,7 +51,9 @@ class MoneyFieldtype extends Fieldtype
     public function process($data)
     {
         if ($data === '' || $data === null) {
-            return null;
+            return $this->config('save_zero_value', false)
+                ? 0
+                : null;
         }
 
         if (! str_contains($data, '.')) {
@@ -66,7 +76,9 @@ class MoneyFieldtype extends Fieldtype
     public function augment($value)
     {
         if (empty($value)) {
-            return null;
+            return $this->config('save_zero_value', false)
+                ? Currency::parse(0, Site::selected())
+                : null;
         }
 
         return Currency::parse($value, Site::current());
@@ -75,7 +87,9 @@ class MoneyFieldtype extends Fieldtype
     public function preProcessIndex($value)
     {
         if (! $value) {
-            return;
+            return $this->config('save_zero_value', false)
+                ? Currency::parse(0, Site::selected())
+                : null;
         }
 
         return Currency::parse($value, Site::selected());

--- a/src/Listeners/EnforceEntryBlueprintFields.php
+++ b/src/Listeners/EnforceEntryBlueprintFields.php
@@ -72,6 +72,7 @@ class EnforceEntryBlueprintFields
             $event->blueprint->ensureField('price', [
                 'type' => 'money',
                 'display' => __('Price'),
+                'save_zero_value' => true,
             ], 'sidebar');
         }
 
@@ -94,6 +95,7 @@ class EnforceEntryBlueprintFields
             'display' => __('Grand Total'),
             'read_only' => true,
             'validate' => ['required'],
+            'save_zero_value' => true,
         ]);
 
         $event->blueprint->ensureField('items_total', [
@@ -101,6 +103,7 @@ class EnforceEntryBlueprintFields
             'display' => __('Items Total'),
             'read_only' => true,
             'validate' => ['required'],
+            'save_zero_value' => true,
         ]);
 
         $event->blueprint->ensureField('shipping_total', [
@@ -108,6 +111,7 @@ class EnforceEntryBlueprintFields
             'display' => __('Shipping Total'),
             'read_only' => true,
             'validate' => ['required'],
+            'save_zero_value' => true,
         ]);
 
         $event->blueprint->ensureField('tax_total', [
@@ -115,6 +119,7 @@ class EnforceEntryBlueprintFields
             'display' => __('Tax Total'),
             'read_only' => true,
             'validate' => ['required'],
+            'save_zero_value' => true,
         ]);
 
         $event->blueprint->ensureField('coupon_total', [
@@ -122,6 +127,7 @@ class EnforceEntryBlueprintFields
             'display' => __('Coupon Total'),
             'read_only' => true,
             'validate' => ['required'],
+            'save_zero_value' => true,
         ]);
 
         $event->blueprint->ensureField('order_status', [

--- a/tests/Fieldtypes/MoneyFieldtypeTest.php
+++ b/tests/Fieldtypes/MoneyFieldtypeTest.php
@@ -2,6 +2,7 @@
 
 use DoubleThreeDigital\SimpleCommerce\Fieldtypes\MoneyFieldtype;
 use DoubleThreeDigital\SimpleCommerce\Tests\Fieldtypes\Helpers\MoneyFieldtypeWithMockedField;
+use Statamic\Fields\Field;
 
 test('can preload currency with no field', function () {
     $preload = (new MoneyFieldtype())->preload();
@@ -24,17 +25,31 @@ test('can preload currency with field', function () {
 test('can pre process data', function () {
     $value = 2550;
 
-    $process = (new MoneyFieldtype())->preProcess($value);
+    $preProcess = (new MoneyFieldtype())->preProcess($value);
 
-    expect($process)->toBe('25.50');
+    expect($preProcess)->toBe('25.50');
 });
 
 test('can pre process data where value includes a decimal points', function () {
     $value = '25.99';
 
-    $process = (new MoneyFieldtype())->preProcess($value);
+    $preProcess = (new MoneyFieldtype())->preProcess($value);
 
-    expect($process)->toBe('25.99');
+    expect($preProcess)->toBe('25.99');
+});
+
+test('can pre process data when value is empty and save_zero_value is false', function () {
+    $preProcess = (new MoneyFieldtype())->preProcess(null);
+
+    expect($preProcess)->toBeNull();
+});
+
+test('can pre process data when value is empty and save_zero_value is true', function () {
+    $preProcess = (new MoneyFieldtype())
+        ->setField(new Field('money', ['save_zero_value' => true]))
+        ->preProcess(null);
+
+    expect($preProcess)->toBe(0);
 });
 
 test('can process data', function () {
@@ -43,6 +58,20 @@ test('can process data', function () {
     $process = (new MoneyFieldtype())->process($value);
 
     expect($process)->toBe(1265);
+});
+
+test('can process data when value is empty and save_zero_value is false', function () {
+    $process = (new MoneyFieldtype())->process(null);
+
+    expect($process)->toBeNull();
+});
+
+test('can process data when value is empty and save_zero_value is true', function () {
+    $process = (new MoneyFieldtype())
+        ->setField(new Field('money', ['save_zero_value' => true]))
+        ->process(null);
+
+    expect($process)->toBe(0);
 });
 
 test('has a title', function () {
@@ -65,18 +94,38 @@ test('can augment data', function () {
     expect($augment)->toBe('£19.45');
 });
 
-test('can augment data when value is null', function () {
-    $value = null;
-
-    $augment = (new MoneyFieldtype())->augment($value);
+test('can augment data when value is empty and save_zero_value is false', function () {
+    $augment = (new MoneyFieldtype())->augment(null);
 
     expect($augment)->toBe(null);
+});
+
+test('can augment data when value is empty and save_zero_value is true', function () {
+    $augment = (new MoneyFieldtype())
+        ->setField(new Field('money', ['save_zero_value' => true]))
+        ->augment(null);
+
+    expect($augment)->toBe('£0.00');
 });
 
 test('can get pre process index', function () {
     $value = 2572;
 
-    $augment = (new MoneyFieldtype())->preProcessIndex($value);
+    $preProcessIndex = (new MoneyFieldtype())->preProcessIndex($value);
 
-    expect($augment)->toBe('£25.72');
+    expect($preProcessIndex)->toBe('£25.72');
+});
+
+test('can get pre process index when value is empty and save_zero_value is false', function () {
+    $preProcessIndex = (new MoneyFieldtype())->preProcessIndex(null);
+
+    expect($preProcessIndex)->toBe(null);
+});
+
+test('can get pre process index when value is empty and save_zero_value is true', function () {
+    $preProcessIndex = (new MoneyFieldtype())
+        ->setField(new Field('money', ['save_zero_value' => true]))
+        ->preProcessIndex(null);
+
+    expect($preProcessIndex)->toBe('£0.00');
 });


### PR DESCRIPTION
This pull request adds a new "Saves Zero Value?" option to the Money fieldtype, ensuring that a Price/Total field is always saved as £0. 

Fixes #916.

## Use Case

I have a case where I have an order blueprint where all the total fields are set as required (as per the default Simple Commerce blueprint).

However, commonly, not all the fields (like the Coupon Total) will actually be set due to the Money field being null/empty. This meant that when I go to save an entry in the orders collection, I can't because it requires the total fields to be *some* value.

## History

From history, I've gone back on forward as to what the default should be here - whether it should always save £0 (which it should IMO) or whether it should save empty, like it does now.

There was an issue a while ago which prompted the change to the way it is now: #459

For now, the behaviour is opt-in (it'll continue to save empty but you can choose to let it save as £0). However, this will likely turn into being opt-out when v6 is released.