### PR TITLE
[5.x] Fix CP Nav permissions check when using database orders

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -313,7 +313,7 @@ class ServiceProvider extends AddonServiceProvider
                 $nav->create(__('Orders'))
                     ->section(__('Simple Commerce'))
                     ->route('runway.index', ['resourceHandle' => $orderResource->handle()])
-                    ->can("View {$orderResource->plural()}")
+                    ->can('view', $orderResource)
                     ->icon(SimpleCommerce::svg('shop'));
             }
 
@@ -342,7 +342,7 @@ class ServiceProvider extends AddonServiceProvider
                 $nav->create(__('Customers'))
                     ->section(__('Simple Commerce'))
                     ->route('runway.index', ['resourceHandle' => $customerResource->handle()])
-                    ->can("View {$customerResource->plural()}")
+                    ->can('view', $customerResource)
                     ->icon('user');
             }
 


### PR DESCRIPTION
This pull request aims to fix an issue where non-super users were unable to access the Orders & Customers pages in the Control Panel, when using Simple Commerce's database driver. 

Fixes #937.