### PR TITLE
[5.x] Status Log Improvements

### DIFF
--- a/docs/php-api.md
+++ b/docs/php-api.md
@@ -132,7 +132,7 @@ $shippingAddress->toArray();
 // Redeem a coupon
 $order->redeemCoupon('coupon-code');
 
-// Get the status log (you may optionally pass in a status as a parameter to get the timestamp)
+// Get the status log
 $order->statusLog();
 
 // Recalculate order totals

--- a/src/Actions/UpdateOrderStatus.php
+++ b/src/Actions/UpdateOrderStatus.php
@@ -26,6 +26,11 @@ class UpdateOrderStatus extends Action
                     $case->value => $case->name,
                 ])->toArray(),
                 'instructions' => __('**Note:** Changing the order status will not refund or charge the customer.'),
+                'validate' => 'required',
+            ],
+            'reason' => [
+                'type' => 'textarea',
+                'instructions' => __("Optionally, provide a reason for this status change. This will be visible in the order's status log."),
             ],
         ];
     }
@@ -63,11 +68,14 @@ class UpdateOrderStatus extends Action
     {
         $orderStatus = OrderStatus::from($values['order_status']);
 
-        collect($items)
-            ->each(function ($entry) use ($orderStatus) {
-                $order = Order::find($entry->id);
-                $order->updateOrderStatus($orderStatus)->save();
-            });
+        $data = collect([
+            'reason' => $values['reason'] ?? null
+        ])->filter();
+
+        collect($items)->each(function ($entry) use ($orderStatus, $data) {
+            $order = Order::find($entry->id);
+            $order->updateOrderStatus($orderStatus, $data->toArray())->save();
+        });
     }
 
     protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool

--- a/src/Actions/UpdateOrderStatus.php
+++ b/src/Actions/UpdateOrderStatus.php
@@ -66,8 +66,7 @@ class UpdateOrderStatus extends Action
         collect($items)
             ->each(function ($entry) use ($orderStatus) {
                 $order = Order::find($entry->id);
-
-                $order->updateOrderStatus($orderStatus);
+                $order->updateOrderStatus($orderStatus)->save();
             });
     }
 

--- a/src/Actions/UpdateOrderStatus.php
+++ b/src/Actions/UpdateOrderStatus.php
@@ -9,6 +9,7 @@ use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Facades\Config;
 use Statamic\Actions\Action;
 use Statamic\Entries\Entry;
+use Statamic\Facades\User;
 
 class UpdateOrderStatus extends Action
 {
@@ -69,7 +70,8 @@ class UpdateOrderStatus extends Action
         $orderStatus = OrderStatus::from($values['order_status']);
 
         $data = collect([
-            'reason' => $values['reason'] ?? null
+            'user' => User::current()->id(),
+            'reason' => $values['reason'] ?? null,
         ])->filter();
 
         collect($items)->each(function ($entry) use ($orderStatus, $data) {

--- a/src/Actions/UpdateOrderStatus.php
+++ b/src/Actions/UpdateOrderStatus.php
@@ -31,7 +31,7 @@ class UpdateOrderStatus extends Action
             ],
             'reason' => [
                 'type' => 'textarea',
-                'instructions' => __("Optionally, provide a reason for this status change. This will be visible in the order's status log."),
+                'instructions' => __("Provide a reason for this status change. This will be visible in the order's status log."),
             ],
         ];
     }

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -298,11 +298,11 @@ class Order implements Contract
         return false;
     }
 
-    public function updateOrderStatus(OrderStatus $orderStatus): self
+    public function updateOrderStatus(OrderStatus $orderStatus, array $data = []): self
     {
         $this
             ->status($orderStatus)
-            ->appendToStatusLog($orderStatus)
+            ->appendToStatusLog($orderStatus, $data)
             ->save();
 
         event(new OrderStatusUpdated($this, $orderStatus));
@@ -310,11 +310,11 @@ class Order implements Contract
         return $this;
     }
 
-    public function updatePaymentStatus(PaymentStatus $paymentStatus): self
+    public function updatePaymentStatus(PaymentStatus $paymentStatus, array $data = []): self
     {
         $this
             ->paymentStatus($paymentStatus)
-            ->appendToStatusLog($paymentStatus)
+            ->appendToStatusLog($paymentStatus, $data)
             ->save();
 
         event(new PaymentStatusUpdated($this, $paymentStatus));

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -322,7 +322,7 @@ class Order implements Contract
         return $this;
     }
 
