### PR TITLE
[5.x] Add "Order Date" field to Orders

### DIFF
--- a/src/Console/Commands/stubs/runway_order_blueprint.yaml
+++ b/src/Console/Commands/stubs/runway_order_blueprint.yaml
@@ -299,6 +299,23 @@ tabs:
     display: Sidebar
     sections:
       - fields:
+          - handle: order_date
+            field:
+              mode: single
+              inline: false
+              full_width: false
+              columns: 1
+              rows: 1
+              time_enabled: false
+              time_seconds_enabled: false
+              type: date
+              display: 'Order Date'
+              icon: date
+              listable: true
+              instructions_position: above
+              visibility: read_only
+              replicator_preview: true
+              hide_display: false
           - handle: order_status
             field:
               type: order_status

--- a/src/Listeners/EnforceEntryBlueprintFields.php
+++ b/src/Listeners/EnforceEntryBlueprintFields.php
@@ -130,6 +130,15 @@ class EnforceEntryBlueprintFields
             'save_zero_value' => true,
         ]);
 
+        $event->blueprint->ensureField('order_date', [
+            'type' => 'date',
+            'display' => 'Order Date',
+            'mode' => 'single',
+            'time_enabled' => false,
+            'listable' => true,
+            'visibility' => 'read_only',
+        ], 'sidebar');
+
         $event->blueprint->ensureField('order_status', [
             'type' => 'order_status',
             'display' => 'Order Status',

--- a/src/Orders/OrderModel.php
+++ b/src/Orders/OrderModel.php
@@ -4,9 +4,13 @@ namespace DoubleThreeDigital\SimpleCommerce\Orders;
 
 use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
 use DoubleThreeDigital\SimpleCommerce\Customers\CustomerModel;
+use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderFacade;
+use Illuminate\Support\Carbon;
 
 class OrderModel extends Model
 {
@@ -32,5 +36,20 @@ class OrderModel extends Model
     public function customer(): BelongsTo
     {
         return $this->belongsTo(CustomerModel::class);
+    }
+
+    public function orderDate(): Attribute
+    {
+        return Attribute::make(
+            get: function () {
+                try {
+                    $order = OrderFacade::find($this->id);
+
+                    return $order->statusLog()->where('status', OrderStatus::Placed)->map->date()->last();
+                } catch (OrderNotFound $e) {
+                    return Carbon::now();
+                }
+            },
+        );
     }
 }

--- a/src/Orders/OrderModel.php
+++ b/src/Orders/OrderModel.php
@@ -5,11 +5,11 @@ namespace DoubleThreeDigital\SimpleCommerce\Orders;
 use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
 use DoubleThreeDigital\SimpleCommerce\Customers\CustomerModel;
 use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
+use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderFacade;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderFacade;
 use Illuminate\Support\Carbon;
 
 class OrderModel extends Model

--- a/tests/ComputedValuesTest.php
+++ b/tests/ComputedValuesTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use Illuminate\Support\Carbon;
 
 uses(DoubleThreeDigital\SimpleCommerce\Tests\TestCase::class);
 uses(SetupCollections::class);
@@ -11,4 +13,13 @@ test('product returns with raw price value', function () {
     $product->save();
 
     expect($product->resource()->raw_price)->toBe(1500);
+});
+
+test('order returns with order date value', function () {
+    $order = Order::make()->set('status_log', [
+        ['status' => 'placed', 'timestamp' => Carbon::parse('1st January 2023')->timestamp, 'data' => []],
+    ]);
+    $order->save();
+
+    expect($order->resource()->order_date->format('Y-m-d'))->toBe('2023-01-01');
 });


### PR DESCRIPTION
This pull request adds back the "Order Date" field to Orders after it was unintentionally removed in v5 as part of the order status refactor.

The "Order Date" will come from the order's status log. It'll use the date the order was moved into the "Placed" status.

Related: #947 & #896