### PR TITLE
[5.x] Tidy up empty states

### DIFF
--- a/resources/views/cp/coupons/index.blade.php
+++ b/resources/views/cp/coupons/index.blade.php
@@ -19,10 +19,13 @@
             action-url="{{ $actionUrl }}"
         ></coupon-listing>
     @else
-        @include('statamic::partials.create-first', [
-            'resource' => __('Coupon'),
-            'svg' => 'empty/collection',
-            'route' => cp_route('simple-commerce.coupons.create'),
+        @include('statamic::partials.empty-state', [
+            'title' => __('Coupons'),
+            'description' => __('Coupons are a great way to offer discounts to your customers. You can create coupons and apply them to orders.'),
+            'svg' => 'empty/content',
+            'button_text' => __('Create Coupon'),
+            'button_url' => cp_route('simple-commerce.coupons.create'),
+            'can' => auth()->user()->can('create coupons'),
         ])
     @endif
 @endsection

--- a/resources/views/cp/tax-categories/index.blade.php
+++ b/resources/views/cp/tax-categories/index.blade.php
@@ -56,10 +56,13 @@
             </table>
         </div>
     @else
-        @include('statamic::partials.create-first', [
-            'resource' => __('Tax Category'),
-            'svg' => 'empty/collection',
-            'route' => cp_route('simple-commerce.tax-categories.create'),
+        @include('statamic::partials.empty-state', [
+            'title' => __('Tax Categories'),
+            'description' => __('Tax Categories allow you to set different tax rates for different types of products. You can create tax categories and assign them to products.'),
+            'svg' => 'empty/content',
+            'button_text' => __('Create Tax Category'),
+            'button_url' => cp_route('simple-commerce.tax-categories.create'),
+            'can' => auth()->user()->can('create tax categories'),
         ])
     @endif
 @endsection

--- a/resources/views/cp/tax-rates/index.blade.php
+++ b/resources/views/cp/tax-rates/index.blade.php
@@ -79,10 +79,13 @@
             </table>
         </div>
     @else
-        @include('statamic::partials.create-first', [
-            'resource' => __('Tax Rate'),
-            'svg' => 'empty/collection',
-            'route' => cp_route('simple-commerce.tax-rates.create'),
+        @include('statamic::partials.empty-state', [
+            'title' => __('Tax Rate'),
+            'description' => __("Tax Rates allow you to set different tax rates for different categories of products, depending on the customer's location."),
+            'svg' => 'empty/content',
+            'button_text' => __('Create Tax Rate'),
+            'button_url' => cp_route('simple-commerce.tax-rates.create'),
+            'can' => auth()->user()->can('create tax rates'),
         ])
     @endif
 @endsection

--- a/resources/views/cp/tax-zones/index.blade.php
+++ b/resources/views/cp/tax-zones/index.blade.php
@@ -64,10 +64,13 @@
             </table>
         </div>
     @else
-        @include('statamic::partials.create-first', [
-            'resource' => __('Tax Zone'),
-            'svg' => 'empty/collection',
-            'route' => cp_route('simple-commerce.tax-zones.create'),
+        @include('statamic::partials.empty-state', [
+            'title' => __('Tax Zone'),
+            'description' => __("Tax Zones allow you to define which locations should be grouped together for tax purposes. You can create tax zones and assign them to tax rates."),
+            'svg' => 'empty/content',
+            'button_text' => __('Create Tax Zone'),
+            'button_url' => cp_route('simple-commerce.tax-zones.create'),
+            'can' => auth()->user()->can('create tax zones'),
         ])
     @endif
 @endsection


### PR DESCRIPTION
This pull request tidies up the Control Panel empty states in Simple Commerce to use the new-ish `empty-state` partial, over the old `create-first` partial (which I only figured out was old after seeing statamic/cms#8787 pop up).