-    public function statusLog(): Collection|string|null
+    public function statusLog($key = null): Collection|string|null
     {
         // Convert the old format to the new format. We can probably remove this in the future.
         if (! empty($this->get('status_log')) && ! is_array(Arr::first($this->get('status_log')))) {
@@ -332,6 +332,14 @@ class Order implements Contract
                     timestamp: Carbon::parse($date)->timestamp
                 );
             })->values()->toArray());
+        }
+
+        // v5 compatability: when a $key is passed, we want to return the date of the status change. (v6 TODO: remove this)
+        if ($key) {
+            return collect($this->get('status_log'))
+                ->filter(fn (array $statusLogEvent) => $statusLogEvent['status'] === $key)
+                ->map(fn (array $statusLogEvent) => Carbon::parse($statusLogEvent['timestamp'])->format('Y-m-d H:i'))
+                ->first();
         }
 
         return collect($this->get('status_log'))->map(function (array $statusLogEvent) {

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -346,12 +346,12 @@ class Order implements Contract
 
     public function appendToStatusLog(OrderStatus|PaymentStatus $status): self
     {
-        $this->statusLog()->push([
+        $statusLog = $this->statusLog()->push([
             'status' => $status->value,
             'timestamp' => Carbon::now()->timestamp,
         ]);
 
-        $this->set('status_log', $this->statusLog()->toArray());
+        $this->set('status_log', $statusLog->toArray());
 
         return $this;
     }

--- a/src/Orders/StatusLogEvent.php
+++ b/src/Orders/StatusLogEvent.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Orders;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Carbon;
+
+class StatusLogEvent implements Arrayable
+{
+    public function __construct(public string|OrderStatus|PaymentStatus $status, public int $timestamp, public array $data = [])
+    {
+        if (is_string($status)) {
+            $this->status = $this->getStatusFromValue($status);
+        }
+    }
+
+    public function date(): Carbon
+    {
+        return Carbon::parse($this->timestamp);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status->value,
+            'timestamp' => $this->timestamp,
+            'data' => $this->data,
+        ];
+    }
+
+    // TODO: maybe refactor this, it's not pretty
+    private function getStatusFromValue(string $value): OrderStatus|PaymentStatus
+    {
+        try {
+            return OrderStatus::from($value);
+        } catch (\Throwable $th) {
+            return PaymentStatus::from($value);
+        }
+    }
+}

--- a/src/Overview.php
+++ b/src/Overview.php
@@ -12,6 +12,7 @@ use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
 use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
 use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
+use DoubleThreeDigital\SimpleCommerce\Orders\StatusLogEvent;
 use DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository;
 use DoubleThreeDigital\SimpleCommerce\Support\Runway;
 use Illuminate\Http\Request;
@@ -103,7 +104,11 @@ class Overview
                             'order_number' => $order->orderNumber(),
                             'edit_url' => $order->resource()->editUrl(),
                             'grand_total' => Currency::parse($order->grandTotal(), Site::selected()),
-                            'paid_at' => Carbon::parse($order->statusLog(PaymentStatus::Paid->value))->format(config('statamic.system.date_format')),
+                            'paid_at' => $order->statusLog()
+                                ->filter(fn (StatusLogEvent $statusLogEvent) => $statusLogEvent->status->is(PaymentStatus::Paid))
+                                ->first()
+                                ->date()
+                                ->format(config('statamic.system.date_format')),
                         ];
                     });
                 }
@@ -130,7 +135,11 @@ class Overview
                                 'record' => $order->resource()->{$orderModel->getRouteKeyName()},
                             ]),
                             'grand_total' => Currency::parse($order->grandTotal(), Site::selected()),
-                            'paid_at' => Carbon::parse($order->statusLog(PaymentStatus::Paid->value))->format(config('statamic.system.date_format')),
+                            'paid_at' => $order->statusLog()
+                                ->filter(fn (StatusLogEvent $statusLogEvent) => $statusLogEvent->status->is(PaymentStatus::Paid))
+                                ->first()
+                                ->date()
+                                ->format(config('statamic.system.date_format')),
                         ];
                     });
                 }

--- a/src/Overview.php
+++ b/src/Overview.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\SimpleCommerce;
 
-use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 use DoubleThreeDigital\SimpleCommerce\Customers\EloquentCustomerRepository;
 use DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository;

