### PR TITLE
[6.x] Reference gateways & shipping methods by handles

### DIFF
--- a/docs/upgrade-guides/v5-x-to-v6-0.md
+++ b/docs/upgrade-guides/v5-x-to-v6-0.md
@@ -46,6 +46,28 @@ php artisan view:clear
 
 If you're storing orders & customers in the database, you should also follow the [Runway v6 Upgrade Guide](https://runway.duncanmcclean.com/upgrade-guides/v5-x-to-v6-0).
 
+## High: References to gateways & shipping methods in orders have changed
+
+Previously, when referencing a Payment Gateway or Shipping Method in an order, Simple Commerce would use its fully-qualified class name, like so:
+
+```yaml
+shipping_method: DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping
+```
+
+However, v6 changes this so Payment Gateways & Shipping Methods are now referenced by their handles:
+
+```yaml
+shipping_method: free_shipping
+```
+
+Simple Commerce *should* automatically update your orders. However, if it didn't or you need to run it manually after deploying (eg. your orders are excluded from version control or stored in a database), you can run this command to manually trigger the updates:
+
+```
+php please sc:update-class-references
+```
+
+If you're manually referencing gateway / shipping method class names anywhere, you should instead reference the handle. To determine if you're referencing class names, search for `{{ class }}` in your site's shipping & checkout pages and change any instances to `{{ handle }}`.
+
 ### Medium: The `all` method on repositories has changed
 
 If you have any custom code which calls `Order::all()`, `Product::all()` or `Customer::all()`, you may need to adjust your code.

--- a/src/Actions/RefundAction.php
+++ b/src/Actions/RefundAction.php
@@ -27,8 +27,7 @@ class RefundAction extends Action
         if (isset(SimpleCommerce::orderDriver()['model'])) {
             $orderModelClass = SimpleCommerce::orderDriver()['model'];
 
-            return $item instanceof $orderModelClass
-                && $item->payment_status === 'paid';
+            return $item instanceof $orderModelClass && $item->payment_status === 'paid';
         }
 
         return false;
@@ -45,7 +44,7 @@ class RefundAction extends Action
             ->each(function ($entry) {
                 $order = Order::find($entry->id);
 
-                return Gateway::use($order->currentGateway()['class'])
+                return Gateway::use($order->currentGateway()['handle'])
                     ->refund($order);
             });
     }

--- a/src/Console/Commands/UpdateClassReferences.php
+++ b/src/Console/Commands/UpdateClassReferences.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Console\Commands;
+
+use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
+use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
+use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
+use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Illuminate\Console\Command;
+use Statamic\Console\RunsInPlease;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+
+class UpdateClassReferences extends Command
+{
+    use RunsInPlease;
+
+    protected $name = 'sc:update-class-references';
+
+    protected $description = 'Part of the v6 update. Updates references to payment gateway & shipping method classes in orders.';
+
+    public function handle()
+    {
+        $this->info('Updating class references...');
+
+        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EntryOrderRepository::class)) {
+            Collection::find(SimpleCommerce::orderDriver()['collection'])
+                ->queryEntries()
+                ->where('gateway', '!=', null)
+                ->chunk(50, function ($orders) {
+                    $orders->each(function ($entry) {
+                        // When the gateway reference is still a class, change it to the handle.
+                        if (class_exists($entry->get('gateway')['use'])) {
+                            $entry->set('gateway', array_merge($entry->get('gateway'), [
+                                'use' => $entry->get('gateway')['use']::handle(),
+                            ]))->saveQuietly();
+                        }
+
+                        // When the shipping method reference is still a class, change it to the handle.
+                        if ($entry->has('shipping_method') && class_exists($entry->get('shipping_method'))) {
+                            $entry->set('shipping_method', $entry->get('shipping_method')::handle())->saveQuietly();
+                        }
+                    });
+                });
+        }
+
+        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EloquentOrderRepository::class)) {
+            OrderModel::query()
+                ->where('gateway', '!=', null)
+                ->chunk(50, function ($orders) {
+                    $orders->each(function ($order) {
+                        // When the gateway reference is still a class, change it to the handle.
+                        if (class_exists($order->gateway['use'])) {
+                            $order->gateway = array_merge($order->gateway, [
+                                'use' => $order->gateway['use']::handle(),
+                            ]);
+
+                            $order->saveQuietly();
+                        }
+
+                        // When the shipping method reference is still a class, change it to the handle.
+                        if (isset($order->data['shipping_method']) && class_exists($order->data['shipping_method'])) {
+                            $order->data['shipping_method'] = $order->data['shipping_method']::handle();
+
+                            $order->saveQuietly();
+                        }
+                    });
+                });
+        }
+    }
+
+    protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool
+    {
+        return is_subclass_of($class, $classToCheckAgainst)
+            || $class === $classToCheckAgainst;
+    }
+}

--- a/src/Console/Commands/UpdateClassReferences.php
+++ b/src/Console/Commands/UpdateClassReferences.php
@@ -5,12 +5,10 @@ namespace DoubleThreeDigital\SimpleCommerce\Console\Commands;
 use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
 use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Illuminate\Console\Command;
 use Statamic\Console\RunsInPlease;
 use Statamic\Facades\Collection;
