### PR TITLE
[5.x] Coupons: Whitelist coupons by domains

### DIFF
--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -145,8 +145,15 @@ class Coupon implements Contract
         }
 
         if ($this->isCustomerSpecific()) {
-            $isCustomerAllowed = collect($this->get('customers'))
-                ->contains(optional($order->customer())->id());
+            $isCustomerAllowed = collect($this->get('customers'))->contains(optional($order->customer())->id());
+
+            if (! $isCustomerAllowed) {
+                return false;
+            }
+        }
+
+        if ($domains = $this->get('customers_by_domain')) {
+            $isCustomerAllowed = collect($domains)->contains(optional($order->customer())->email());
 
             if (! $isCustomerAllowed) {
                 return false;

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -8,13 +8,13 @@ use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use DoubleThreeDigital\SimpleCommerce\Currency;
 use DoubleThreeDigital\SimpleCommerce\Facades\Coupon as CouponFacade;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderFacade;
+use Illuminate\Support\Str;
 use Statamic\Data\ContainsData;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Data\TracksQueriedColumns;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
-use Illuminate\Support\Str;
 
 class Coupon implements Contract
 {

--- a/src/Coupons/CouponBlueprint.php
+++ b/src/Coupons/CouponBlueprint.php
@@ -136,6 +136,7 @@ class CouponBlueprint
                                         'options' => [
                                             'all' => __('All'),
                                             'specific_customers' => __('Specific customers'),
+                                            'customers_by_domain' => __('Specific customers (by domain)'),
                                         ],
                                         'inline' => false,
                                         'type' => 'radio',
@@ -148,6 +149,18 @@ class CouponBlueprint
                                     'handle' => 'customers',
                                     'field' => $customerField,
                                 ],
+                                [
+                                    'handle' => 'customers_by_domain',
+                                    'field' => [
+                                        'type' => 'list',
+                                        'display' => __('Domains'),
+                                        'instructions' => __('Provide a list of domains that are eligible for this coupon. One per line.'),
+                                        'add_button' => __('Add Domain'),
+                                        'if' => [
+                                            'customer_eligibility' => 'customers_by_domain',
+                                        ],
+                                    ],
+                                ]
                             ],
                         ],
                         [

--- a/src/Coupons/CouponBlueprint.php
+++ b/src/Coupons/CouponBlueprint.php
@@ -160,7 +160,7 @@ class CouponBlueprint
                                             'customer_eligibility' => 'customers_by_domain',
                                         ],
                                     ],
