### PR TITLE
[6.x] Use authenticated user as customer

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,10 +2,13 @@
 
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Session;
 use Statamic\Facades\Parse;
 use Statamic\Facades\Stache;
 use Statamic\Facades\User;
+use Statamic\Statamic;
 
 uses(\DoubleThreeDigital\SimpleCommerce\Tests\TestCase::class)->in('Actions', 'Console', 'Coupons', 'Customers', 'Data', 'Fieldtypes', '__fixtures__', 'Gateways', 'Helpers', 'Http', 'Listeners', 'Modifiers', 'Orders', 'Rules', 'Tags', 'Tax');
 uses(\DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections::class)->in('Actions', 'Coupons', 'Listeners');
@@ -113,4 +116,32 @@ function fakeCart($cart = null)
         ->andReturn([]);
 
     return $cart;
+}
+
+function setupUserCustomerRepository(): void
+{
+    Config::set('simple-commerce.content.customers', [
+        'repository' => \DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository::class,
+    ]);
+
+    Statamic::repository(
+        \DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository::class,
+        \DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository::class
+    );
+
+    File::deleteDirectory(__DIR__.'/../__fixtures__/users');
+    app('stache')->stores()->get('users')->clear();
+}
+
+function tearDownUserCustomerRepository(): void
+{
+    Config::set('simple-commerce.content.customers', [
+        'repository' => \DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository::class,
+        'collection' => 'customers',
+    ]);
+
+    Statamic::repository(
+        \DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository::class,
+        \DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository::class
+    );
 }


### PR DESCRIPTION
This PR implements a change in behaviour when the following conditions are true:

* You're using [Statamic users as customers](https://simple-commerce.duncanmcclean.com/customers#content-users-driver)
* A user is currently logged in
* No customer is currently set on the order

Until now, in this situation, nothing happened. You would have to manually set the customer to be the current user.

However, with this PR, you'll no longer have to do that. Simple Commerce will pick up the fact the customer should be the currently logged in user & update the order like so whenever you submit any of the `{{ sc:cart }}` or `{{ sc:checkout }}` forms.

Related: https://github.com/duncanmcclean/simple-commerce/discussions/946