-use Statamic\Facades\Entry;
 
 class UpdateClassReferences extends Command
 {

--- a/src/Fieldtypes/GatewayFieldtype.php
+++ b/src/Fieldtypes/GatewayFieldtype.php
@@ -84,6 +84,10 @@ class GatewayFieldtype extends Fieldtype
 
     public function augment($value)
     {
+        if (! $value) {
+            return null;
+        }
+
         $gateway = SimpleCommerce::gateways()->firstWhere('handle', $value['use']);
 
         if (! $gateway) {

--- a/src/Fieldtypes/GatewayFieldtype.php
+++ b/src/Fieldtypes/GatewayFieldtype.php
@@ -32,9 +32,7 @@ class GatewayFieldtype extends Fieldtype
 
         $actionUrl = null;
 
-        $gateway = SimpleCommerce::gateways()
-            ->where('handle', $value['use'])
-            ->first();
+        $gateway = SimpleCommerce::gateways()->firstWhere('handle', $value['use']);
 
         if (! $gateway) {
             return null;
@@ -86,9 +84,7 @@ class GatewayFieldtype extends Fieldtype
 
     public function augment($value)
     {
-        $gateway = SimpleCommerce::gateways()
-            ->where('handle', $value['use'])
-            ->first();
+        $gateway = SimpleCommerce::gateways()->firstWhere('handle', $value['use']);
 
         if (! $gateway) {
             return null;
@@ -105,9 +101,7 @@ class GatewayFieldtype extends Fieldtype
             return;
         }
 
-        $gateway = SimpleCommerce::gateways()
-            ->where('handle', $value['use'])
-            ->first();
+        $gateway = SimpleCommerce::gateways()->firstWhere('handle', $value['use']);
 
         if (! $gateway) {
             return null;

--- a/src/Fieldtypes/GatewayFieldtype.php
+++ b/src/Fieldtypes/GatewayFieldtype.php
@@ -33,7 +33,13 @@ class GatewayFieldtype extends Fieldtype
         $actionUrl = null;
 
         $gateway = SimpleCommerce::gateways()
-            ->where('class', isset($value['use']) ? $value['use'] : $value)
+            ->filter(function ($gateway) use ($value) {
+                $handle = isset($value['use'])
+                    ? $value['use']
+                    : $value;
+
+                return $gateway['handle'] === $handle || $gateway['class'] === $handle;
+            })
             ->first();
 
         if (! $gateway) {
@@ -68,7 +74,7 @@ class GatewayFieldtype extends Fieldtype
             'entry' => optional($this->field->parent())->id,
 
             'gateway_class' => $gateway['class'],
-            'display' => Gateway::use($gateway['class'])->fieldtypeDisplay($value),
+            'display' => Gateway::use($gateway['handle'])->fieldtypeDisplay($value),
 
             'actions' => $actions,
             'action_url' => $actionUrl,
@@ -87,7 +93,13 @@ class GatewayFieldtype extends Fieldtype
     public function augment($value)
     {
         $gateway = SimpleCommerce::gateways()
-            ->where('class', isset($value['use']) ? $value['use'] : $value)
+            ->filter(function ($gateway) use ($value) {
+                $handle = isset($value['use'])
+                    ? $value['use']
+                    : $value;
+
+                return $gateway['handle'] === $handle || $gateway['class'] === $handle;
+            })
             ->first();
 
         if (! $gateway) {
@@ -106,7 +118,13 @@ class GatewayFieldtype extends Fieldtype
         }
 
         $gateway = SimpleCommerce::gateways()
-            ->where('class', isset($value['use']) ? $value['use'] : $value)
+            ->filter(function ($gateway) use ($value) {
+                $handle = isset($value['use'])
+                    ? $value['use']
+                    : $value;
+
+                return $gateway['handle'] === $handle || $gateway['class'] === $handle;
+            })
             ->first();
 
         if (! $gateway) {

--- a/src/Fieldtypes/GatewayFieldtype.php
+++ b/src/Fieldtypes/GatewayFieldtype.php
@@ -33,13 +33,7 @@ class GatewayFieldtype extends Fieldtype
         $actionUrl = null;
 
         $gateway = SimpleCommerce::gateways()
-            ->filter(function ($gateway) use ($value) {
-                $handle = isset($value['use'])
-                    ? $value['use']
-                    : $value;
-
-                return $gateway['handle'] === $handle || $gateway['class'] === $handle;
-            })
+            ->where('handle', $value['use'])
             ->first();
 
         if (! $gateway) {
@@ -93,13 +87,7 @@ class GatewayFieldtype extends Fieldtype
     public function augment($value)
     {
         $gateway = SimpleCommerce::gateways()
-            ->filter(function ($gateway) use ($value) {
-                $handle = isset($value['use'])
-                    ? $value['use']
-                    : $value;
-
-                return $gateway['handle'] === $handle || $gateway['class'] === $handle;
-            })
+            ->where('handle', $value['use'])
             ->first();
 
         if (! $gateway) {
@@ -118,13 +106,7 @@ class GatewayFieldtype extends Fieldtype
         }
 
         $gateway = SimpleCommerce::gateways()
-            ->filter(function ($gateway) use ($value) {
-                $handle = isset($value['use'])
-                    ? $value['use']
-                    : $value;
-
-                return $gateway['handle'] === $handle || $gateway['class'] === $handle;
-            })
+            ->where('handle', $value['use'])
             ->first();
 
         if (! $gateway) {

--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -11,21 +11,18 @@ use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Statamic\Extend\HasHandle;
 
 abstract class BaseGateway
 {
+    use HasHandle;
+
     public function __construct(
         protected array $config = [],
-        protected string $handle = '',
         protected string $webhookUrl = '',
         protected string $redirectUrl = '/',
         protected string $errorRedirectUrl = '/'
     ) {
-    }
-
-    public function handle(): string
-    {
-        return $this->handle;
     }
 
     public function name(): string
@@ -99,7 +96,7 @@ abstract class BaseGateway
     public function callbackUrl(array $extraParamters = []): string
     {
         $data = array_merge($extraParamters, [
-            'gateway' => $this->handle,
+            'gateway' => static::handle(),
             '_redirect' => $this->redirectUrl,
             '_error_redirect' => $this->errorRedirectUrl,
         ]);
@@ -131,7 +128,7 @@ abstract class BaseGateway
         // We need to ensure that the gateway is available in the
         // order when the OrderPaid event is dispatched.
         $order->gateway([
-            'use' => get_class($this),
+            'use' => static::handle(),
             'data' => [],
         ]);
 

--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -103,8 +103,12 @@ abstract class BaseGateway
         return route('statamic.simple-commerce.gateways.callback', $data);
     }
 
-    public function webhookUrl(): string
+    public function webhookUrl(): ?string
     {
+        if (app()->environment('testing')) {
+            return null;
+        }
+
         return Str::finish(config('app.url'), '/').config('statamic.routes.action').'/simple-commerce/gateways/'.$this::handle().'/webhook';
     }
 

--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Statamic\Extend\HasHandle;
+use Statamic\Extend\RegistersItself;
 
 abstract class BaseGateway
 {

--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -12,7 +12,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Statamic\Extend\HasHandle;
-use Statamic\Extend\RegistersItself;
 
 abstract class BaseGateway
 {

--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -19,7 +19,6 @@ abstract class BaseGateway
 
     public function __construct(
         protected array $config = [],
-        protected string $webhookUrl = '',
         protected string $redirectUrl = '/',
         protected string $errorRedirectUrl = '/'
     ) {
@@ -106,7 +105,7 @@ abstract class BaseGateway
 
     public function webhookUrl(): string
     {
-        return $this->webhookUrl;
+        return Str::finish(config('app.url'), '/').config('statamic.routes.action').'/simple-commerce/gateways/'.$this::handle().'/webhook';
     }
 
     public function redirectUrl(): ?string

--- a/src/Gateways/Builtin/DummyGateway.php
+++ b/src/Gateways/Builtin/DummyGateway.php
@@ -9,6 +9,8 @@ use Illuminate\Http\Request;
 
 class DummyGateway extends BaseGateway implements Gateway
 {
+    protected static $handle = 'dummy';
+
     public function name(): string
     {
         return __('Dummy');

--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -23,6 +23,7 @@ use Statamic\Statamic;
 class MollieGateway extends BaseGateway implements Gateway
 {
     protected $mollie;
+    protected static $handle = 'mollie';
 
     public function name(): string
     {

--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -23,6 +23,7 @@ use Statamic\Statamic;
 class MollieGateway extends BaseGateway implements Gateway
 {
     protected $mollie;
+
     protected static $handle = 'mollie';
 
     public function name(): string

--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -26,6 +26,7 @@ use Statamic\Facades\Site;
 class PayPalGateway extends BaseGateway implements Gateway
 {
     protected $paypalClient;
+
     protected static $handle = 'paypal';
 
     public function name(): string

--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -26,6 +26,7 @@ use Statamic\Facades\Site;
 class PayPalGateway extends BaseGateway implements Gateway
 {
     protected $paypalClient;
+    protected static $handle = 'paypal';
 
     public function name(): string
     {

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -26,6 +26,7 @@ use Stripe\Stripe;
 class StripeGateway extends BaseGateway implements Gateway
 {
     protected bool $isUsingTestMode = false;
+    protected static $handle = 'stripe';
 
     public function name(): string
     {

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -26,6 +26,7 @@ use Stripe\Stripe;
 class StripeGateway extends BaseGateway implements Gateway
 {
     protected bool $isUsingTestMode = false;
+
     protected static $handle = 'stripe';
 
     public function name(): string

--- a/src/Gateways/Manager.php
+++ b/src/Gateways/Manager.php
@@ -61,7 +61,7 @@ class Manager implements Contract
         $order = Order::find($order->id());
 
         $order->gateway([
-            'use' => $this->handle,  // TODO
+            'use' => $this->handle,
             'data' => $checkout,
         ]);
 
@@ -134,11 +134,7 @@ class Manager implements Contract
             throw new GatewayNotProvided('No gateway provided.');
         }
 
-        $gateway = SimpleCommerce::gateways()
-            ->filter(function ($gateway) {
-                return $this->handle === $gateway['class']::handle() || $gateway['class'] === $this->handle;
-            })
-            ->first();
+        $gateway = SimpleCommerce::gateways()->firstWhere('handle', $this->handle);
 
         if (! $gateway) {
             throw new GatewayDoesNotExist("Gateway [{$this->handle}] does not exist.");

--- a/src/Gateways/Manager.php
+++ b/src/Gateways/Manager.php
@@ -136,7 +136,7 @@ class Manager implements Contract
 
         $gateway = SimpleCommerce::gateways()
             ->filter(function ($gateway) {
-                return $gateway['class']::handle() === $this->handle || $gateway['class'] === $this->handle;
+                return $this->handle === $gateway['class']::handle() || $gateway['class'] === $this->handle;
             })
             ->first();
 

--- a/src/Gateways/Manager.php
+++ b/src/Gateways/Manager.php
@@ -142,10 +142,6 @@ class Manager implements Contract
 
         $data = ['config' => $gateway['config']];
 
-        if (isset($gateway['webhook_url'])) {
-            $data['webhookUrl'] = $gateway['webhook_url'];
-        }
-
         if ($this->redirectUrl) {
             $data['redirectUrl'] = $this->redirectUrl;
         }

--- a/src/Gateways/Manager.php
+++ b/src/Gateways/Manager.php
@@ -128,7 +128,7 @@ class Manager implements Contract
         return $this;
     }
 
-    protected function resolve()
+    public function resolve()
     {
         if (! $this->handle) {
             throw new GatewayNotProvided('No gateway provided.');

--- a/src/Http/Requests/CheckoutRequest.php
+++ b/src/Http/Requests/CheckoutRequest.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Http\Requests;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway as GatewayContract;
 use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use DoubleThreeDigital\SimpleCommerce\Rules\ValidCoupon;

--- a/src/Http/Requests/CheckoutRequest.php
+++ b/src/Http/Requests/CheckoutRequest.php
@@ -7,6 +7,7 @@ use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
 use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use DoubleThreeDigital\SimpleCommerce\Rules\ValidCoupon;
 use DoubleThreeDigital\SimpleCommerce\Rules\ValidGateway;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Illuminate\Foundation\Http\FormRequest;
 
 class CheckoutRequest extends FormRequest
@@ -64,18 +65,6 @@ class CheckoutRequest extends FormRequest
 
     protected function shouldDoGatewayValidation(): bool
     {
-        $gateway = $this->get('gateway');
-
-        if (! class_exists($gateway)) {
-            return false;
-        }
-
-        $isGateway = (new $gateway()) instanceof GatewayContract;
-
-        if (! $isGateway) {
-            return false;
-        }
-
-        return true;
+        return SimpleCommerce::gateways()->where('handle', $this->get('gateway'))->count() > 0;
     }
 }

--- a/src/Orders/Calculator/ShippingCalculator.php
+++ b/src/Orders/Calculator/ShippingCalculator.php
@@ -20,7 +20,7 @@ class ShippingCalculator
 
         $order->shippingTotal(
             Shipping::site(Site::current()->handle())
-                ->use($shippingMethod ?? $defaultShippingMethod)
+                ->use($shippingMethod ?? $defaultShippingMethod::handle())
                 ->calculateCost($order)
         );
 

--- a/src/Orders/Calculator/ShippingTaxCalculator.php
+++ b/src/Orders/Calculator/ShippingTaxCalculator.php
@@ -4,7 +4,6 @@ namespace DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
 
 use Closure;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\Facades\Shipping;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Statamic\Facades\Site;

--- a/src/Orders/Calculator/ShippingTaxCalculator.php
+++ b/src/Orders/Calculator/ShippingTaxCalculator.php
@@ -4,6 +4,8 @@ namespace DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
 
 use Closure;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
+use DoubleThreeDigital\SimpleCommerce\Facades\Shipping;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Statamic\Facades\Site;
 
@@ -19,7 +21,7 @@ class ShippingTaxCalculator
         }
 
         $taxEngine = SimpleCommerce::taxEngine();
-        $taxCalculation = $taxEngine->calculateForShipping($order, new $shippingMethod);
+        $taxCalculation = $taxEngine->calculateForShipping($order, Shipping::use($shippingMethod)->resolve());
 
         $order->set('shipping_tax', $taxCalculation->toArray());
 

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -215,11 +215,7 @@ class Order implements Contract
 
     public function currentGateway(): ?array
     {
-        $value = $this->gateway()['use'];
-
-        return SimpleCommerce::gateways()
-            ->filter(fn ($gateway) => $gateway['handle'] === $value || $gateway['class'] === $value)
-            ->first();
+        return SimpleCommerce::gateways()->firstWhere('handle', $this->gateway()['use']);
     }
 
     public function resource($resource = null)

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -215,15 +215,13 @@ class Order implements Contract
 
     public function currentGateway(): ?array
     {
-        if (is_string($this->gateway())) {
-            return SimpleCommerce::gateways()->firstWhere('class', $this->gateway());
-        }
+        $value = isset($this->gateway()['use'])
+            ? $this->gateway()['use']
+            : $this->gateway();
 
-        if (is_array($this->gateway())) {
-            return SimpleCommerce::gateways()->firstWhere('class', $this->gateway()['use']);
-        }
-
-        return null;
+        return SimpleCommerce::gateways()
+            ->filter(fn ($gateway) => $gateway['handle'] === $value || $gateway['class'] === $value)
+            ->first();
     }
 
     public function resource($resource = null)

--- a/src/Rules/ValidGateway.php
+++ b/src/Rules/ValidGateway.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Rules;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Illuminate\Contracts\Validation\Rule;
 

--- a/src/Rules/ValidGateway.php
+++ b/src/Rules/ValidGateway.php
@@ -3,23 +3,14 @@
 namespace DoubleThreeDigital\SimpleCommerce\Rules;
 
 use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Illuminate\Contracts\Validation\Rule;
 
 class ValidGateway implements Rule
 {
     public function passes($attribute, $value)
     {
-        if (! class_exists($value)) {
-            return false;
-        }
-
-        $isGateway = (new $value()) instanceof Gateway;
-
-        if (! $isGateway) {
-            return false;
-        }
-
-        return true;
+        return SimpleCommerce::gateways()->where('handle', $value)->count() > 0;
     }
 
     public function message()

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -39,6 +39,7 @@ class ServiceProvider extends AddonServiceProvider
         Console\Commands\MigrateOrderStatuses::class,
         Console\Commands\MigrateOrdersToDatabase::class,
         Console\Commands\SwitchToDatabase::class,
+        Console\Commands\UpdateClassReferences::class,
     ];
 
     protected $fieldtypes = [

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -121,6 +121,8 @@ class ServiceProvider extends AddonServiceProvider
         UpdateScripts\v5_0\UpdateOrderBlueprint::class,
         UpdateScripts\v5_0\CreateShippingTaxCategory::class,
         UpdateScripts\v5_0\MigrateCouponsAfterUiUpdates::class,
+
+        UpdateScripts\v6_0\UpdateClassReferences::class,
     ];
 
     protected $vite = [

--- a/src/Shipping/BaseShippingMethod.php
+++ b/src/Shipping/BaseShippingMethod.php
@@ -4,9 +4,12 @@ namespace DoubleThreeDigital\SimpleCommerce\Shipping;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Statamic\Extend\HasHandle;
 
 class BaseShippingMethod
 {
+    use HasHandle;
+
     public function __construct(protected array $config = [])
     {
     }

--- a/src/Shipping/Manager.php
+++ b/src/Shipping/Manager.php
@@ -55,7 +55,7 @@ class Manager implements Contract
 
         $shippingMethod = SimpleCommerce::shippingMethods($siteHandle)
             ->filter(function ($shippingMethod) {
-                return $shippingMethod['class']::handle() === $this->handle || $shippingMethod['class'] === $this->handle;
+                return $this->handle === $shippingMethod['class']::handle() || $shippingMethod['class'] === $this->handle;
             })
             ->first();
 

--- a/src/Shipping/Manager.php
+++ b/src/Shipping/Manager.php
@@ -53,11 +53,7 @@ class Manager implements Contract
     {
         $siteHandle = $this->siteHandle ?? Site::current()->handle();
 
-        $shippingMethod = SimpleCommerce::shippingMethods($siteHandle)
-            ->filter(function ($shippingMethod) {
-                return $this->handle === $shippingMethod['class']::handle() || $shippingMethod['class'] === $this->handle;
-            })
-            ->first();
+        $shippingMethod = SimpleCommerce::shippingMethods($siteHandle)->firstWhere('handle', $this->handle);
 
         if (! $shippingMethod) {
             throw new ShippingMethodDoesNotExist("Shipping method [{$this->handle}] does not exist.");

--- a/src/Shipping/Manager.php
+++ b/src/Shipping/Manager.php
@@ -13,18 +13,18 @@ class Manager implements Contract
 {
     protected $siteHandle;
 
-    protected $className;
+    protected $handle;
 
     public function site($siteHandle): self
     {
-        $this->className = $siteHandle;
+        $this->siteHandle = $siteHandle;
 
         return $this;
     }
 
-    public function use($className): self
+    public function use($handle): self
     {
-        $this->className = $className;
+        $this->handle = $handle;
 
         return $this;
     }
@@ -49,19 +49,21 @@ class Manager implements Contract
         return $this->resolve()->checkAvailability($order, $address);
     }
 
-    protected function resolve()
+    public function resolve()
     {
-        if (! resolve($this->className)) {
-            throw new ShippingMethodDoesNotExist("Shipping method [{$this->className}] does not exist.");
-        }
-
         $siteHandle = $this->siteHandle ?? Site::current()->handle();
 
         $shippingMethod = SimpleCommerce::shippingMethods($siteHandle)
-            ->where('class', $this->className)
+            ->filter(function ($shippingMethod) {
+                return $shippingMethod['class']::handle() === $this->handle || $shippingMethod['class'] === $this->handle;
+            })
             ->first();
 
-        return resolve($this->className, [
+        if (! $shippingMethod) {
+            throw new ShippingMethodDoesNotExist("Shipping method [{$this->handle}] does not exist.");
+        }
+
+        return resolve($shippingMethod['class'], [
             'config' => $shippingMethod['config'] ?? [],
         ]);
     }

--- a/src/SimpleCommerce.php
+++ b/src/SimpleCommerce.php
@@ -107,6 +107,7 @@ class SimpleCommerce
 
                         return [
                             'name' => $instance->name(),
+                            'handle' => $key::handle(),
                             'description' => $instance->description(),
                             'class' => $key,
                             'config' => $config,
@@ -153,6 +154,7 @@ class SimpleCommerce
 
         static::$shippingMethods[$site][] = [
             'name' => $instance->name(),
+            'handle' => $shippingMethod::handle(),
             'description' => $instance->description(),
             'class' => $shippingMethod,
             'config' => $config,

--- a/src/SimpleCommerce.php
+++ b/src/SimpleCommerce.php
@@ -5,7 +5,6 @@ namespace DoubleThreeDigital\SimpleCommerce;
 use Closure;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Str;
 use Statamic\Facades\Addon;
 use Statamic\Facades\Site;
 use Statamic\Statamic;

--- a/src/SimpleCommerce.php
+++ b/src/SimpleCommerce.php
@@ -68,7 +68,6 @@ class SimpleCommerce
                     'display' => isset($gateway[1]['display']) ? $gateway[1]['display'] : $instance->name(),
                     'checkoutRules' => $instance->checkoutRules(),
                     'config' => $gateway[1],
-                    'webhook_url' => Str::finish(config('app.url'), '/').config('statamic.routes.action').'/simple-commerce/gateways/'.$class::handle().'/webhook',
                 ];
             });
     }

--- a/src/SimpleCommerce.php
+++ b/src/SimpleCommerce.php
@@ -55,18 +55,20 @@ class SimpleCommerce
     {
         return collect(static::$gateways)
             ->map(function ($gateway) {
+                $class = $gateway[0];
+
                 /** @var Contracts\Gateway $instance */
-                $instance = new $gateway[0]();
+                $instance = new $class();
 
                 return [
                     'name' => $instance->name(),
-                    'handle' => $handle = Str::of($instance->name())->camel()->lower()->__toString(),
-                    'class' => $gateway[0],
+                    'handle' => $class::handle(),
+                    'class' => $class,
                     'formatted_class' => addslashes($gateway[0]),
                     'display' => isset($gateway[1]['display']) ? $gateway[1]['display'] : $instance->name(),
                     'checkoutRules' => $instance->checkoutRules(),
                     'config' => $gateway[1],
-                    'webhook_url' => Str::finish(config('app.url'), '/').config('statamic.routes.action').'/simple-commerce/gateways/'.$handle.'/webhook',
+                    'webhook_url' => Str::finish(config('app.url'), '/').config('statamic.routes.action').'/simple-commerce/gateways/'.$class::handle().'/webhook',
                 ];
             });
     }

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -68,9 +68,7 @@ class CheckoutTags extends SubTag
         $cart = $this->getCart();
         $gatewayHandle = last(explode(':', $tag));
 
-        $gateway = SimpleCommerce::gateways()
-            ->filter(fn ($gateway) => $gatewayHandle === $gateway['class']::handle())
-            ->first();
+        $gateway = SimpleCommerce::gateways()->firstWhere('handle', $gatewayHandle);
 
         if (! $gateway) {
             throw new GatewayDoesNotExist($gatewayHandle);

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -69,7 +69,7 @@ class CheckoutTags extends SubTag
         $gatewayHandle = last(explode(':', $tag));
 
         $gateway = SimpleCommerce::gateways()
-            ->where('handle', $gatewayHandle)
+            ->filter(fn ($gateway) => $gateway['class']::handle() === $gatewayHandle)
             ->first();
 
         if (! $gateway) {
@@ -111,7 +111,7 @@ class CheckoutTags extends SubTag
                 : back()->with($data);
         }
 
-        $prepare = Gateway::use($gateway['class']);
+        $prepare = Gateway::use($gateway['handle']);
 
         if ($this->params->has('redirect')) {
             $prepare->withRedirectUrl($this->params->get('redirect'));
@@ -127,7 +127,7 @@ class CheckoutTags extends SubTag
             array_merge(
                 $cart->gateway() !== null && is_string($cart->gateway()) ? $cart->gateway() : [],
                 [
-                    'use' => $gateway['class'],
+                    'use' => $gateway['class']::handle(),
                 ]
             )
         );

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -123,7 +123,7 @@ class CheckoutTags extends SubTag
 
         $cart->gateway([
             ...$cart->gateway() ?? [],
-            'use' => $gateway['class']::class(),
+            'use' => $gateway['class']::handle(),
         ]);
 
         $cart->set($gateway['handle'], $prepare);

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -34,10 +34,10 @@ class CheckoutTags extends SubTag
                     return true;
                 })
                 ->each(function ($gateway) use (&$cart, &$data) {
-                    $config = Gateway::use($gateway['class'])->config();
-                    $prepare = Gateway::use($gateway['class'])->prepare(request(), $cart);
+                    $config = Gateway::use($gateway['handle'])->config();
+                    $prepare = Gateway::use($gateway['handle'])->prepare(request(), $cart);
 
-                    $callbackUrl = Gateway::use($gateway['class'])
+                    $callbackUrl = Gateway::use($gateway['handle'])
                         ->withRedirectUrl($this->params->get('redirect') ?? request()->path())
                         ->withErrorRedirectUrl($this->params->get('error_redirect') ?? request()->path())
                         ->callbackUrl();

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -69,7 +69,7 @@ class CheckoutTags extends SubTag
         $gatewayHandle = last(explode(':', $tag));
 
         $gateway = SimpleCommerce::gateways()
-            ->filter(fn ($gateway) => $gateway['class']::handle() === $gatewayHandle)
+            ->filter(fn ($gateway) => $gatewayHandle === $gateway['class']::handle())
             ->first();
 
         if (! $gateway) {

--- a/src/Tags/ShippingTags.php
+++ b/src/Tags/ShippingTags.php
@@ -19,7 +19,7 @@ class ShippingTags extends SubTag
         return SimpleCommerce::shippingMethods(Site::current()->handle())
             ->map(function ($shippingMethod) use ($order) {
                 $instance = Shipping::site(Site::current()->handle())
-                    ->use($shippingMethod['class']);
+                    ->use($shippingMethod['handle']);
 
                 if (! $shipingAddress = $order->shippingAddress()) {
                     return null;

--- a/src/Tags/ShippingTags.php
+++ b/src/Tags/ShippingTags.php
@@ -32,7 +32,7 @@ class ShippingTags extends SubTag
                 $cost = $instance->calculateCost($order);
 
                 return [
-                    'handle' => $shippingMethod['class'],
+                    'handle' => $shippingMethod['handle'],
                     'name' => $instance->name(),
                     'description' => $instance->description(),
                     'cost' => Currency::parse($cost, Site::current()),

--- a/src/UpdateScripts/v6_0/UpdateClassReferences.php
+++ b/src/UpdateScripts/v6_0/UpdateClassReferences.php
@@ -28,15 +28,23 @@ class UpdateClassReferences extends UpdateScript
                 ->queryEntries()
                 ->where('gateway', '!=', null)
                 ->chunk(50, function ($orders) {
-                    $orders->each(function ($entry) {
-                        if (! class_exists($entry->get('gateway')['use'])) {
-                            return;
-                        }
+                    $orders
+                        ->each(function ($entry) {
+                            if (! class_exists($entry->get('gateway')['use'])) {
+                                return;
+                            }
 
-                        $entry->set('gateway', array_merge($entry->get('gateway'), [
-                            'use' => $entry->get('gateway')['use']::handle(),
-                        ]))->saveQuietly();
-                    });
+                            $entry->set('gateway', array_merge($entry->get('gateway'), [
+                                'use' => $entry->get('gateway')['use']::handle(),
+                            ]))->saveQuietly();
+                        })
+                        ->each(function ($entry) {
+                            if (! $entry->has('shipping_method') || ! class_exists($entry->get('shipping_method'))) {
+                                return;
+                            }
+
+                            $entry->set('shipping_method', $entry->get('shipping_method')::handle())->saveQuietly();
+                        });
                 });
         }
 
@@ -44,17 +52,27 @@ class UpdateClassReferences extends UpdateScript
             OrderModel::query()
                 ->where('gateway', '!=', null)
                 ->chunk(50, function ($orders) {
-                    $orders->each(function ($order) {
-                        if (! class_exists($order->gateway['use'])) {
-                            return;
-                        }
+                    $orders
+                        ->each(function ($order) {
+                            if (! class_exists($order->gateway['use'])) {
+                                return;
+                            }
 
-                        $order->gateway = array_merge($order->gateway, [
-                            'use' => $order->gateway['use']::handle(),
-                        ]);
+                            $order->gateway = array_merge($order->gateway, [
+                                'use' => $order->gateway['use']::handle(),
+                            ]);
 
-                        $order->saveQuietly();
-                    });
+                            $order->saveQuietly();
+                        })
+                        ->each(function ($order) {
+                            if (! isset($order->data['shipping_method']) || ! class_exists($order->data['shipping_method'])) {
+                                return;
+                            }
+
+                            $order->data['shipping_method'] = $order->data['shipping_method']::handle();
+
+                            $order->saveQuietly();
+                        });
                 });
         }
 

--- a/src/UpdateScripts/v6_0/UpdateClassReferences.php
+++ b/src/UpdateScripts/v6_0/UpdateClassReferences.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0;
+
+use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
+use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
+use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Statamic\Facades\Collection;
+use Statamic\UpdateScripts\UpdateScript;
+
+class UpdateClassReferences extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('6.0.0');
+    }
+
+    public function update()
+    {
+        $this->updateInOrders();
+    }
+
+    protected function updateInOrders(): self
+    {
+        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EntryOrderRepository::class)) {
+            Collection::find(SimpleCommerce::orderDriver()['collection'])
+                ->queryEntries()
+                ->where('gateway', '!=', null)
+                ->chunk(50, function ($orders) {
+                    $orders->each(function ($entry) {
+                        if (! class_exists($entry->get('gateway')['use'])) {
+                            return;
+                        }
+
+                        $entry->set('gateway', array_merge($entry->get('gateway'), [
+                            'use' => $entry->get('gateway')['use']::handle(),
+                        ]))->saveQuietly();
+                    });
+                });
+        }
+
+        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EloquentOrderRepository::class)) {
+            OrderModel::query()
+                ->where('gateway', '!=', null)
+                ->chunk(50, function ($orders) {
+                    $orders->each(function ($order) {
+                        if (! class_exists($order->gateway['use'])) {
+                            return;
+                        }
+
+                        $order->gateway = array_merge($order->gateway, [
+                            'use' => $order->gateway['use']::handle(),
+                        ]);
+
+                        $order->saveQuietly();
+                    });
+                });
+        }
+
+        return $this;
+    }
+
+    protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool
+    {
+        return is_subclass_of($class, $classToCheckAgainst)
+            || $class === $classToCheckAgainst;
+    }
+}

--- a/src/UpdateScripts/v6_0/UpdateClassReferences.php
+++ b/src/UpdateScripts/v6_0/UpdateClassReferences.php
@@ -6,6 +6,7 @@ use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
 use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use Illuminate\Support\Facades\Artisan;
 use Statamic\Facades\Collection;
 use Statamic\UpdateScripts\UpdateScript;
 
@@ -18,70 +19,6 @@ class UpdateClassReferences extends UpdateScript
 
     public function update()
     {
-        $this->updateInOrders();
-    }
-
-    protected function updateInOrders(): self
-    {
-        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EntryOrderRepository::class)) {
-            Collection::find(SimpleCommerce::orderDriver()['collection'])
-                ->queryEntries()
-                ->where('gateway', '!=', null)
-                ->chunk(50, function ($orders) {
-                    $orders
-                        ->each(function ($entry) {
-                            if (! class_exists($entry->get('gateway')['use'])) {
-                                return;
-                            }
-
-                            $entry->set('gateway', array_merge($entry->get('gateway'), [
-                                'use' => $entry->get('gateway')['use']::handle(),
-                            ]))->saveQuietly();
-                        })
-                        ->each(function ($entry) {
-                            if (! $entry->has('shipping_method') || ! class_exists($entry->get('shipping_method'))) {
-                                return;
-                            }
-
-                            $entry->set('shipping_method', $entry->get('shipping_method')::handle())->saveQuietly();
-                        });
-                });
-        }
-
-        if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EloquentOrderRepository::class)) {
-            OrderModel::query()
-                ->where('gateway', '!=', null)
-                ->chunk(50, function ($orders) {
-                    $orders
-                        ->each(function ($order) {
-                            if (! class_exists($order->gateway['use'])) {
-                                return;
-                            }
-
-                            $order->gateway = array_merge($order->gateway, [
-                                'use' => $order->gateway['use']::handle(),
-                            ]);
-
-                            $order->saveQuietly();
-                        })
-                        ->each(function ($order) {
-                            if (! isset($order->data['shipping_method']) || ! class_exists($order->data['shipping_method'])) {
-                                return;
-                            }
-
-                            $order->data['shipping_method'] = $order->data['shipping_method']::handle();
-
-                            $order->saveQuietly();
-                        });
-                });
-        }
-
-        return $this;
-    }
-
-    protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool
-    {
-        return is_subclass_of($class, $classToCheckAgainst)
-            || $class === $classToCheckAgainst;
+        Artisan::call('sc:update-class-references');
     }
 }

--- a/src/UpdateScripts/v6_0/UpdateClassReferences.php
+++ b/src/UpdateScripts/v6_0/UpdateClassReferences.php
@@ -2,12 +2,7 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Facades\Artisan;
-use Statamic\Facades\Collection;
 use Statamic\UpdateScripts\UpdateScript;
 
 class UpdateClassReferences extends UpdateScript

--- a/tests/Actions/RefundActionTest.php
+++ b/tests/Actions/RefundActionTest.php
@@ -3,6 +3,7 @@
 use DoubleThreeDigital\SimpleCommerce\Actions\RefundAction;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\DummyGateway;
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
 use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
 use Statamic\Facades\Collection;
@@ -75,7 +76,7 @@ test('order can be refunded', function () {
             'status' => OrderStatus::Placed,
             'payment_status' => PaymentStatus::Paid,
             'gateway' => [
-                'use' => 'DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\DummyGateway',
+                'use' => DummyGateway::handle(),
                 'data' => [
                     'id' => '123456789abcdefg',
                 ],

--- a/tests/Fieldtypes/GatewayFieldtypeTest.php
+++ b/tests/Fieldtypes/GatewayFieldtypeTest.php
@@ -36,7 +36,7 @@ test('can preprocess', function () {
     Auth::setUser($user);
 
     $preProcess = (new GatewayFieldtype)->setField($field)->preProcess([
-        'use' => DummyGateway::class,
+        'use' => DummyGateway::handle(),
         'data' => [
             'id' => 'abc123',
             'smth' => 'cool',
@@ -47,7 +47,7 @@ test('can preprocess', function () {
 
     $this->assertArrayHasKey('data', $preProcess);
     $this->assertSame([
-        'use' => DummyGateway::class,
+        'use' => DummyGateway::handle(),
         'data' => [
             'id' => 'abc123',
             'smth' => 'cool',
@@ -64,7 +64,7 @@ test('can preprocess', function () {
 test('can process', function () {
     $process = (new GatewayFieldtype)->process([
         'data' => [
-            'use' => DummyGateway::class,
+            'use' => DummyGateway::handle(),
             'data' => ['smth' => 'cool'],
         ],
         'actions' => [],
@@ -73,14 +73,14 @@ test('can process', function () {
     expect($process)->toBeArray();
 
     $this->assertSame([
-        'use' => DummyGateway::class,
+        'use' => DummyGateway::handle(),
         'data' => ['smth' => 'cool'],
     ], $process);
 });
 
 test('can augment', function () {
     $augment = (new GatewayFieldtype)->augment([
-        'use' => DummyGateway::class,
+        'use' => DummyGateway::handle(),
         'data' => ['smth' => 'cool'],
     ]);
 
@@ -99,7 +99,7 @@ test('can augment', function () {
 
 test('can preprocess index', function () {
     $preProcessIndex = (new GatewayFieldtype)->preProcessIndex([
-        'use' => DummyGateway::class,
+        'use' => DummyGateway::handle(),
         'data' => ['smth' => 'cool'],
     ]);
 

--- a/tests/Fieldtypes/GatewayFieldtypeTest.php
+++ b/tests/Fieldtypes/GatewayFieldtypeTest.php
@@ -93,7 +93,6 @@ test('can augment', function () {
     $this->assertArrayHasKey('display', $augment);
     $this->assertArrayHasKey('checkoutRules', $augment);
     $this->assertArrayHasKey('config', $augment);
-    $this->assertArrayHasKey('webhook_url', $augment);
     $this->assertArrayHasKey('data', $augment);
 });
 

--- a/tests/Gateways/Builtin/BaseGatewayTest.php
+++ b/tests/Gateways/Builtin/BaseGatewayTest.php
@@ -84,7 +84,7 @@ test('can mark order as paid with offsite gateway and ensure gateway is set in o
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
 
     Event::assertDispatched(function (PaymentStatusUpdated $event) {
-        return $event->order->gateway['use'] === FakeOffsiteGateway::class;
+        return $event->order->gateway['use'] === FakeOffsiteGateway::handle();
     });
 
     // Assert stock count has been updated
@@ -155,6 +155,6 @@ test('can mark order as paid with onsite gateway and ensure gateway is set in or
     expect(PaymentStatus::Paid)->toBe($order->fresh()->paymentStatus());
 
     Event::assertDispatched(function (PaymentStatusUpdated $event) {
-        return $event->order->gateway['use'] === FakeOnsiteGateway::class;
+        return $event->order->gateway['use'] === FakeOnsiteGateway::handle();
     });
 });

--- a/tests/Gateways/Builtin/MollieGatewayTest.php
+++ b/tests/Gateways/Builtin/MollieGatewayTest.php
@@ -27,7 +27,6 @@ test('has a name', function () {
 });
 
 test('can prepare', function () {
-
     $product = Product::make()
         ->price(5500)
         ->data(['title' => 'Concert Ticket']);

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -380,7 +380,7 @@ test('can refund charge', function () {
     Stripe::setApiKey(env('STRIPE_SECRET'));
 
     $order = Order::make()->grandTotal(1234)->gateway([
-        'use' => StripeGateway::class,
+        'use' => StripeGateway::handle(),
         'data' => [
             'payment_intent' => $paymentIntent = PaymentIntent::create([
                 'amount' => 1234,
@@ -443,7 +443,7 @@ test('returns array from payment display', function () {
     Stripe::setApiKey(env('STRIPE_SECRET'));
 
     $fieldtypeDisplay = $this->cardElementsGateway->fieldtypeDisplay([
-        'use' => StripeGateway::class,
+        'use' => StripeGateway::handle(),
         'data' => [
             'payment_intent' => $paymentIntent = PaymentIntent::create([
                 'amount' => 1234,
@@ -462,7 +462,7 @@ test('returns array from payment display', function () {
 
 test('does not return array from payment display if no payment intent is set', function () {
     $fieldtypeDisplay = $this->cardElementsGateway->fieldtypeDisplay([
-        'use' => StripeGateway::class,
+        'use' => StripeGateway::handle(),
         'data' => [],
     ]);
 

--- a/tests/Http/Controllers/CheckoutControllerTest.php
+++ b/tests/Http/Controllers/CheckoutControllerTest.php
@@ -62,7 +62,7 @@ test('can post checkout', function () {
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -111,7 +111,7 @@ test('cant post checkout and ensure custom form request is used', function () {
             '_request' => encrypt(CheckoutFormRequest::class),
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -162,7 +162,7 @@ test('can post checkout with name and email', function () {
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Mike Scott',
             'email' => 'mike.scott@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -221,7 +221,7 @@ test('can post checkout with first name and last name and email', function () {
             'first_name' => 'Mike',
             'last_name' => 'Scott',
             'email' => 'mike.scott@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -277,7 +277,7 @@ test('cant post checkout with name and email when email address contains spaces'
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Mike Scott',
             'email' => 'mike dot scott@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -328,7 +328,7 @@ test('can post checkout with only email', function () {
         ->withSession(['simple-commerce-cart' => $order->id])
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'email' => 'jim@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -388,7 +388,7 @@ test('can post checkout with customer already present in order', function () {
     $this
         ->withSession(['simple-commerce-cart' => $order->id])
         ->post(route('statamic.simple-commerce.checkout.store'), [
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -452,7 +452,7 @@ test('can post checkout with customer present in request', function () {
         ->withSession(['simple-commerce-cart' => $order->id])
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'customer' => $customer->id,
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -529,7 +529,7 @@ test('can post checkout with customer where customer has invalid orders', functi
         ->withSession(['simple-commerce-cart' => $order->id])
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'customer' => $customer->id,
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -591,7 +591,7 @@ test('can post checkout with customer array', function () {
                 'name' => 'Joe Doe',
                 'email' => 'joe.doe@example.com',
             ],
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -659,7 +659,7 @@ test('can post checkout with customer array and existing customer', function () 
                 'name' => 'Joe Doe',
                 'email' => 'joe.doe@example.com',
             ],
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -728,7 +728,7 @@ test('can post checkout with customer array with additional information', functi
                 'email' => 'joe.doe@example.com',
                 'dob' => '01/01/2000',
             ],
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -805,7 +805,7 @@ test('can post checkout with customer array and existing customer with additiona
                 'email' => 'joe.doe@example.com',
                 'dob' => '01/01/2000',
             ],
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -868,7 +868,7 @@ test('can post checkout with customer array and use logged in user as customer',
         ->actingAs($user)
         ->withSession(['simple-commerce-cart' => $order->id])
         ->post(route('statamic.simple-commerce.checkout.store'), [
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -944,7 +944,7 @@ test('can post checkout with coupon', function () {
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1084,7 +1084,7 @@ test('cant post checkout with coupon where minimum cart value has not been reach
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1159,7 +1159,7 @@ test('cant post checkout with coupon when coupon has been redeemed for maxium us
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1234,7 +1234,7 @@ test('cant post checkout with coupon where coupon is only valid for products not
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1291,7 +1291,7 @@ test('can post checkout with product with stock counter', function () {
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1345,7 +1345,7 @@ test('can post checkout when product is running low on stock', function () {
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1399,7 +1399,7 @@ test('cant post checkout when product has no stock', function () {
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1460,7 +1460,7 @@ test('cant post checkout when product has a single item left in stock and single
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1539,7 +1539,7 @@ test('can post checkout with variant product with stock counter', function () {
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1616,7 +1616,7 @@ test('can post checkout when variant product is running low on stock', function 
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1693,7 +1693,7 @@ test('cant post checkout when variant product has no stock', function () {
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1777,7 +1777,7 @@ test('can post checkout when variant product has a single item left in stock and
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1836,7 +1836,7 @@ test('can post checkout and ensure remaining request data is saved to order', fu
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1896,7 +1896,7 @@ test('cant post checkout and ensure remaining request data is saved to order if 
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -1998,7 +1998,7 @@ test('cant post checkout with no payment information on paid order', function ()
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
         ])
         ->assertSessionHasErrors(['card_number', 'expiry_month', 'expiry_year', 'cvc']);
 
@@ -2132,7 +2132,7 @@ test('can post checkout requesting json and ensure json is returned', function (
         ->postJson(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -2191,7 +2191,7 @@ test('can post checkout and ensure user is redirected', function () {
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -2256,7 +2256,7 @@ test('can post checkout and ensure order paid notifications are sent', function 
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Guvna B',
             'email' => 'guvna.b@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -2318,7 +2318,7 @@ test('can post checkout and ensure temp gateway data is tidied up', function () 
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => DummyGateway::class,
+            'gateway' => DummyGateway::handle(),
             'card_number' => '4242424242424242',
             'expiry_month' => '01',
             'expiry_year' => '2025',
@@ -2365,7 +2365,7 @@ test('can post checkout and ensure gateway validation rules are used', function 
     $this
         ->withSession(['simple-commerce-cart' => $order->id])
         ->postJson(route('statamic.simple-commerce.checkout.store'), [
-            'gateway' => TestValidationGateway::class,
+            'gateway' => TestValidationGateway::handle(),
         ])
         ->assertJson([
             'errors' => [
@@ -2418,7 +2418,7 @@ test('can post checkout and ensure gateway errors are handled correctly', functi
         ->post(route('statamic.simple-commerce.checkout.store'), [
             'name' => 'Smelly Joe',
             'email' => 'smelly.joe@example.com',
-            'gateway' => TestCheckoutErrorGateway::class,
+            'gateway' => TestCheckoutErrorGateway::handle(),
         ])
         ->assertSessionHasErrors('gateway');
 

--- a/tests/Orders/Calculator/ShippingCalculatorTest.php
+++ b/tests/Orders/Calculator/ShippingCalculatorTest.php
@@ -51,7 +51,7 @@ it('calculates shipping total using shipping method from order', function () {
 
     $order = Order::make()->lineItems([
         ['id' => '123', 'product' => $product->id, 'quantity' => 2, 'total' => 2000],
-    ])->set('shipping_method', Postage::class)->save();
+    ])->set('shipping_method', Postage::handle())->save();
 
     $order = Pipeline::send($order)->through([ShippingCalculator::class])->thenReturn();
 

--- a/tests/Orders/Calculator/ShippingTaxCalculatorTest.php
+++ b/tests/Orders/Calculator/ShippingTaxCalculatorTest.php
@@ -39,7 +39,7 @@ it('calculates shipping tax when price does not include tax', function () {
 
     $order = Order::make()->lineItems([
         ['id' => '123', 'product' => $product->id, 'quantity' => 1, 'total' => 1000],
-    ])->set('shipping_method', Postage::class)->shippingTotal(250)->save();
+    ])->set('shipping_method', Postage::handle())->shippingTotal(250)->save();
 
     $order = Pipeline::send($order)->through([ShippingTaxCalculator::class])->thenReturn();
 
@@ -61,7 +61,7 @@ it('calculates shipping tax when price includes tax', function () {
 
     $order = Order::make()->lineItems([
         ['id' => '123', 'product' => $product->id, 'quantity' => 1, 'total' => 1000],
-    ])->set('shipping_method', Postage::class)->shippingTotal(250)->save();
+    ])->set('shipping_method', Postage::handle())->shippingTotal(250)->save();
 
     $order = Pipeline::send($order)->through([ShippingTaxCalculator::class])->thenReturn();
 

--- a/tests/Tax/BasicTaxEngineTest.php
+++ b/tests/Tax/BasicTaxEngineTest.php
@@ -3,11 +3,13 @@
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use DoubleThreeDigital\SimpleCommerce\Tax\BasicTaxEngine;
 use DoubleThreeDigital\SimpleCommerce\Tax\TaxCalculation;
 use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods\DummyShippingMethod;
 use Illuminate\Support\Facades\Config;
 use Statamic\Facades\Collection;
+use Statamic\Facades\Site;
 
 /**
  * Inline with the fix suggested here: https://github.com/duncanmcclean/simple-commerce/pull/438#issuecomment-888498198
@@ -149,9 +151,11 @@ test('can calculate shipping tax when included in price', function () {
     Config::set('simple-commerce.tax_engine_config.included_in_prices', true);
     Config::set('simple-commerce.tax_engine_config.shipping_taxes', true);
 
+    SimpleCommerce::registerShippingMethod(Site::current()->handle(), DummyShippingMethod::class);
+
     $order = Order::make()
         ->status(OrderStatus::Cart)
-        ->merge(['shipping_method' => DummyShippingMethod::class])
+        ->merge(['shipping_method' => DummyShippingMethod::handle()])
         ->shippingTotal(500);
 
     $order->save();

--- a/tests/Tax/StandardTaxEngineTest.php
+++ b/tests/Tax/StandardTaxEngineTest.php
@@ -6,11 +6,13 @@ use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
 use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
 use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
+use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
 use DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxEngine as StandardTaxEngine;
 use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods\DummyShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
+use Statamic\Facades\Site;
 use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 
 uses(SetupCollections::class);
@@ -461,6 +463,7 @@ test('throws prevent checkout exception if no address provided', function () {
 // https://github.com/duncanmcclean/simple-commerce/issues/856
 test('can use default shipping tax rate if no rate available', function () {
     Config::set('simple-commerce.tax_engine_config.behaviour.no_rate_available', 'default_rate');
+    SimpleCommerce::registerShippingMethod(Site::current()->handle(), DummyShippingMethod::class);
 
     TaxZone::make()
         ->id('everywhere')
@@ -517,7 +520,7 @@ test('can use default shipping tax rate if no rate available', function () {
             'billing_address' => '1 Test Street',
             'billing_country' => 'GB',
             'use_shipping_address_for_billing' => false,
-            'shipping_method' => DummyShippingMethod::class,
+            'shipping_method' => DummyShippingMethod::handle(),
         ]);
 
     $order->save();

--- a/tests/__fixtures__/app/Gateways/TestOffsiteGateway.php
+++ b/tests/__fixtures__/app/Gateways/TestOffsiteGateway.php
@@ -9,6 +9,8 @@ use Illuminate\Http\Request;
 
 class TestOffsiteGateway extends BaseGateway implements Gateway
 {
+    protected static $handle = 'testoffsitegateway';
+
     public function name(): string
     {
         return 'Test Off-site Gateway';

--- a/tests/__fixtures__/app/Gateways/TestOnsiteGateway.php
+++ b/tests/__fixtures__/app/Gateways/TestOnsiteGateway.php
@@ -9,6 +9,8 @@ use Illuminate\Http\Request;
 
 class TestOnsiteGateway extends BaseGateway implements Gateway
 {
+    protected static $handle = 'testonsitegateway';
+
     public function name(): string
     {
         return 'Test On-site Gateway';

--- a/tests/__fixtures__/app/ShippingMethods/DummyShippingMethod.php
+++ b/tests/__fixtures__/app/ShippingMethods/DummyShippingMethod.php
@@ -5,8 +5,9 @@ namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
 use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
 use DoubleThreeDigital\SimpleCommerce\Orders\Address;
+use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
 
-class DummyShippingMethod implements ShippingMethod
+class DummyShippingMethod extends BaseShippingMethod implements ShippingMethod
 {
     public function name(): string
     {


### PR DESCRIPTION
This pull request makes some necessary changes to the way Gateways & Shipping Methods are stored in order data. 

Previously, the fully qualified class name was saved to the order's YAML:

```yaml
shipping_method: DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping
```

However, with this PR, gateways & shipping methods are now references by their "handles":

```yaml
shipping_method: free_shipping
```

References in orders will be automatically updated upon updating.

These changes were necessary as part of the change in namespace from `DoubleThreeDigital` to `DuncanMcClean` which is due to happen in the v6 release.

This PR is a draft for now since there's a couple of rough edges I want to iron out before merging.

## To Do

* [x] Consider completely deprecating the class-based syntax to reduce tech debt & metal overhead.
    * [x] Only accept handles in "form" requests (search `TripleFourDigital\\ComplexCommerce\\SmellyGatewayHaha` as reference)
* [x] Move the code from `UpdateClassReferences` into a command so it can be run manually if needed.
* [x] Add notes to upgrade guide
    * [x] "The way gateways / shipping methods are references in orders has changed"
    * [x] Handles for gateways are now generated differently. You should review your payment page & any other integrations you have which may rely on the existing handles.
* [x] Ensure the payment page in the Starter Kit is up-to-date (do references to hard-coded class names need changing to handles?)
* [x] Fix failing tests