### PR TITLE
[5.x] Allow localization of Product Variants field

### DIFF
--- a/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
@@ -83,6 +83,8 @@ export default {
 
     props: ['meta'],
 
+    inject: ['storeName'],
+
     data() {
         return {
             variants: [
@@ -130,14 +132,24 @@ export default {
 
     mounted() {
         if (this.value.variants && this.value.options) {
-            this.canWatchVariants = false
-            this.variants = this.value.variants
-            this.options = this.value.options
-            this.canWatchVariants = true
+            this.updateVariantsAndOptions();
         }
+
+        this.$store.watch((state) => state.publish[this.storeName].site, (newValue, oldValue) => {
+            if (newValue !== oldValue) {
+                this.updateVariantsAndOptions();
+            }
+        })
     },
 
     methods: {
+        updateVariantsAndOptions() {
+            this.canWatchVariants = false;
+            this.variants = this.value.variants;
+            this.options = this.value.options;
+            this.canWatchVariants = true;
+        },
+
         addVariant() {
             this.variants.push({
                 name: '',
@@ -184,8 +196,7 @@ export default {
 
                 this.options = this.cartesian.map((item) => {
                     let key = typeof item === 'string' ? item : item.join('_')
-                    let variantName =
-                        typeof item === 'string' ? item : item.join(', ')
+                    let variantName = typeof item === 'string' ? item : item.join(', ')
 
                     let existingData = this.value.options.filter((option) => {
                         return option.key === key

--- a/src/Fieldtypes/ProductVariantsFieldtype.php
+++ b/src/Fieldtypes/ProductVariantsFieldtype.php
@@ -228,7 +228,7 @@ class ProductVariantsFieldtype extends Fieldtype
 
     protected function optionFields(): Fields
     {
-        $optionFields = array_merge([
+        $optionFields = collect([
             [
                 'handle' => 'key',
                 'field' => [
@@ -261,7 +261,15 @@ class ProductVariantsFieldtype extends Fieldtype
                     'width' => 50,
                 ],
             ],
-        ], $this->config('option_fields', []));
+        ])
+            ->merge($this->config('option_fields', []))
+            ->when($this->config('localizable', false), function ($fields) {
+                return $fields->map(function (array $field) {
+                    $field['field']['localizable'] = true;
+                    return $field;
+                });
+            })
+            ->toArray();
 
         return new Fields($optionFields, $this->field()->parent(), $this->field());
     }

--- a/src/Fieldtypes/ProductVariantsFieldtype.php
+++ b/src/Fieldtypes/ProductVariantsFieldtype.php
@@ -266,6 +266,7 @@ class ProductVariantsFieldtype extends Fieldtype
             ->when($this->config('localizable', false), function ($fields) {
                 return $fields->map(function (array $field) {
                     $field['field']['localizable'] = true;
+
                     return $field;
                 });
             })

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -118,6 +118,7 @@ class ServiceProvider extends AddonServiceProvider
     ];
 
     protected $vite = [
+        'hotFile' => 'vendor/simple-commerce/hot',
         'publicDirectory' => 'dist',
         'input' => [
             'resources/js/cp.js',

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ import vue2 from '@vitejs/plugin-vue2'
 export default defineConfig({
     plugins: [
         laravel({
-            hotFile: 'vite.hot',
+            hotFile: 'dist/hot',
             publicDirectory: 'dist',
             input: ['resources/js/cp.js', 'resources/css/cp.css'],
         }),


### PR DESCRIPTION
This pull request allows for Product Variants to be localized so you can localize the price & any other custom fields on variant options.

To enable this behaviour, simply make the "Product Variants" field localizable in your product blueprint:

![CleanShot 2023-12-20 at 22 26 22](https://github.com/duncanmcclean/simple-commerce/assets/19637309/b4f2e189-e4d1-4f09-bc17-3f02ddc0b148)

Closes #942.