### PR TITLE
[5.x] Telemetry

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,27 @@
+---
+title: Telemetry
+---
+
+Every 30 days, Simple Commerce will send an **anonymized** telemetry request to my domain, containing the following information:
+
+* Site Hash (based off your `APP_URL`, to help identify unique sites)
+* Statamic version
+* Simple Commerce version
+* PHP version
+* Timestamp of last telemetry send
+* Count of orders since last telemetry send
+* Sum of order grand totals since last telemetry send
+
+This information helps me see which Simple Commerce / Statamic / PHP versions are in-use, alongside some basic statistics for marketing purposes (eg. Simple Commerce processes on average X orders per month, £x are processed by Simple Commerce on average per month).
+
+Telemetry requests will only be sent in a production environment, on a web request.
+
+## Opt-out of telemetry
+
+If you wish to opt-out of Simple Commerce's Telemetry feature, you may add this to your Simple Commerce config file:
+
+```php
+// config/simple-commerce.php
+
+'enable_telemetry' => true,
+```

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -149,7 +149,9 @@ class ServiceProvider extends AddonServiceProvider
                 ->registerPermissions()
                 ->registerComputedValues();
 
-            Telemetry::send();
+            if (! app()->environment('testing')) {
+                Telemetry::send();
+            }
         });
 
         if (class_exists('Barryvdh\Debugbar\ServiceProvider') && config('debugbar.enabled', false) === true) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -148,6 +148,8 @@ class ServiceProvider extends AddonServiceProvider
                 ->createNavItems()
                 ->registerPermissions()
                 ->registerComputedValues();
+
+            Telemetry::send();
         });
 
         if (class_exists('Barryvdh\Debugbar\ServiceProvider') && config('debugbar.enabled', false) === true) {

--- a/src/Telemetry.php
+++ b/src/Telemetry.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce;
+
+use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
+use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
+use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Statamic\Facades\Collection;
+use Statamic\Statamic;
+
+class Telemetry
+{
+    public static function send(): void
+    {
+        if (! config('simple-commerce.enable_telemetry', true)) {
+            return;
+        }
+
+        if (app()->runningInConsole()) {
+            return;
+        }
+
+        if (! app()->environment('production')) {
+            return;
+        }
+
+        $telemetryPath = storage_path('statamic/addons/simple-commerce/telemetry.json');
+
+        if (File::exists($telemetryPath)) {
+            $telemetry = json_decode(File::get($telemetryPath), true);
+            $lastSentAt = Carbon::parse($telemetry['last_sent_at']);
+
+            if ($lastSentAt->diffInDays(Carbon::now()) < 1) {
+                return;
+            }
+        }
+
+        [$ordersCountSinceLastTelemetry, $ordersGrandTotalSinceLastTelemetry] = static::ordersSinceLastTelemetry($lastSentAt ?? null);
+
+        if (is_null($ordersCountSinceLastTelemetry) && is_null($ordersGrandTotalSinceLastTelemetry)) {
+            return;
+        }
+
+        $payload = [
+            'site_hash' => md5(config('app.url')),
+            'statamic_version' => Statamic::version(),
+            'addon_version' => SimpleCommerce::version(),
+            'php_version' => phpversion(),
+            'data' => [
+                'last_sent_at' => $lastSentAt?->timestamp ?? null,
+                'orders_count' => $ordersCountSinceLastTelemetry,
+                'orders_grand_total' => $ordersGrandTotalSinceLastTelemetry,
+            ],
+        ];
+
+        try {
+            $request = Http::post('https://doublethree.digital/api/telemetry/simple-commerce', $payload);
+        } catch (\Exception $e) {
+            Log::warning("Simple Commerce was unable to phone home. Error: {$e->getMessage()}");
+
+            return;
+        }
+
+        if (! $request->ok()) {
+            return;
+        }
+
+        File::ensureDirectoryExists(storage_path('statamic/addons/simple-commerce'));
+
+        File::put(storage_path('statamic/addons/simple-commerce/telemetry.json'), json_encode([
+            'last_sent_at' => Carbon::now()->timestamp,
+            'payload' => $payload,
+        ]));
+    }
+
+    protected static function ordersSinceLastTelemetry(Carbon $lastSentAt = null): array
+    {
+        if ((new self)->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EntryOrderRepository::class)) {
+            $query = Collection::find(SimpleCommerce::orderDriver()['collection'])
+                ->queryEntries()
+                ->where('payment_status', PaymentStatus::Paid->value)
+                ->when($lastSentAt, function ($query) use ($lastSentAt) {
+                    $query->where('status_log->paid', '>=', $lastSentAt->format('Y-m-d H:i'));
+                });
+
+            return [
+                $query->count(),
+                (int) $query->get()->map(fn ($entry) => $entry->get('grand_total'))->sum(),
+            ];
+        }
+
+        if ((new self)->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EloquentOrderRepository::class)) {
+            $orderModel = new (SimpleCommerce::orderDriver()['model']);
+
+            $query = $orderModel::query()
+                ->where('payment_status', PaymentStatus::Paid->value)
+                ->when($lastSentAt, function ($query) use ($lastSentAt) {
+                    $query->where('data->status_log->paid', '>=', $lastSentAt);
+                });
+
+            return [
+                $query->count(),
+                (int) $query->sum('grand_total')
+            ];
+        }
+
+        return [null, null];
+    }
+
+    protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool
+    {
+        return is_subclass_of($class, $classToCheckAgainst)
+            || $class === $classToCheckAgainst;
+    }
+}

