### PR TITLE
[5.x] Improvements around tax display

### DIFF
--- a/docs/tags/cart.md
+++ b/docs/tags/cart.md
@@ -52,10 +52,11 @@ There's tags for each of the different totals in a cart.
 -   `{{ sc:cart:grand_total }}` - Does the same thing as `sc:cart:total`
 -   `{{ sc:cart:items_total }}` - Returns the total of all cart items.
 -   `{{ sc:cart:shipping_total }}` - Returns the shipping total of the cart.
+-   `{{ sc:cart:shipping_total_with_tax }}` - Return the shipping total, inclusive of any tax.
 -   `{{ sc:cart:tax_total }}` - Returns the tax total of the cart.
 -   `{{ sc:cart:tax_total_split }}` - Returns the tax total of the cart, split by tax rate.
 -   `{{ sc:cart:coupon_total }}` - Returns the total amount saved from coupons.
--   `{{ sc:cart:itemsTotalWithTax }}` - Sums up both the items total & tax totals
+-   `{{ sc:cart:items_total_with_tax }}` - Returns the total of all line items, inclusive of any tax.
 
 If you need the 'raw' value for any of these totals, meaning the integer, rather than the formatted currency amount, you can do this: `{{ sc:cart:raw_grand_total }}`.
 

--- a/resources/views/emails/backoffice_order_paid.blade.php
+++ b/resources/views/emails/backoffice_order_paid.blade.php
@@ -9,14 +9,13 @@
 | {{ __('Items') }}       | {{ __('Quantity') }}         | {{ __('Total') }} |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
-| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->total(), $site) }} |
+| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->totalIncludingTax(), $site) }} |
 @endforeach
-| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotal(), $site) }}
+| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotalWithTax(), $site) }}
 @if($order->coupon())
 | | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
-| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotal(), $site) }}
-| | {{ __('Tax') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
+| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotalWithTax(), $site) }}
 | | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent

--- a/resources/views/emails/backoffice_order_paid.blade.php
+++ b/resources/views/emails/backoffice_order_paid.blade.php
@@ -1,3 +1,5 @@
+{{ $taxIncludedInPrices = config('simple-commerce.tax_engine_config.included_in_prices') }}
+
 @component('mail::message')
 # {{ __('New Order') }}
 
@@ -9,13 +11,13 @@
 | {{ __('Items') }}       | {{ __('Quantity') }}         | {{ __('Total') }} |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
-| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->totalIncludingTax(), $site) }} |
+| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $lineItem->totalIncludingTax() : $lineItem->total(), $site) }} |
 @endforeach
-| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotalWithTax(), $site) }}
+| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->itemsTotalWithTax() : $order->itemsTotal(), $site) }}
 @if($order->coupon())
 | | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
-| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotalWithTax(), $site) }}
+| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->shippingTotalWithTax() : $order->shippingTotal(), $site) }}
 | | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent

--- a/resources/views/emails/backoffice_order_paid.blade.php
+++ b/resources/views/emails/backoffice_order_paid.blade.php
@@ -18,6 +18,9 @@
 | | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
 | | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->shippingTotalWithTax() : $order->shippingTotal(), $site) }}
+@if(!$taxIncludedInPrices)
+| | {{ __('Tax') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
+@endif
 | | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent

--- a/resources/views/emails/customer_order_paid.blade.php
+++ b/resources/views/emails/customer_order_paid.blade.php
@@ -9,14 +9,13 @@
 | {{ __('Items') }}       | {{ __('Quantity') }}         | {{ __('Total') }} |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
-| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->total(), $site) }} |
+| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->totalIncludingTax(), $site) }} |
 @endforeach
-| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotal(), $site) }}
+| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotalWithTax(), $site) }}
 @if($order->coupon())
 | | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
-| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotal(), $site) }}
-| | {{ __('Tax') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
+| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotalWithTax(), $site) }}
 | | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent

--- a/resources/views/emails/customer_order_paid.blade.php
+++ b/resources/views/emails/customer_order_paid.blade.php
@@ -1,3 +1,5 @@
+{{ $taxIncludedInPrices = config('simple-commerce.tax_engine_config.included_in_prices') }}
+
 @component('mail::message')
 # {{ __('Order Confirmation') }}
 
@@ -9,13 +11,13 @@
 | {{ __('Items') }}       | {{ __('Quantity') }}         | {{ __('Total') }} |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
-| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->totalIncludingTax(), $site) }} |
+| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $lineItem->totalIncludingTax() : $lineItem->total(), $site) }} |
 @endforeach
-| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotalWithTax(), $site) }}
+| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->itemsTotalWithTax() : $order->itemsTotal(), $site) }}
 @if($order->coupon())
 | | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
-| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotalWithTax(), $site) }}
+| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->shippingTotalWithTax() : $order->shippingTotal(), $site) }}
 | | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent

--- a/resources/views/emails/customer_order_paid.blade.php
+++ b/resources/views/emails/customer_order_paid.blade.php
@@ -18,6 +18,9 @@
 | | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
 | | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->shippingTotalWithTax() : $order->shippingTotal(), $site) }}
+@if(!$taxIncludedInPrices)
+| | {{ __('Tax') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
+@endif
 | | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent

--- a/resources/views/emails/customer_order_shipped.blade.php
+++ b/resources/views/emails/customer_order_shipped.blade.php
@@ -9,14 +9,13 @@
 | {{ __('Items') }}       | {{ __('Quantity') }}         | {{ __('Total') }} |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
-| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->total(), $site) }} |
+| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->totalIncludingTax(), $site) }} |
 @endforeach
-| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotal(), $site) }}
+| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotalWithTax(), $site) }}
 @if($order->coupon())
 | | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
-| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotal(), $site) }}
-| | {{ __('Tax') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
+| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotalWithTax(), $site) }}
 | | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent

--- a/resources/views/emails/customer_order_shipped.blade.php
+++ b/resources/views/emails/customer_order_shipped.blade.php
@@ -18,6 +18,9 @@
 | | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
 | | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->shippingTotalWithTax() : $order->shippingTotal(), $site) }}
+@if(!$taxIncludedInPrices)
+| | {{ __('Tax') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
+@endif
 | | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent

--- a/resources/views/emails/customer_order_shipped.blade.php
+++ b/resources/views/emails/customer_order_shipped.blade.php
@@ -1,3 +1,5 @@
+{{ $taxIncludedInPrices = config('simple-commerce.tax_engine_config.included_in_prices') }}
+
 @component('mail::message')
 # {{ __('Order Shipped') }}
 
@@ -9,13 +11,13 @@
 | {{ __('Items') }}       | {{ __('Quantity') }}         | {{ __('Total') }} |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
-| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($lineItem->totalIncludingTax(), $site) }} |
+| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $lineItem->totalIncludingTax() : $lineItem->total(), $site) }} |
 @endforeach
-| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->itemsTotalWithTax(), $site) }}
+| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->itemsTotalWithTax() : $order->itemsTotal(), $site) }}
 @if($order->coupon())
 | | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
-| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->shippingTotalWithTax(), $site) }}
+| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->shippingTotalWithTax() : $order->shippingTotal(), $site) }}
 | | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent

--- a/src/Orders/LineItem.php
+++ b/src/Orders/LineItem.php
@@ -76,6 +76,11 @@ class LineItem
             ->args(func_get_args());
     }
 
+    public function totalIncludingTax(): int
+    {
+        return $this->total() + $this->tax()['amount'];
+    }
+
     public function tax($tax = null)
     {
         return $this

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -131,6 +131,13 @@ class Order implements Contract
             ->args(func_get_args());
     }
 
+    public function itemsTotalWithTax(): int
+    {
+        return $this->lineItems()->sum(function (LineItem $lineItem) {
+            return $lineItem->totalIncludingTax();
+        });
+    }
+
     public function taxTotal($taxTotal = null)
     {
         return $this

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -152,6 +152,18 @@ class Order implements Contract
             ->args(func_get_args());
     }
 
