### PR TITLE
[5.x] Add augmentation to Country & Region fieldtypes

### DIFF
--- a/src/Fieldtypes/CountryFieldtype.php
+++ b/src/Fieldtypes/CountryFieldtype.php
@@ -57,4 +57,13 @@ class CountryFieldtype extends Relationship
             return __($country['name']);
         })->join(', ');
     }
+
+    public function augment($values)
+    {
+        if (! $values) {
+            return null;
+        }
+
+        return Countries::firstWhere('iso', $values);
+    }
 }

--- a/src/Fieldtypes/RegionFieldtype.php
+++ b/src/Fieldtypes/RegionFieldtype.php
@@ -59,4 +59,13 @@ class RegionFieldtype extends Relationship
             return __($region['name']);
         })->join(', ');
     }
+
+    public function augment($values)
+    {
+        if (! $values) {
+            return null;
+        }
+
+        return Regions::find($values);
+    }
 }

--- a/tests/Fieldtypes/CountryFieldtypeTest.php
+++ b/tests/Fieldtypes/CountryFieldtypeTest.php
@@ -67,3 +67,11 @@ test('can preprocess with multiple countries', function () {
     expect($preProcessIndex)->toBeString();
     expect('United Kingdom, United States')->toBe($preProcessIndex);
 });
+
+test('can augment country', function () {
+    $augment = $this->fieldtype->augment('GB');
+
+    expect($augment)->toBeArray();
+    expect($augment['iso'])->toBe('GB');
+    expect($augment['name'])->toBe('United Kingdom');
+});

--- a/tests/Fieldtypes/RegionFieldtypeTest.php
+++ b/tests/Fieldtypes/RegionFieldtypeTest.php
@@ -68,3 +68,11 @@ test('can preprocess with multiple regions', function () {
     expect($preProcessIndex)->toBeString();
     expect('Scotland, Wales')->toBe($preProcessIndex);
 });
+
+it('can augment region', function () {
+    $augment = $this->fieldtype->augment('gb-sct');
+
+    expect($augment)->toBeArray();
+    expect($augment['id'])->toBe('gb-sct');
+    expect($augment['name'])->toBe('Scotland');
+});


### PR DESCRIPTION
This pull request adds augmentation to the Country & Region fieldtypes, allowing you to do things like this when dealing with order information:

```antlers
{{ billing_region:name }}

{{ billing_country:name }}
```

Previously, you could only get the country/region ID, then you'd need to lookup the name using a custom tag or something similar.