### PR TITLE
[5.x] Coupon UI Improvements & Add 'Start Date' to coupons

### DIFF
--- a/resources/js/components/Fieldtypes/CouponSummaryFieldtype.vue
+++ b/resources/js/components/Fieldtypes/CouponSummaryFieldtype.vue
@@ -1,0 +1,65 @@
+<template>
+    <div>
+        <ul class="list-disc pl-6">
+            <li v-if="values.type === 'fixed' && values.value && values.value.value !== null" class="text-sm mb-1.5">
+                <span class="font-semibold" v-text="formatCurrency(values.value.value)"></span> off entire order
+            </li>
+
+            <li v-if="values.type === 'percentage' && values.value && values.value.value !== null" class="text-sm mb-1.5">
+                <span class="font-semibold" v-text="`${values.value.value}%`"></span> off entire order
+            </li>
+
+            <li v-if="values.minimum_cart_value" class="text-sm mb-1.5">
+                Redeemable when items total is above <span v-text="formatCurrency(this.values.minimum_cart_value)"></span>
+            </li>
+
+            <li v-if="values.customer_eligibility === 'all'" class="text-sm mb-1.5">
+                {{ __(`Redeemable by all customers`) }}
+            </li>
+
+            <li v-if="values.customer_eligibility === 'specific_customers'" class="text-sm mb-1.5">
+                Only redeemable by specific customers
+            </li>
+
+            <li v-if="values.maximum_uses" class="text-sm mb-1.5">
+                Can only be used {{ values.maximum_uses }} times
+            </li>
+
+            <li v-if="values.products.length > 0" class="text-sm mb-1.5">
+                Can only be used when certain products are part of the order
+            </li>
+
+            <li v-if="values.expires_at?.date" class="text-sm mb-1.5">
+                Redeemable after {{ values.valid_from.date }}
+            </li>
+
+            <li v-if="values.expires_at?.date" class="text-sm mb-1.5">
+                Redeemable until {{ values.expires_at.date }}
+            </li>
+        </ul>
+    </div>
+</template>
+
+<script>
+import { __ } from '../../../../vendor/statamic/cms/resources/js/bootstrap/globals'
+
+export default {
+    name: 'CouponSummaryFieldtype',
+
+    mixins: [Fieldtype],
+
+    inject: ['storeName'],
+
+    computed: {
+        values() {
+            return Statamic.$store.state.publish[this.storeName].values
+        },
+    },
+
+    methods: {
+        formatCurrency(amount) {
+            return this.meta.currency.symbol + amount
+        },
+    }
+}
+</script>

--- a/resources/js/cp.js
+++ b/resources/js/cp.js
@@ -1,6 +1,7 @@
 // Fieldtypes
 
 import CouponCodeFieldtype from './components/Fieldtypes/CouponCodeFieldtype.vue'
+import CouponSummaryFieldtype from './components/Fieldtypes/CouponSummaryFieldtype.vue'
 import CouponValueFieldtype from './components/Fieldtypes/CouponValueFieldtype.vue'
 import GatewayFieldtype from './components/Fieldtypes/GatewayFieldtype.vue'
 import MoneyFieldtype from './components/Fieldtypes/MoneyFieldtype.vue'
@@ -13,6 +14,7 @@ import ProductVariantsFildtype from './components/Fieldtypes/ProductVariants/Pro
 import StatusLogFieldtype from './components/Fieldtypes/StatusLogFieldtype.vue'
 
 Statamic.$components.register('coupon-code-fieldtype', CouponCodeFieldtype)
+Statamic.$components.register('coupon-summary-fieldtype', CouponSummaryFieldtype)
 Statamic.$components.register('coupon-value-fieldtype', CouponValueFieldtype)
 Statamic.$components.register('gateway-fieldtype', GatewayFieldtype)
 Statamic.$components.register('money-fieldtype', MoneyFieldtype)

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -110,6 +110,12 @@ class Coupon implements Contract
             return false;
         }
 