--- a/tests/Actions/UpdateOrderStatusTest.php
+++ b/tests/Actions/UpdateOrderStatusTest.php
@@ -7,11 +7,17 @@ use Spatie\TestTime\TestTime;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Stache;
+use Statamic\Facades\User;
+
+use function Pest\Laravel\actingAs;
 
 beforeEach(function () {
     $this->setupCollections();
 
     $this->action = new UpdateOrderStatus();
+
+    $user = User::make()->id('one')->makeSuper()->save();
+    actingAs($user);
 });
 
 test('is not visible to products', function () {
@@ -52,7 +58,7 @@ test('order can have its status updated', function () {
 
     expect('dispatched')->toBe($order->data()->get('order_status'));
     expect($order->data()->get('status_log'))->toBe([
-        ['status' => 'dispatched', 'timestamp' => $now, 'data' => []],
+        ['status' => 'dispatched', 'timestamp' => $now, 'data' => ['user' => 'one']],
     ]);
 });
 
@@ -74,13 +80,13 @@ test('order can have its status updated with reason', function () {
 
     $this->action->run([$order], [
         'order_status' => 'dispatched',
-        'reason' => 'Dispatched and handed over to the delivery company.',
+        'reason' => 'Handed to the delivery company.',
     ]);
 
     $order->fresh();
 
     expect('dispatched')->toBe($order->data()->get('order_status'));
     expect($order->data()->get('status_log'))->toBe([
-        ['status' => 'dispatched', 'timestamp' => $now, 'data' => ['reason' => 'Dispatched and handed over to the delivery company.']],
+        ['status' => 'dispatched', 'timestamp' => $now, 'data' => ['user' => 'one', 'reason' => 'Handed to the delivery company.']],
     ]);
 });

--- a/tests/Actions/UpdateOrderStatusTest.php
+++ b/tests/Actions/UpdateOrderStatusTest.php
@@ -2,6 +2,7 @@
 
 use DoubleThreeDigital\SimpleCommerce\Actions\UpdateOrderStatus;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use Illuminate\Support\Carbon;
 use Spatie\TestTime\TestTime;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -30,7 +31,7 @@ test('is not visible to products', function () {
 test('order can have its status updated', function () {
     TestTime::freeze();
 
-    $now = TestTime::now()->format('Y-m-d H:i');
+    $now = Carbon::now()->timestamp;
 
     Collection::make('orders')->save();
 
@@ -50,8 +51,7 @@ test('order can have its status updated', function () {
     $order->fresh();
 
     expect('dispatched')->toBe($order->data()->get('order_status'));
-
-    $this->assertSame($order->data()->get('status_log'), [
-        'dispatched' => $now,
+    expect($order->data()->get('status_log'))->toBe([
+        ['status' => 'dispatched', 'timestamp' => $now],
     ]);
 });

--- a/tests/Actions/UpdateOrderStatusTest.php
+++ b/tests/Actions/UpdateOrderStatusTest.php
@@ -52,6 +52,35 @@ test('order can have its status updated', function () {
 
     expect('dispatched')->toBe($order->data()->get('order_status'));
     expect($order->data()->get('status_log'))->toBe([
-        ['status' => 'dispatched', 'timestamp' => $now],
+        ['status' => 'dispatched', 'timestamp' => $now, 'data' => []],
+    ]);
+});
+
+test('order can have its status updated with reason', function () {
+    TestTime::freeze();
+
+    $now = Carbon::now()->timestamp;
+
+    Collection::make('orders')->save();
+
+    $order = Entry::make()
+        ->collection('orders')
+        ->id(Stache::generateId())
+        ->data([
+            'order_status' => 'cart',
+        ]);
+
+    $order->save();
+
+    $this->action->run([$order], [
+        'order_status' => 'dispatched',
+        'reason' => 'Dispatched and handed over to the delivery company.',
+    ]);
+
+    $order->fresh();
+
+    expect('dispatched')->toBe($order->data()->get('order_status'));
+    expect($order->data()->get('status_log'))->toBe([
+        ['status' => 'dispatched', 'timestamp' => $now, 'data' => ['reason' => 'Dispatched and handed over to the delivery company.']],
     ]);
 });

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -306,7 +306,7 @@ test('can checkout when in card elements mode', function () {
     $order = $order->fresh();
 
     expect(PaymentStatus::Paid)->toBe($order->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 })->skip(! env('STRIPE_SECRET'));
 
 test('cant checkout when in payment elements mode', function () {
@@ -363,7 +363,7 @@ test('cant checkout when in payment elements mode', function () {
     $order = $order->fresh();
 
     expect(PaymentStatus::Unpaid)->toBe($order->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 })->skip(! env('STRIPE_SECRET'));
 
 test('has checkout rules', function () {

--- a/tests/Http/Controllers/CheckoutControllerTest.php
+++ b/tests/Http/Controllers/CheckoutControllerTest.php
@@ -76,7 +76,7 @@ test('can post checkout', function () {
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Finally, assert order is no longer attached to the users' session
     expect(session()->has('simple-commerce-cart'))->toBeFalse();
@@ -128,7 +128,7 @@ test('cant post checkout and ensure custom form request is used', function () {
 
     $this->assertNotSame($order->fresh()->status(), OrderStatus::Placed);
     $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
-    expect($order->statusLog('paid'))->toBeNull();
+    expect($order->statusLogIncludes(PaymentStatus::Paid))->toBeFalse();
 
     // Finally, assert order is no longer attached to the users' session
     expect(session()->has('simple-commerce-cart'))->toBeTrue();
@@ -176,7 +176,7 @@ test('can post checkout with name and email', function () {
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert customer has been created with provided details
     $this->assertNotNull($order->customer());
@@ -235,7 +235,7 @@ test('can post checkout with first name and last name and email', function () {
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert customer has been created with provided details
     $this->assertNotNull($order->customer());
@@ -292,7 +292,7 @@ test('cant post checkout with name and email when email address contains spaces'
 
     $this->assertNotSame($order->fresh()->status(), OrderStatus::Placed);
     $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
-    expect($order->statusLog('paid'))->toBeNull();
+    expect($order->statusLogIncludes(PaymentStatus::Paid))->toBeFalse();
 
     // Assert customer has been created with provided details
     expect($order->customer())->toBeNull();
@@ -342,7 +342,7 @@ test('can post checkout with only email', function () {
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert email has been set on the order
     $this->assertNotNull($order->customer());
@@ -402,7 +402,7 @@ test('can post checkout with customer already present in order', function () {
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert customer has been updated
     $this->assertNotNull($order->customer());
@@ -466,7 +466,7 @@ test('can post checkout with customer present in request', function () {
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert customer has been updated
     $this->assertNotNull($order->customer());
@@ -543,7 +543,7 @@ test('can post checkout with customer where customer has invalid orders', functi
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert customer has been updated
     $this->assertNotNull($order->customer());
@@ -605,7 +605,7 @@ test('can post checkout with customer array', function () {
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert customer has been created with provided details
     $this->assertNotNull($order->customer());
@@ -673,7 +673,7 @@ test('can post checkout with customer array and existing customer', function () 
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert customer has been created with provided details
     $this->assertNotNull($order->customer());
@@ -742,7 +742,7 @@ test('can post checkout with customer array with additional information', functi
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert customer has been created with provided details
     $this->assertNotNull($order->customer());
@@ -819,7 +819,7 @@ test('can post checkout with customer array and existing customer with additiona
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert customer has been created with provided details
     $this->assertNotNull($order->customer());
@@ -895,7 +895,7 @@ test('can post checkout with coupon', function () {
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert the coupon has been redeemed propery & the total has been recalculated
     expect($coupon->id)->toBe($order->coupon()->id());
@@ -960,7 +960,7 @@ test('can post checkout with coupon when checkout request will reach the coupons
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert the coupon has been redeemed propery & the total has been recalculated
     expect($coupon->id)->toBe($order->coupon()->id());
@@ -1036,7 +1036,7 @@ test('cant post checkout with coupon where minimum cart value has not been reach
 
     $this->assertNotSame($order->fresh()->status(), OrderStatus::Placed);
     $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
-    expect($order->statusLog('paid'))->toBeNull();
+    expect($order->statusLogIncludes(PaymentStatus::Paid))->toBeFalse();
 
     // Assert the coupon has been redeemed propery & the total has been recalculated
     expect($order->coupon())->toBeNull();
@@ -1111,7 +1111,7 @@ test('cant post checkout with coupon when coupon has been redeemed for maxium us
 
     $this->assertNotSame($order->fresh()->status(), OrderStatus::Placed);
     $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
-    expect($order->statusLog('paid'))->toBeNull();
+    expect($order->statusLogIncludes(PaymentStatus::Paid))->toBeFalse();
 
     // Assert the coupon has been redeemed propery & the total has been recalculated
     expect($order->coupon())->toBeNull();
@@ -1186,7 +1186,7 @@ test('cant post checkout with coupon where coupon is only valid for products not
 
     $this->assertNotSame($order->fresh()->status(), OrderStatus::Placed);
     $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
-    expect($order->statusLog('paid'))->toBeNull();
+    expect($order->statusLogIncludes(PaymentStatus::Paid))->toBeFalse();
 
     // Assert the coupon has been redeemed propery & the total has been recalculated
     expect($order->coupon())->toBeNull();
@@ -1241,7 +1241,7 @@ test('can post checkout with product with stock counter', function () {
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert stock has been reduced
     expect(49)->toBe($product->fresh()->stock());
@@ -1295,7 +1295,7 @@ test('can post checkout when product is running low on stock', function () {
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert stock has been reduced
     expect(8)->toBe($product->fresh()->stock());
@@ -1355,7 +1355,7 @@ test('cant post checkout when product has no stock', function () {
 
     $this->assertNotSame($order->fresh()->status(), OrderStatus::Placed);
     $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
-    expect($order->statusLog('paid'))->toBeNull();
+    expect($order->statusLogIncludes(PaymentStatus::Paid))->toBeFalse();
 
     // Asset the stock is the same (it hasn't been reduced yet because the
     // checkout failed at the validation stage)
@@ -1411,7 +1411,7 @@ test('cant post checkout when product has a single item left in stock and single
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert stock has been reduced
     expect(0)->toBe($product->fresh()->stock());
@@ -1489,7 +1489,7 @@ test('can post checkout with variant product with stock counter', function () {
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert stock has been reduced
     expect(49)->toBe($product->fresh()->variant('Red_Small')->stock());
@@ -1566,7 +1566,7 @@ test('can post checkout when variant product is running low on stock', function 
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert stock has been reduced
     expect(8)->toBe($product->fresh()->variant('Red_Small')->stock());
@@ -1649,7 +1649,7 @@ test('cant post checkout when variant product has no stock', function () {
 
     $this->assertNotSame($order->fresh()->status(), OrderStatus::Placed);
     $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
-    expect($order->statusLog('paid'))->toBeNull();
+    expect($order->statusLogIncludes(PaymentStatus::Paid))->toBeFalse();
 
     // Asset the stock is the same (it hasn't been reduced yet because the
     // checkout failed at the validation stage)
@@ -1727,7 +1727,7 @@ test('can post checkout when variant product has a single item left in stock and
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert stock has been reduced
     expect(0)->toBe($product->fresh()->variant('Red_Small')->stock());
@@ -1787,7 +1787,7 @@ test('can post checkout and ensure remaining request data is saved to order', fu
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert that the 'extra remaining data' has been saved to the order
     expect('I like jam on toast!')->toBe($order->get('gift_note'));
@@ -1847,7 +1847,7 @@ test('cant post checkout and ensure remaining request data is saved to order if 
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert that the 'extra remaining data' has been saved to the order
     expect('I like jam on toast!')->toBe($order->get('gift_note'));
@@ -1898,7 +1898,7 @@ test('can post checkout with no payment information on free order', function () 
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Finally, assert order is no longer attached to the users' session
     expect(session()->has('simple-commerce-cart'))->toBeFalse();
@@ -1945,7 +1945,7 @@ test('cant post checkout with no payment information on paid order', function ()
 
     $this->assertNotSame($order->fresh()->status(), OrderStatus::Placed);
     $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
-    expect($order->statusLog('paid'))->toBeNull();
+    expect($order->statusLogIncludes(PaymentStatus::Paid))->toBeFalse();
 
     // Finally, assert order is no longer attached to the users' session
     expect(session()->has('simple-commerce-cart'))->toBeTrue();
@@ -1989,7 +1989,7 @@ test('cant post checkout with no gateway in request', function () {
 
     $this->assertNotSame($order->fresh()->status(), OrderStatus::Placed);
     $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
-    expect($order->statusLog('paid'))->toBeNull();
+    expect($order->statusLogIncludes(PaymentStatus::Paid))->toBeFalse();
 
     // Finally, assert order is no longer attached to the users' session
     expect(session()->has('simple-commerce-cart'))->toBeTrue();
@@ -2034,7 +2034,7 @@ test('cant post checkout with invalid gateway in request', function () {
 
     $this->assertNotSame($order->fresh()->status(), OrderStatus::Placed);
     $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
-    expect($order->statusLog('paid'))->toBeNull();
+    expect($order->statusLogIncludes(PaymentStatus::Paid))->toBeFalse();
 
     // Finally, assert order is no longer attached to the users' session
     expect(session()->has('simple-commerce-cart'))->toBeTrue();
@@ -2087,7 +2087,7 @@ test('can post checkout requesting json and ensure json is returned', function (
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert customer has been created with provided details
     $this->assertNotNull($order->customer());
@@ -2143,7 +2143,7 @@ test('can post checkout and ensure user is redirected', function () {
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert customer has been created with provided details
     $this->assertNotNull($order->customer());
@@ -2213,7 +2213,7 @@ test('can post checkout and ensure order paid notifications are sent', function 
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Finally, assert order is no longer attached to the users' session
     expect(session()->has('simple-commerce-cart'))->toBeFalse();
@@ -2264,7 +2264,7 @@ test('can post checkout and ensure temp gateway data is tidied up', function () 
 
     expect(OrderStatus::Placed)->toBe($order->fresh()->status());
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
-    $this->assertNotNull($order->statusLog('paid'));
+    $this->assertNotNull($order->statusLogIncludes(PaymentStatus::Paid));
 
     // Assert order is no longer attached to the users' session
     expect(session()->has('simple-commerce-cart'))->toBeFalse();
@@ -2318,7 +2318,7 @@ test('can post checkout and ensure gateway validation rules are used', function 
 
     $this->assertNotSame($order->fresh()->status(), OrderStatus::Placed);
     $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
-    expect($order->statusLog('paid'))->toBeNull();
+    expect($order->statusLogIncludes(PaymentStatus::Paid))->toBeFalse();
 
     // Finally, assert order is no longer attached to the users' session
     expect(session()->has('simple-commerce-cart'))->toBeTrue();
@@ -2365,7 +2365,7 @@ test('can post checkout and ensure gateway errors are handled correctly', functi
 
     $this->assertNotSame($order->fresh()->status(), OrderStatus::Placed);
     $this->assertNotSame($order->fresh()->paymentStatus(), PaymentStatus::Paid);
-    expect($order->statusLog('paid'))->toBeNull();
+    expect($order->statusLogIncludes(PaymentStatus::Paid))->toBeFalse();
 
     // Finally, assert order is no longer attached to the users' session
     expect(session()->has('simple-commerce-cart'))->toBeTrue();


### PR DESCRIPTION
This pull request makes some improvements to the Status Log that keeps track of status changes on orders.

## Changes to the format

Currently, an order's status log is stored like this:

```yaml
status_log:
  paid: '2023-12-21 00:56'
  placed: '2023-12-21 00:56'
```

This is *fine*. However, it comes with one main downside: there's no way of storing status-related metadata, like who updated an order's status or why.

This PR fixes that by changing the format the status log is saved in. Here's how the `status_log` is saved after this change:

```yaml
status_log:
  -
    status: paid
    timestamp: 1703120160
    data: { }
  -
    status: placed
    timestamp: 1703120160
    data: { }
```

In order to avoid introducing breaking changes, Simple Commerce will continue to *read* the old format, then whenever status changes happen, the status log will be saved in its new format.

## Changes to the "Update Order Status" action

This PR adds a new "Reason" field to the "Update Order Status" action. This is an optional text field where additional context can be provided about a status change, which will be visible in the order's status log (which is coming soon! 👀 ).

![CleanShot 2023-12-22 at 00 10 40](https://github.com/duncanmcclean/simple-commerce/assets/19637309/841f79e0-f18b-4b01-87cb-277238715370)

## API Changes

If you were using the PHP API for getting status log information, you'll notice a few things have changed:

* The `->statusLog()` method will now return a collection of `StatusLogEvent` objects, instead of an array as was returned previously.
* For now, you can continue to provide a `$key` to the `statusLog` method to get the relevant timestamp (`->statusLog('paid')`). This parameter will be removed in v6.
* Not related to the PHP API but if you were doing `->get('status_log')`, you'll need to change your code to handle both the old & new formats. 

## To Do

* [x] Fix failing tests
* [x] Refactor status log events into `StatusLogEvent` DTO
* [x] Fix "Status Log" fieldtype
* [x] Update Order Status action
    * [x] Log the user against the change
    * [x] Allow user to optionally provide a reason for updating the order status
* [x] Provide backwards compatibility for passing parameter to the `statusLog` method.