### PR TITLE
[5.x] Fix querying the status log

### DIFF
--- a/src/Fieldtypes/StatusLogFieldtype.php
+++ b/src/Fieldtypes/StatusLogFieldtype.php
@@ -36,8 +36,12 @@ class StatusLogFieldtype extends Fieldtype
     {
         // Support the old format for the status log. We can remove this in the future.
         if (! empty($value) && ! is_array(Arr::first($value))) {
-            return collect($value)->map(function ($timestamp, $status) {
-                return Carbon::parse($timestamp);
+            $value = collect($value)->map(function ($date, $status) {
+                return [
+                    'status' => $status,
+                    'timestamp' => Carbon::parse($date)->timestamp,
+                    'data' => [],
+                ];
             })->toArray();
         }
 

--- a/src/Fieldtypes/StatusLogFieldtype.php
+++ b/src/Fieldtypes/StatusLogFieldtype.php
@@ -50,8 +50,19 @@ class StatusLogFieldtype extends Fieldtype
         });
     }
 
+    /**
+     * Allows for querying the timestamp of a status (it'll query the latest timestamp for that status)
+     * Eg: `->whereDate('status_log->paid', '>', '2024-01-01')`
+     */
     public function toQueryableValue($value)
     {
-        return $this->augment($value);
+        return $this->augment($value)
+            ->groupBy(fn (StatusLogEvent $statusLogEvent) => $statusLogEvent->status->value)
+            ->map(function ($events) {
+                $latestEvent = $events->sortByDesc(fn (StatusLogEvent $statusLogEvent) => $statusLogEvent->date())->first();
+
+                return $latestEvent->date();
+            })
+            ->toArray();
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where the Status Log field couldn't be queried due to the new format introduced in #956.

After the changes in #956, querying the status log would result in nothing being returned because stuff was being returned in a different format than previously.

```php
// Used to work but doesn't after #956

Entry::query()
    ->where('collection', 'orders')
    ->whereDate('status_log->paid', '>=', '2024-01-01');
```

This PR essentially maps the new format into what was being returned first - where it's a key/value array with the status and timestamp. This allows for this:

If you have the same status repeated multiple times in your "status log", the latest event of that status will be the one used for querying. 