--- a/src/Telemetry.php
+++ b/src/Telemetry.php
@@ -104,7 +104,7 @@ class Telemetry
 
             return [
                 $query->count(),
-                (int) $query->sum('grand_total')
+                (int) $query->sum('grand_total'),
             ];
         }
 

--- a/src/Telemetry.php
+++ b/src/Telemetry.php
@@ -20,11 +20,11 @@ class Telemetry
             return;
         }
 
-        if (app()->runningInConsole()) {
+        if (app()->runningInConsole() && ! app()->runningUnitTests()) {
             return;
         }
 
-        if (! app()->environment('production')) {
+        if (! app()->environment('production') && ! app()->environment('testing')) {
             return;
         }
 
@@ -34,7 +34,7 @@ class Telemetry
             $telemetry = json_decode(File::get($telemetryPath), true);
             $lastSentAt = Carbon::parse($telemetry['last_sent_at']);
 
-            if ($lastSentAt->diffInDays(Carbon::now()) < 1) {
+            if ($lastSentAt->diffInDays(Carbon::now()) < 30) {
                 return;
             }
         }

--- a/src/Telemetry.php
+++ b/src/Telemetry.php
@@ -28,6 +28,7 @@ class Telemetry
             return;
         }
 
+        $lastSentAt = null;
         $telemetryPath = storage_path('statamic/addons/simple-commerce/telemetry.json');
 
         if (File::exists($telemetryPath)) {

--- a/tests/TelemetryTest.php
+++ b/tests/TelemetryTest.php
@@ -1,0 +1,200 @@
+<?php
+
+use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
+use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
+use DoubleThreeDigital\SimpleCommerce\Telemetry;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\{SetupCollections, RefreshContent};
+
+use function PHPUnit\Framework\assertFileDoesNotExist;
+use function PHPUnit\Framework\assertNotNull;
+use function PHPUnit\Framework\assertNotSame;
+
+uses(DoubleThreeDigital\SimpleCommerce\Tests\TestCase::class);
+uses(SetupCollections::class);
+uses(RefreshContent::class);
+
+beforeEach(function () {
+    $this->setupCollections();
+
+    File::delete(storage_path('statamic/addons/simple-commerce/telemetry.json'));
+});
+
+test('does not send telemetry if disabled', function () {
+    Http::fake();
+
+    Config::set('simple-commerce.enable_telemetry', false);
+
+    Telemetry::send();
+
+    Http::assertNothingSent();
+
+    assertFileDoesNotExist(storage_path('statamic/addons/simple-commerce/telemetry.json'));
+});
+
+test('does not send telemetry if telemetry was last sent within the last 30 days', function () {
+    Http::fake();
+
+    File::ensureDirectoryExists(storage_path('statamic/addons/simple-commerce'));
+
+    File::put(storage_path('statamic/addons/simple-commerce/telemetry.json'), json_encode([
+        'last_sent_at' => now()->subDays(29)->timestamp,
+    ]));
+
+    Telemetry::send();
+
+    Http::assertNothingSent();
+});
+
+test('does send telemetry if telemetry was last sent more then 30 days ago', function () {
+    Http::fake(function (Request $request) {
+        return Http::response([
+            'success' => true,
+        ], 200, [
+            'Content-Type' => 'application/json',
+        ]);
+    });
+
+    File::ensureDirectoryExists(storage_path('statamic/addons/simple-commerce'));
+
+    File::put(storage_path('statamic/addons/simple-commerce/telemetry.json'), json_encode([
+        'last_sent_at' => $originalLastSentAt = now()->subDays(31)->timestamp,
+    ]));
+
+    Telemetry::send();
+
+    $telemetryData = json_decode(File::get(storage_path('statamic/addons/simple-commerce/telemetry.json')), true);
+
+    assertNotSame($originalLastSentAt, $telemetryData['last_sent_at']);
+});
+
+test('does send telemetry if telemetry has never been sent before', function () {
+    Http::fake(function (Request $request) {
+        return Http::response([
+            'success' => true,
+        ], 200, [
+            'Content-Type' => 'application/json',
+        ]);
+    });
+
+    Telemetry::send();
+
+    $telemetryData = json_decode(File::get(storage_path('statamic/addons/simple-commerce/telemetry.json')), true);
+
+    assertNotNull($telemetryData['last_sent_at']);
+});
+
+test('orders count and orders grand total are correct since last telemetry', function () {
+    Http::fake(function (Request $request) {
+        return Http::response([
+            'success' => true,
+        ], 200, [
+            'Content-Type' => 'application/json',
+        ]);
+    });
+
+    $product = Product::make()->price(1000)->data(['title' => 'Food']);
+    $product->save();
+
+    $orderOne = Order::make()
+        ->grandTotal(1000)
+        ->paymentStatus(PaymentStatus::Paid)
+        ->data(['status_log' => ['paid' => now()->subDays(60)->format('Y-m-d H:i')]]);
+
+    $orderTwo = Order::make()
+        ->grandTotal(1523)
+        ->paymentStatus(PaymentStatus::Paid)
+        ->data(['status_log' => ['paid' => now()->subDays(45)->format('Y-m-d H:i')]]);
+
+    $orderThree = Order::make()
+        ->grandTotal(1523)
+        ->paymentStatus(PaymentStatus::Paid)
+        ->data(['status_log' => ['paid' => now()->subDays(10)->format('Y-m-d H:i')]]);
+
+    $orderOne->save();
+    $orderTwo->save();
+    $orderThree->save();
+
+    File::ensureDirectoryExists(storage_path('statamic/addons/simple-commerce'));
+
+    File::put(storage_path('statamic/addons/simple-commerce/telemetry.json'), json_encode([
+        'last_sent_at' => $originalLastSentAt = now()->subDays(30)->timestamp,
+    ]));
+
+    Telemetry::send();
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['data']['orders_count'] === 1
+            && $body['data']['orders_grand_total'] === 1523;
+    });
+
+    $telemetryData = json_decode(File::get(storage_path('statamic/addons/simple-commerce/telemetry.json')), true);
+
+    assertNotSame($originalLastSentAt, $telemetryData['last_sent_at']);
+});
+
+test('orders count and orders grand total are correct when telemetry has never been sent before', function () {
+    Http::fake(function (Request $request) {
+        return Http::response([
+            'success' => true,
+        ], 200, [
+            'Content-Type' => 'application/json',
+        ]);
+    });
+
+    $product = Product::make()->price(1000)->data(['title' => 'Food']);
+    $product->save();
+
+    $orderOne = Order::make()
+        ->grandTotal(1000)
+        ->paymentStatus(PaymentStatus::Paid)
+        ->data(['status_log' => ['paid' => now()->subDays(60)->format('Y-m-d H:i')]]);
+
+    $orderTwo = Order::make()
+        ->grandTotal(1523)
+        ->paymentStatus(PaymentStatus::Paid)
+        ->data(['status_log' => ['paid' => now()->subDays(45)->format('Y-m-d H:i')]]);
+
+    $orderThree = Order::make()
+        ->grandTotal(1523)
+        ->paymentStatus(PaymentStatus::Paid)
+        ->data(['status_log' => ['paid' => now()->subDays(10)->format('Y-m-d H:i')]]);
+
+    $orderOne->save();
+    $orderTwo->save();
+    $orderThree->save();
+
+    Telemetry::send();
+
+    Http::assertSent(function (Request $request) {
+        $body = json_decode($request->body(), true);
+
+        return $body['data']['orders_count'] === 3
+            && $body['data']['orders_grand_total'] === 4046;
+    });
+
+    $telemetryData = json_decode(File::get(storage_path('statamic/addons/simple-commerce/telemetry.json')), true);
+
+    assertNotNull($telemetryData['last_sent_at']);
+});
+
+test('can handle server error by telemetry endpoint', function () {
+    Http::fake(function (Request $request) {
+        return Http::response([
+            'success' => false,
+        ], 500, [
+            'Content-Type' => 'application/json',
+        ]);
+    });
+
+    Telemetry::send();
+
+    assertFileDoesNotExist(storage_path('statamic/addons/simple-commerce/telemetry.json'));
+});

--- a/tests/TelemetryTest.php
+++ b/tests/TelemetryTest.php
@@ -2,14 +2,14 @@
 
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
 use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
 use DoubleThreeDigital\SimpleCommerce\Telemetry;
+use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\RefreshContent;
+use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\{SetupCollections, RefreshContent};
 
 use function PHPUnit\Framework\assertFileDoesNotExist;
 use function PHPUnit\Framework\assertNotNull;


### PR DESCRIPTION
This pull request introduces anonymous telemetry into Simple Commerce.

Every 30 days, in production, Simple Commerce will send an API request to my backend, with the following information:

* Site Hash, based on your `APP_URL` (so I can identify telemetry to a specific site, but without knowing the site's domain)
* Statamic / PHP / Simple Commerce versions
* Number of orders made since the last telemetry request
* Total of orders made since the last telemetry request (let's me do things like "Simple Commerce processes £xxx of orders every month").

## Opt-out

All of the data sent to the API is anonymous and can't be tied back to your site. However, if you wish to opt-out, you may add the following setting to your `config/simple-commerce.php` file:

```php
'enable_telemetry' => false,
```

## To Do

* [x] Write tests
* [x] Update documentation