### PR TITLE
[5.x] Pass field config to variant option fields when augmenting

### DIFF
--- a/src/Fieldtypes/ProductVariantsFieldtype.php
+++ b/src/Fieldtypes/ProductVariantsFieldtype.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
 
+use Illuminate\Support\Arr;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fields;
 use Statamic\Fields\Fieldtype;
@@ -136,6 +137,7 @@ class ProductVariantsFieldtype extends Fieldtype
                             ->map(function ($field) use ($value, $method) {
                                 return (new FieldtypeRepository())
                                     ->find($field['type'])
+                                    ->setField(new Field($field['handle'], Arr::except($field, ['handle'])))
                                     ->{$method}($value);
                             })
                             ->first();


### PR DESCRIPTION
This pull request fixes an issue I've just spotted while sorting something else where the field config for variant option fields wasn't being passed along when the options were being augmented.

This meant that if you had an Assets field, you'd see an error about the "asset container" not being set, even if it was set in the field's config because the config wasn't being passed along.