+        if ($this->get('valid_from') !== null) {
+            if (Carbon::parse($this->get('valid_from'))->isFuture()) {
+                return false;
+            }
+        }
+
         if ($this->has('expires_at') && $this->get('expires_at') !== null) {
             if (Carbon::parse($this->get('expires_at'))->isPast()) {
                 return false;

--- a/src/Coupons/CouponBlueprint.php
+++ b/src/Coupons/CouponBlueprint.php
@@ -15,33 +15,36 @@ class CouponBlueprint
         $customerField = [
             'mode' => 'default',
             'collections' => [
-                'customers',
+                config('simple-commerce.content.customers.collection', 'customers'),
             ],
-            'display' => __('Customers'),
+            'display' => __('Specific Customers'),
             'type' => 'entries',
             'icon' => 'entries',
-            'instructions' => __('If selected, this coupon will only be valid for selected customers.'),
-            'width' => 50,
+            'if' => [
+                'customer_eligibility' => 'specific_customers',
+            ],
         ];
 
         if (self::isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], UserCustomerRepository::class)) {
             $customerField = [
                 'mode' => 'default',
-                'display' => __('Customers'),
+                'display' => __('Specific Customers'),
                 'type' => 'users',
                 'icon' => 'users',
-                'instructions' => __('If selected, this coupon will only be valid for selected customers.'),
-                'width' => 50,
+                'if' => [
+                    'customer_eligibility' => 'specific_customers',
+                ],
             ];
         }
 
         if (self::isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], EloquentCustomerRepository::class)) {
             $customerField = [
                 'type' => 'has_many',
-                'instructions' => __('If selected, this coupon will only be valid for selected customers.'),
-                'display' => __('Customers'),
-                'width' => 50,
+                'display' => __('Specific Customers'),
                 'resource' => 'customers',
+                'if' => [
+                    'customer_eligibility' => 'specific_customers',
+                ],
             ];
         }
 
@@ -58,7 +61,7 @@ class CouponBlueprint
                                         'display' => __('Coupon Code'),
                                         'validate' => ['required'],
                                         'listable' => true,
-                                        'instructions' => __('Customers will use this code to redeem the coupon.'),
+                                        'instructions' => __('Customers will enter this code to redeem the coupon.'),
                                     ],
                                 ],
                                 [
@@ -70,6 +73,11 @@ class CouponBlueprint
                                         'listable' => true,
                                     ],
                                 ],