+    public function shippingTotalWithTax(): int
+    {
+        $shippingTotal = $this->shippingTotal();
+        $shippingTax = $this->get('shipping_tax');
+
+        if (isset($shippingTax) && ! $shippingTax['price_includes_tax']) {
+            return $shippingTotal + $shippingTax['amount'];
+        }
+
+        return $shippingTotal;
+    }
+
     public function couponTotal($couponTotal = null)
     {
         return $this

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -126,14 +126,7 @@ class CartTags extends SubTag
     public function shippingTotalWithTax()
     {
         if ($this->hasCart()) {
-            $shippingTotal = $this->getCart()->shippingTotal();
-            $shippingTax = $this->getCart()->get('shipping_tax');
-
-            if (isset($shippingTax) && ! $shippingTax['price_includes_tax']) {
-                return Currency::parse($shippingTotal + $shippingTax['amount'], Site::current());
-            }
-
-            return Currency::parse($shippingTotal, Site::current());
+            return $this->getCart()->shippingTotalWithTax();
         }
 
         return 0;

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -116,6 +116,22 @@ class CartTags extends SubTag
         return 0;
     }
 
+    public function shippingTotalWithTax()
+    {
+        if ($this->hasCart()) {
+            $shippingTotal = $this->getCart()->shippingTotal();
+            $shippingTax = $this->getCart()->get('shipping_tax');
+
+            if (isset($shippingTax) && ! $shippingTax['price_includes_tax']) {
+                return Currency::parse($shippingTotal + $shippingTax['amount'], Site::current());
+            }
+
+            return Currency::parse($shippingTotal, Site::current());
+        }
+
+        return 0;
+    }
+
     public function rawShippingTotal()
     {
         if ($this->hasCart()) {

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -99,11 +99,7 @@ class CartTags extends SubTag
     public function itemsTotalWithTax()
     {
         if ($this->hasCart()) {
-            $itemsTotalWithTax = $this->getCart()->lineItems()->sum(function (LineItem $lineItem) {
-                return $lineItem->totalIncludingTax();
-            });
-
-            return Currency::parse($itemsTotalWithTax, Site::current());
+            return Currency::parse($this->getCart()->itemsTotalWithTax(), Site::current());
         }
 
         return 0;

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -5,6 +5,7 @@ namespace DoubleThreeDigital\SimpleCommerce\Tags;
 use DoubleThreeDigital\SimpleCommerce\Currency;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Statamic\Facades\Site;
@@ -98,10 +99,11 @@ class CartTags extends SubTag
     public function itemsTotalWithTax()
     {
         if ($this->hasCart()) {
-            return Currency::parse(
-                $this->getCart()->itemsTotal() + $this->getCart()->taxTotal(),
-                Site::current()
-            );
+            $itemsTotalWithTax = $this->getCart()->lineItems()->sum(function (LineItem $lineItem) {
+                return $lineItem->totalIncludingTax();
+            });
+
+            return Currency::parse($itemsTotalWithTax, Site::current());
         }
 
         return 0;
@@ -111,6 +113,15 @@ class CartTags extends SubTag
     {
         if ($this->hasCart()) {
             return $this->getCart()->toAugmentedArray()['shipping_total']->value();
+        }
+
+        return 0;
+    }
+
+    public function rawShippingTotal()
+    {
+        if ($this->hasCart()) {
+            return $this->getCart()->shippingTotal();
         }
 
         return 0;
@@ -127,15 +138,6 @@ class CartTags extends SubTag
             }
 
             return Currency::parse($shippingTotal, Site::current());
-        }
-
-        return 0;
-    }
-
-    public function rawShippingTotal()
-    {
-        if ($this->hasCart()) {
-            return $this->getCart()->shippingTotal();
         }
 
         return 0;

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -125,7 +125,7 @@ class CartTags extends SubTag
     public function shippingTotalWithTax()
     {
         if ($this->hasCart()) {
-            return $this->getCart()->shippingTotalWithTax();
+            return Currency::parse($this->getCart()->shippingTotalWithTax(), Site::current());
         }
 
         return 0;

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -5,7 +5,6 @@ namespace DoubleThreeDigital\SimpleCommerce\Tags;
 use DoubleThreeDigital\SimpleCommerce\Currency;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
-use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Statamic\Facades\Site;

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -190,13 +190,72 @@ test('can get cart items total', function () {
     expect((string) tag('{{ sc:cart:itemsTotal }}'))->toBe('£25.50');
 });
 
-test('can get cart items total with cart tax total', function () {
-    $cart = Order::make()->itemsTotal(2550)->taxTotal(620);
+test('can get cart items total with cart tax total, when tax is included in the price', function () {
+    $product = Product::make()
+        ->price(1000)
+        ->data([
+            'title' => 'Dog Food',
+        ]);
+
+    $product->save();
+
+    $cart = Order::make()
+        ->lineItems([
+            [
+                'id' => 'blah',
+                'product' => $product->id(),
+                'quantity' => 1,
+                'total' => 800,
+                'tax' => [
+                    'amount' => 200,
+                    'rate' => 20,
+                    'price_includes_tax' => true,
+                ],
+            ],
+        ])
+        ->itemsTotal(1000)
+        ->taxTotal(200)
+        ->grandTotal(1000);
+
     $cart->save();
 
     fakeCart($cart);
 
-    expect((string) tag('{{ sc:cart:itemsTotalWithTax }}'))->toBe('£31.70');
+    expect((string) tag('{{ sc:cart:itemsTotalWithTax }}'))->toBe('£10.00');
+});
+
+test('can get cart items total with cart tax total, when tax is not included in the price', function () {
+    $product = Product::make()
+        ->price(1000)
+        ->data([
+            'title' => 'Dog Food',
+        ]);
+
+    $product->save();
+
+    $cart = Order::make()
+        ->lineItems([
+            [
+                'id' => 'blah',
+                'product' => $product->id(),
+                'quantity' => 1,
+                'total' => 1000,
+                'tax' => [
+                    'amount' => 200,
+                    'rate' => 20,
+                    'price_includes_tax' => false,
+                ],
+            ],
+        ])
+        ->itemsTotal(1000)
+        ->taxTotal(200)
+        ->grandTotal(1200);
+
+    $cart->save();
+
+    fakeCart($cart);
+
+    expect((string) tag('{{ sc:cart:itemsTotalWithTax }}'))->toBe('£12.00');
 });
 
 test('can get cart shipping total', function () {

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -208,6 +208,36 @@ test('can get cart shipping total', function () {
     expect((string) tag('{{ sc:cart:shippingTotal }}'))->toBe('£25.50');
 });
 
+test('can get cart shipping total with tax when tax is included in the price', function () {
+    $cart = Order::make()->shippingTotal(2550)->merge([
+        'shipping_tax' => [
+            'amount' => 400,
+            'rate' => 20,
+            'price_includes_tax' => true,
+        ],
+    ]);
+    $cart->save();
+
+    fakeCart($cart);
+
+    expect((string) tag('{{ sc:cart:shippingTotalWithTax }}'))->toBe('£25.50');
+});
+
+test('can get cart shipping total with tax when tax is not included in the price', function () {
+    $cart = Order::make()->shippingTotal(2000)->merge([
+        'shipping_tax' => [
+            'amount' => 400,
+            'rate' => 20,
+            'price_includes_tax' => false,
+        ],
+    ]);
+    $cart->save();
+
+    fakeCart($cart);
+
+    expect((string) tag('{{ sc:cart:shippingTotalWithTax }}'))->toBe('£24.00');
+});
+
 test('can get cart tax total', function () {
     $cart = Order::make()->taxTotal(2550);
     $cart->save();


### PR DESCRIPTION
This pull request implements some improvements around how tax is displayed, especially when tax isn't included as part of product prices.

## Improvements

### Add `{{ sc:cart:shippingTotalWithTax }}` tag

A new `shippingTotalWithTax` method has been added to the `{{ sc:cart }}` tag. This allows you to get the shipping total, inclusive of tax.

```antlers
{{ sc:cart:shippingTotalWithTax }}
```

### Fix `{{ sc:cart:itemsTotalWithTax }}` tag

This PR fixed an issue I spotted with the `itemsTotalWithTax` method on the `{{ sc:cart }}` tag. When this tag was used in conjunction with shipping tax, the returned calculations would be incorrect.

Now, the total inclusive of tax will just run through the tax totals for each of the line items rather than relying on the `tax_total` field.

### Line Items: Added `totalIncludingTax` method

A new method has been added to the `LineItem` class, allowing you to get the line item total including any taxes relating to that line item.

```php
$lineItem = $order->lineItems()->first();

$lineItem->totalIncludingTax();
```

### Totals in email should all include tax, if tax is included in prices

When the `included_in_prices` setting is `true` in the tax engine config, totals in Simple Commerce's built-in order emails will be displayed inclusive of tax. 

The 'Tax Total' row has been removed from the order summary table in these cases.

## To Do

* [x] Add `shippingTotalWithTax` tag
* [x] Fix the `itemsTotalWithTax` tag
* [x] Line Items: `totalIncludingTax` method
* [x] Totals in email should all include tax, if tax is included in prices
* [x] Update documentation