### PR TITLE
[6.x] Drop support for gateway being saved as strings on orders

### DIFF
--- a/src/Console/Commands/MigrateOrdersToDatabase.php
+++ b/src/Console/Commands/MigrateOrdersToDatabase.php
@@ -158,10 +158,6 @@ class MigrateOrdersToDatabase extends Command
                 }
 
                 if ($gateway = $entry->get('gateway')) {
-                    if (is_string($gateway)) {
-                        $gateway = ['use' => $gateway];
-                    }
-
                     $order->gateway($gateway);
                 }
 

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -215,15 +215,7 @@ class Order implements Contract
 
     public function currentGateway(): ?array
     {
-        if (is_string($this->gateway())) {
-            return SimpleCommerce::gateways()->firstWhere('class', $this->gateway());
-        }
-
-        if (is_array($this->gateway())) {
-            return SimpleCommerce::gateways()->firstWhere('class', $this->gateway()['use']);
-        }
-
-        return null;
+        return SimpleCommerce::gateways()->firstWhere('class', $this->gateway()['use']);
     }
 
     public function resource($resource = null)
@@ -370,16 +362,9 @@ class Order implements Contract
     {
         $this->updatePaymentStatus(PaymentStatus::Refunded);
 
-        if (is_string($this->gateway())) {
-            $data = [
-                'use' => $this->gateway(),
-                'refund' => $refundData,
-            ];
-        } elseif (is_array($this->gateway())) {
-            $data = array_merge($this->gateway(), [
-                'refund' => $refundData,
-            ]);
-        }
+        $data = array_merge($this->gateway(), [
+            'refund' => $refundData,
+        ]);
 
         $this->gateway($data);
 

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -123,14 +123,10 @@ class CheckoutTags extends SubTag
 
         $prepare = $prepare->prepare(request(), $cart);
 
-        $cart->gateway(
-            array_merge(
-                $cart->gateway() !== null && is_string($cart->gateway()) ? $cart->gateway() : [],
-                [
-                    'use' => $gateway['class'],
-                ]
-            )
-        );
+        $cart->gateway([
+            ...$cart->gateway() ?? [],
+            'use' => $gateway['class']
+        ]);
 
         $cart->set($gateway['handle'], $prepare);
 

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -125,7 +125,7 @@ class CheckoutTags extends SubTag
 
         $cart->gateway([
             ...$cart->gateway() ?? [],
-            'use' => $gateway['class']
+            'use' => $gateway['class'],
         ]);
 
         $cart->set($gateway['handle'], $prepare);


### PR DESCRIPTION
This pull request completely drops support for Simple Commerce reading gateway data in the legacy string format. Only the array format will be supported.

The array format was introduced quite a while ago now (in v2.4.0, see #498) so it's probably about time we rip of the bandaid and stop supporting it!. Good riddance strings!

## Examples

### Strings

```yaml
gateway: \DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway
```

### Arrays

```yaml
gateway: 
    use: \DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway
    data: 
        id: pi_123456789
```