+                            ],
+                        ],
+                        [
+                            'display' => __('Options'),
+                            'fields' => [
                                 [
                                     'handle' => 'type',
                                     'field' => [
@@ -87,9 +95,7 @@ class CouponBlueprint
                                         'type' => 'select',
                                         'display' => 'Type',
                                         'width' => 50,
-                                        'validate' => [
-                                            'required',
-                                        ],
+                                        'validate' => ['required'],
                                         'listable' => true,
                                         'max_items' => 1,
                                     ],
@@ -100,34 +106,60 @@ class CouponBlueprint
                                         'type' => 'coupon_value',
                                         'display' => __('Value'),
                                         'width' => 50,
-                                        'validate' => [
-                                            'required',
-                                        ],
+                                        'validate' => ['required',],
                                         'listable' => true,
                                     ],
                                 ],
                             ],
                         ],
                         [
-                            'display' => __('Optional Settings'),
+                            'display' => __('Minimum Requirements'),
+                            'fields' => [
+                                [
+                                    'handle' => 'minimum_cart_value',
+                                    'field' => [
+                                        'type' => 'money',
+                                        'instructions' => __("The minimum value the customer's cart should have before this coupon can be redeemed."),
+                                        'width' => 50,
+                                        'display' => __('Minimum Order Value'),
+                                        'listable' => 'hidden',
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'display' => __('Customer Eligibility'),
+                            'fields' => [
+                                [
+                                    'handle' => 'customer_eligibility',
+                                    'field' => [
+                                        'options' => [
+                                            'all' => __('All'),
+                                            'specific_customers' => __('Specific customers'),
+                                        ],
+                                        'inline' => false,
+                                        'type' => 'radio',
+                                        'display' => __('Which customers are eligible for this coupon?'),
+                                        'validate' => ['required'],
+                                        'default' => 'all',
+                                    ],
+                                ],
+                                [
+                                    'handle' => 'customers',
+                                    'field' => $customerField,
+                                ],
+                            ],
+                        ],
+                        [
+                            'display' => __('Usage Limits'),
                             'fields' => [
                                 [
                                     'handle' => 'maximum_uses',
                                     'field' => [
                                         'type' => 'integer',
-                                        'instructions' => __('If set, this coupon will only be able to be used a certain amount of times.'),
                                         'width' => 50,
-                                        'display' => __('Maximum Uses'),
-                                        'listable' => 'hidden',
-                                    ],
-                                ],
-                                [
-                                    'handle' => 'minimum_cart_value',
-                                    'field' => [
-                                        'type' => 'money',
-                                        'instructions' => __("What's the minimum items total a cart should have before this coupon can be redeemed?"),
-                                        'width' => 50,
-                                        'display' => __('Minimum Cart Value'),
+                                        'display' => __('Maximum times coupon can be redeemed'),
+                                        'instructions' => __('By default, coupons can be redeemed an unlimited amount of times. You can set a maximum here if you wish.'),
                                         'listable' => 'hidden',
                                     ],
                                 ],
@@ -136,43 +168,59 @@ class CouponBlueprint
                                     'field' => [
                                         'mode' => 'default',
                                         'collections' => [
-                                            config('simple-commerce.content.products.collection', 'product'),
+                                            config('simple-commerce.content.products.collection', 'products'),
                                         ],
-                                        'display' => __('Products'),
+                                        'display' => __('Limit to certain products'),
+                                        'instructions' => __('This coupon will only be redeemable when *any* of these products are present in the order.'),
                                         'type' => 'entries',
                                         'icon' => 'entries',
-                                        'width' => 50,
-                                        'instructions' => __('If selected, this coupon will only be valid when any of the products are present.'),
-                                        'listable' => 'hidden',
-                                    ],
-                                ],
-                                [
-                                    'handle' => 'customers',
-                                    'field' => $customerField,
-                                ],
-                                [
-                                    'handle' => 'expires_at',
-                                    'field' => [
-                                        'type' => 'date',
-                                        'display' => __('Expires At'),
-                                        'instructions' => __('If defined, this coupon will no longer be redeemable after the expiry date.'),
                                         'width' => 50,
                                         'listable' => 'hidden',
                                     ],
                                 ],
                             ],
                         ],
+                        [
+                            'display' => __('Active Dates'),
+                            'instructions' => __('Configure when this coupon is active. Leave both dates blank to make the coupon active indefinitely.'),
+                            'fields' => [
+                                [
+                                    'handle' => 'valid_from',
+                                    'field' => [
+                                        'type' => 'date',
+                                        'display' => __('Start Date'),
+                                        'width' => 50,
+                                        'listable' => 'hidden',
+                                    ],
+                                ],
+                                [
+                                    'handle' => 'expires_at',
+                                    'field' => [
+                                        'type' => 'date',
+                                        'display' => __('End Date'),
+                                        'width' => 50,
+                                        'listable' => 'hidden',
+                                    ],
+                                ],
+                            ],
+                        ]
                     ],
                 ],
                 'sidebar' => [
                     'sections' => [
                         [
                             'fields' => [
+                                ['handle' => 'summary', 'field' => ['type' => 'coupon_summary']],
+                            ],
+                        ],
+                        [
+                            'fields' => [
+                                // TODO: Remove this 'Enabled' state in favour of the start/end dates.
                                 [
                                     'handle' => 'enabled',
                                     'field' => [
                                         'type' => 'toggle',
-                                        'instructions' => __('When disabled, this coupon will not be redeemable.'),
+                                        'instructions' => __('When disabled, this coupon will not be able to be redeemed. This setting overrides other settings.'),
                                         'default' => true,
                                         'listable' => 'hidden',
                                         'display' => __('Enabled?'),
@@ -182,9 +230,9 @@ class CouponBlueprint
                                     'handle' => 'redeemed',
                                     'field' => [
                                         'type' => 'integer',
-                                        'instructions' => __('Amount of times this coupon has been redeemed.'),
-                                        'display' => __('Redeemed'),
-                                        'read_only' => true,
+                                        'display' => __('Redemptions'),
+                                        'instructions' => __('The number of times this coupon has been redeemed.'),
+                                        'visibility' => 'read_only',
                                         'default' => 0,
                                         'listable' => 'hidden',
                                     ],

--- a/src/Coupons/CouponBlueprint.php
+++ b/src/Coupons/CouponBlueprint.php
@@ -106,7 +106,7 @@ class CouponBlueprint
                                         'type' => 'coupon_value',
                                         'display' => __('Value'),
                                         'width' => 50,
-                                        'validate' => ['required',],
+                                        'validate' => ['required'],
                                         'listable' => true,
                                     ],
                                 ],
@@ -203,7 +203,7 @@ class CouponBlueprint
                                     ],
                                 ],
                             ],
-                        ]
+                        ],
                     ],
                 ],
                 'sidebar' => [

--- a/src/Fieldtypes/CouponSummaryFieldtype.php
+++ b/src/Fieldtypes/CouponSummaryFieldtype.php
@@ -9,6 +9,7 @@ use Statamic\Fields\Fieldtype;
 class CouponSummaryFieldtype extends Fieldtype
 {
     protected $selectable = false;
+
     protected $component = 'coupon-summary';
 
     public function preload()

--- a/src/Fieldtypes/CouponSummaryFieldtype.php
+++ b/src/Fieldtypes/CouponSummaryFieldtype.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+
+use DoubleThreeDigital\SimpleCommerce\Currency;
+use Statamic\Facades\Site;
+use Statamic\Fields\Fieldtype;
+
+class CouponSummaryFieldtype extends Fieldtype
+{
+    protected $selectable = false;
+    protected $component = 'coupon-summary';
+
+    public function preload()
+    {
+        return [
+            'currency' => Currency::get(Site::current()),
+        ];
+    }
+}

--- a/src/Http/Controllers/CP/Coupons/CouponController.php
+++ b/src/Http/Controllers/CP/Coupons/CouponController.php
@@ -51,6 +51,7 @@ class CouponController
     public function create(CreateRequest $request)
     {
         $blueprint = CouponBlueprint::getBlueprint();
+        $blueprint = $blueprint->removeField('redeemed');
 
         $fields = $blueprint->fields();
         $fields = $fields->preProcess();

--- a/src/Http/Requests/CP/Coupon/StoreRequest.php
+++ b/src/Http/Requests/CP/Coupon/StoreRequest.php
@@ -67,9 +67,25 @@ class StoreRequest extends FormRequest
                 'nullable',
                 'array',
             ],
+            'customer_eligibility' => [
+                'nullable',
+                'string',
+                Rule::in(['all', 'specific_customers']),
+            ],
             'customers' => [
                 'nullable',
                 'array',
+            ],
+            'valid_from' => [
+                'nullable',
+                'array',
+            ],
+            'valid_from.date' => [
+                'nullable',
+                'date',
+            ],
+            'valid_from.time' => [
+                'nullable',
             ],
             'expires_at' => [
                 'nullable',

--- a/src/Http/Requests/CP/Coupon/UpdateRequest.php
+++ b/src/Http/Requests/CP/Coupon/UpdateRequest.php
@@ -61,9 +61,25 @@ class UpdateRequest extends FormRequest
                 'nullable',
                 'array',
             ],
+            'customer_eligibility' => [
+                'nullable',
+                'string',
+                Rule::in(['all', 'specific_customers']),
+            ],
             'customers' => [
                 'nullable',
                 'array',
+            ],
+            'valid_from' => [
+                'nullable',
+                'array',
+            ],
+            'valid_from.date' => [
+                'nullable',
+                'date',
+            ],
+            'valid_from.time' => [
+                'nullable',
             ],
             'expires_at' => [
                 'nullable',

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -45,6 +45,7 @@ class ServiceProvider extends AddonServiceProvider
         Fieldtypes\CountryFieldtype::class,
         Fieldtypes\CouponCodeFieldtype::class,
         Fieldtypes\CouponFieldtype::class,
+        Fieldtypes\CouponSummaryFieldtype::class,
         Fieldtypes\CouponValueFieldtype::class,
         Fieldtypes\GatewayFieldtype::class,
         Fieldtypes\MoneyFieldtype::class,
@@ -119,6 +120,7 @@ class ServiceProvider extends AddonServiceProvider
         UpdateScripts\v5_0\UpdateNotificationsConfig::class,
         UpdateScripts\v5_0\UpdateOrderBlueprint::class,
         UpdateScripts\v5_0\CreateShippingTaxCategory::class,
+        UpdateScripts\v5_0\MigrateCouponsAfterUiUpdates::class,
     ];
 
     protected $vite = [

--- a/src/UpdateScripts/v5_0/MigrateCouponsAfterUiUpdates.php
+++ b/src/UpdateScripts/v5_0/MigrateCouponsAfterUiUpdates.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v5_0;
+
+use DoubleThreeDigital\SimpleCommerce\Contracts\Coupon as CouponContract;
+use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
+use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
+use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Statamic\UpdateScripts\UpdateScript;
+
+class MigrateCouponsAfterUiUpdates extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('5.9.0');
+    }
+
+    public function update()
+    {
+        Coupon::all()
+            ->filter(function (CouponContract $coupon) {
+                return $coupon->has('customers');
+            })
+            ->each(function (CouponContract $coupon) {
+                $coupon
+                    ->set('customer_eligibility', 'specific_customers')
+                    ->save();
+            });
+    }
+}

--- a/src/UpdateScripts/v5_0/MigrateCouponsAfterUiUpdates.php
+++ b/src/UpdateScripts/v5_0/MigrateCouponsAfterUiUpdates.php
@@ -4,9 +4,6 @@ namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v5_0;
 
 use DoubleThreeDigital\SimpleCommerce\Contracts\Coupon as CouponContract;
 use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Statamic\UpdateScripts\UpdateScript;
 
 class MigrateCouponsAfterUiUpdates extends UpdateScript

--- a/tests/Coupons/CouponTest.php
+++ b/tests/Coupons/CouponTest.php
@@ -260,6 +260,28 @@ test('is not valid when coupon is disabled', function () {
     expect($isValid)->toBeFalse();
 });
 
+test('is not valid before coupon valid_from timestamp', function () {
+    [$product, $order] = buildCartWithProducts();
+
+    $coupon = Coupon::make()
+        ->id(Stache::generateId())
+        ->code('halv-price')
+        ->value(50)
+        ->type('percentage')
+        ->data([
+            'description' => 'Halv Price',
+            'redeemed' => 0,
+            'minimum_cart_value' => null,
+            'valid_from' => '2030-01-01',
+        ]);
+
+    $coupon->save();
+
+    $isValid = $coupon->isValid($order);
+
+    expect($isValid)->toBeFalse();
+});
+
 test('is not valid after coupon has expired', function () {
     [$product, $order] = buildCartWithProducts();
 


### PR DESCRIPTION
This pull request makes some major improvements to the Coupons UI in the Control Panel. 

* Primarily, changes have been made to the coupon blueprint making it easier to configure any settings/conditions for coupons. 
* A new "Summary" has also been introduced in the sidebar, providing a short & sweet summary of the discount, who can redeem it and when it can be redeemed.
* This PR also introduces a new "Start Date" (`valid_from`) field for coupons so you can configure when a coupon starts being valid.

![CleanShot 2024-01-02 at 10 42 52](https://github.com/duncanmcclean/simple-commerce/assets/19637309/4a4c938b-ce18-4012-b64e-f4446ad01e49)
![CleanShot 2024-01-02 at 10 43 07](https://github.com/duncanmcclean/simple-commerce/assets/19637309/f78187e8-fdc5-42cd-a1aa-0500222f5787)

