### PR TITLE
[5.x] Fix country & region fieldtype tests

### DIFF
--- a/tests/Fieldtypes/CountryFieldtypeTest.php
+++ b/tests/Fieldtypes/CountryFieldtypeTest.php
@@ -19,6 +19,7 @@ test('can get index items', function () {
         'id' => 'ZW',
         'iso' => 'ZW',
         'name' => 'Zimbabwe',
+        'title' => 'Zimbabwe',
     ]);
 });
 

--- a/tests/Fieldtypes/RegionFieldtypeTest.php
+++ b/tests/Fieldtypes/RegionFieldtypeTest.php
@@ -20,6 +20,7 @@ test('can get index items', function () {
         'country_iso' => 'ZW',
         'country_name' => 'Zimbabwe',
         'name' => 'Mashonaland West',
+        'title' => 'Mashonaland West',
     ]);
 });
 


### PR DESCRIPTION
This pull request fixes the failing tests for the Country & Region fieldtypes after I change I committed directly to `5.x` recently (🙈).