-                                ]
+                                ],
                             ],
                         ],
                         [

--- a/src/Http/Requests/CP/Coupon/StoreRequest.php
+++ b/src/Http/Requests/CP/Coupon/StoreRequest.php
@@ -70,11 +70,20 @@ class StoreRequest extends FormRequest
             'customer_eligibility' => [
                 'nullable',
                 'string',
-                Rule::in(['all', 'specific_customers']),
+                Rule::in(['all', 'specific_customers', 'customers_by_domain']),
             ],
             'customers' => [
-                'nullable',
+                'required_if:customer_eligibility,specific_customers',
                 'array',
+            ],
+            'customers_by_domain' => [
+                'required_if:customer_eligibility,customers_by_domain',
+                'array',
+            ],
+            'customers_by_domain.*' => [
+                'required',
+                'string',
+                'regex:/^[^@]*$/',
             ],
             'valid_from' => [
                 'nullable',

--- a/src/Http/Requests/CP/Coupon/UpdateRequest.php
+++ b/src/Http/Requests/CP/Coupon/UpdateRequest.php
@@ -64,11 +64,20 @@ class UpdateRequest extends FormRequest
             'customer_eligibility' => [
                 'nullable',
                 'string',
-                Rule::in(['all', 'specific_customers']),
+                Rule::in(['all', 'specific_customers', 'customers_by_domain']),
             ],
             'customers' => [
-                'nullable',
+                'required_if:customer_eligibility,specific_customers',
                 'array',
+            ],
+            'customers_by_domain' => [
+                'required_if:customer_eligibility,customers_by_domain',
+                'array',
+            ],
+            'customers_by_domain.*' => [
+                'required',
+                'string',
+                'regex:/^[^@]*$/',
             ],
             'valid_from' => [
                 'nullable',

--- a/tests/Coupons/CouponTest.php
+++ b/tests/Coupons/CouponTest.php
@@ -303,3 +303,67 @@ test('is not valid after coupon has expired', function () {
 
     expect($isValid)->toBeFalse();
 });
+
+test('is valid for customer where email matches domain', function () {
+    [$product, $order] = buildCartWithProducts();
+
+    $customer = Customer::make()
+        ->email('john@example.com')
+        ->data(['name' => 'John Doe'])
+        ->save();
+
+    $order->customer($customer->id());
+    $order->save();
+
+    $coupon = Coupon::make()
+        ->id(Stache::generateId())
+        ->code('halv-price')
+        ->value(50)
+        ->type('percentage')
+        ->data([
+            'description' => 'Halv Price',
+            'redeemed' => 0,
+            'minimum_cart_value' => null,
+            'customers_by_domain' => [
+                'example.com',
+            ],
+        ]);
+
+    $coupon->save();
+
+    $isValid = $coupon->isValid($order);
+
+    expect($isValid)->toBeTrue();
+});
+
+test('is not valid for customer where email does not match domain', function () {
+    [$product, $order] = buildCartWithProducts();
+
+    $customer = Customer::make()
+        ->email('john@example.com')
+        ->data(['name' => 'John Doe'])
+        ->save();
+
+    $order->customer($customer->id());
+    $order->save();
+
+    $coupon = Coupon::make()
+        ->id(Stache::generateId())
+        ->code('halv-price')
+        ->value(50)
+        ->type('percentage')
+        ->data([
+            'description' => 'Halv Price',
+            'redeemed' => 0,
+            'minimum_cart_value' => null,
+            'customers_by_domain' => [
+                'doublethree.digital',
+            ],
+        ]);
+
+    $coupon->save();
+
+    $isValid = $coupon->isValid($order);
+
+    expect($isValid)->toBeFalse();
+});

--- a/tests/Coupons/CouponTest.php
+++ b/tests/Coupons/CouponTest.php
@@ -195,6 +195,7 @@ test('is valid when limited to certain customers and current customer is in allo
             'description' => 'Hof Price',
             'redeemed' => 0,
             'minimum_cart_value' => null,
+            'customer_eligibility' => 'specific_customers',
             'customers' => [$customer->id],
         ]);
 
@@ -228,6 +229,7 @@ test('is not valid when limited to customers and current customer is not in allo
             'description' => 'Hof Price',
             'redeemed' => 0,
             'minimum_cart_value' => null,
+            'customer_eligibility' => 'specific_customers',
             'customers' => [$customer->id],
         ]);
 
@@ -324,6 +326,7 @@ test('is valid for customer where email matches domain', function () {
             'description' => 'Halv Price',
             'redeemed' => 0,
             'minimum_cart_value' => null,
+            'customer_eligibility' => 'customers_by_domain',
             'customers_by_domain' => [
                 'example.com',
             ],
@@ -356,6 +359,7 @@ test('is not valid for customer where email does not match domain', function () 
             'description' => 'Halv Price',
             'redeemed' => 0,
             'minimum_cart_value' => null,
+            'customer_eligibility' => 'customers_by_domain',
             'customers_by_domain' => [
                 'doublethree.digital',
             ],

--- a/tests/Http/Controllers/CP/CouponControllerTest.php
+++ b/tests/Http/Controllers/CP/CouponControllerTest.php
@@ -31,6 +31,7 @@ test('can store coupon', function () {
             'minimum_cart_value' => '65.00',
             'enabled' => true,
             'expires_at' => null,
+            'customer_eligibility' => 'all',
         ])
         ->assertJsonStructure([
             'redirect',
@@ -62,6 +63,7 @@ test('can store coupon with expiry date', function () {
                 'date' => '2024-01-01',
                 'time' => null,
             ],
+            'customer_eligibility' => 'all',
         ])
         ->assertJsonStructure([
             'redirect',
@@ -83,6 +85,7 @@ test('cant store coupon where a coupon already exists with the provided code', f
             'description' => 'Fifty Friday',
             'redeemed' => 0,
             'minimum_cart_value' => null,
+            'customer_eligibility' => 'all',
         ])
         ->save();
 
@@ -96,6 +99,7 @@ test('cant store coupon where a coupon already exists with the provided code', f
                 'value' => 30,
             ],
             'description' => '30% discount on a Tuesday!',
+            'customer_eligibility' => 'all',
         ])
         ->assertSessionHasErrors('code');
 });
@@ -144,6 +148,7 @@ test('can update coupon', function () {
             'description' => 'Fifty Friday',
             'redeemed' => 0,
             'minimum_cart_value' => null,
+            'customer_eligibility' => 'all',
         ]);
 
     $coupon->save();
@@ -161,6 +166,7 @@ test('can update coupon', function () {
             'enabled' => false,
             'minimum_cart_value' => '76.00',
             'expires_at' => null,
+            'customer_eligibility' => 'all',
         ])
         ->assertJsonStructure([
             'coupon',
@@ -184,6 +190,7 @@ test('can update coupon with expriry date', function () {
             'description' => 'Fifty Friday',
             'redeemed' => 0,
             'minimum_cart_value' => null,
+            'customer_eligibility' => 'all',
         ]);
 
     $coupon->save();
@@ -204,6 +211,7 @@ test('can update coupon with expriry date', function () {
                 'date' => '2024-01-01',
                 'time' => null,
             ],
+            'customer_eligibility' => 'all',
         ])
         ->assertJsonStructure([
             'coupon',
@@ -224,6 +232,7 @@ test('cant update coupon if type is percentage and value is greater than 100', f
             'description' => 'Fifty Friday',
             'redeemed' => 0,
             'minimum_cart_value' => null,
+            'customer_eligibility' => 'all',
         ]);
 
     $coupon->save();
@@ -238,6 +247,7 @@ test('cant update coupon if type is percentage and value is greater than 100', f
                 'value' => 110,
             ],
             'description' => 'You can actually get a 51% discount on Friday!',
+            'customer_eligibility' => 'all',
         ])
         ->assertSessionHasErrors('value.value');
 


### PR DESCRIPTION
This pull request implements the ability to whitelist customers by specifying domains for coupons, instead of selecting individual customers.

![CleanShot 2024-01-02 at 11 38 03](https://github.com/duncanmcclean/simple-commerce/assets/19637309/964c5d14-79bc-4da1-bd93-ebc722675157)

Requested in #920.