### PR TITLE
[6.x] Refactor gateway data

### DIFF
--- a/docs/php-api.md
+++ b/docs/php-api.md
@@ -111,8 +111,9 @@ $order->coupon();
 // Set the coupon (either pass in the ID of a coupon or a Coupon instance)
 $order->coupon($coupon);
 
-// Get the current gateway
-$order->currentGateway();
+// Get the order's gateway & payment data
+$order->gatewayData()->gateway()->name(); // Returns the gateway's name
+$order->gatewayData()->data()->all(); // Returns an array of the gateway/payment data
 
 // Get the shipping address (returns an Address instance)
 $shippingAddress = $order->shippingAddress();

--- a/docs/upgrade-guides/v5-x-to-v6-0.md
+++ b/docs/upgrade-guides/v5-x-to-v6-0.md
@@ -80,6 +80,22 @@ This saves you needing to `find` the order/product/customer to use any of Simple
 
 The "Overview" page has been removed in Simple Commerce v6, in favour of Dashboard Widgets. To configure Simple Commerce widgets, review the [Control Panel](/control-panel#content-widgets) page.
 
+### Medium: Order Gateway methods have changed
+
+Both the `gateway` and `currentGateway` methods on orders have been replaced. If you were calling these methods anywhere in your code, you should update your code to use the new `gatewayData` method:
+
+```php
+// Get the gateway's name & handle
+$order->gatewayData()->gateway()->name();
+$order->gatewayData()->gateway()::handle();
+
+// Get the gateway / payment info
+$order->gatewayData()->data();
+
+// Get any refund data
+$order->gatewayData()->refund();
+```
+
 ## Previous upgrade guides
 
 -   [v2.2 to v2.3](/upgrade-guides/v2-2-to-v2-3)

--- a/src/Actions/RefundAction.php
+++ b/src/Actions/RefundAction.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Actions;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
 use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;

--- a/src/Actions/RefundAction.php
+++ b/src/Actions/RefundAction.php
@@ -44,8 +44,7 @@ class RefundAction extends Action
             ->each(function ($entry) {
                 $order = Order::find($entry->id);
 
-                return Gateway::use($order->currentGateway()['handle'])
-                    ->refund($order);
+                return $order->gatewayData()->gateway()->refund($order);
             });
     }
 

--- a/src/Console/Commands/MigrateOrdersToDatabase.php
+++ b/src/Console/Commands/MigrateOrdersToDatabase.php
@@ -158,7 +158,7 @@ class MigrateOrdersToDatabase extends Command
                 }
 
                 if ($gateway = $entry->get('gateway')) {
-                    $order->gatewayData($gateway);
+                    $order->gatewayData(gateway: $gateway);
                 }
 
                 $order->data($data);

--- a/src/Console/Commands/MigrateOrdersToDatabase.php
+++ b/src/Console/Commands/MigrateOrdersToDatabase.php
@@ -158,7 +158,7 @@ class MigrateOrdersToDatabase extends Command
                 }
 
                 if ($gateway = $entry->get('gateway')) {
-                    $order->gateway($gateway);
+                    $order->gatewayData($gateway);
                 }
 
                 $order->data($data);

--- a/src/Contracts/GatewayManager.php
+++ b/src/Contracts/GatewayManager.php
@@ -35,4 +35,6 @@ interface GatewayManager
     public function withRedirectUrl(string $redirectUrl): self;
 
     public function withErrorRedirectUrl(string $errorRedirectUrl): self;
+
+    public function resolve();
 }

--- a/src/Contracts/ShippingManager.php
+++ b/src/Contracts/ShippingManager.php
@@ -13,4 +13,6 @@ interface ShippingManager
     public function calculateCost(Order $order): int;
 
     public function checkAvailability(Order $order, Address $address): bool;
+
+    public function resolve();
 }

--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -130,10 +130,7 @@ abstract class BaseGateway
     {
         // We need to ensure that the gateway is available in the
         // order when the OrderPaid event is dispatched.
-        $order->gatewayData([
-            'use' => static::handle(),
-            'data' => [],
-        ]);
+        $order->gatewayData(gateway: static::handle(), data: []);
 
         if ($this->isOffsiteGateway()) {
             $order = app(CheckoutPipeline::class)

--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -130,7 +130,7 @@ abstract class BaseGateway
     {
         // We need to ensure that the gateway is available in the
         // order when the OrderPaid event is dispatched.
-        $order->gateway([
+        $order->gatewayData([
             'use' => static::handle(),
             'data' => [],
         ]);

--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -210,15 +210,7 @@ class PayPalGateway extends BaseGateway implements Gateway
                     ->save();
             }
 
-            $order->gatewayData(
-                array_merge(
-                    $order->gatewayData(),
-                    [
-                        'data' => $responseBody,
-                    ]
-                )
-            );
-
+            $order->gatewayData(data: $responseBody);
             $order->save();
 
             $this->markOrderAsPaid($order);

--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -210,9 +210,9 @@ class PayPalGateway extends BaseGateway implements Gateway
                     ->save();
             }
 
-            $order->gateway(
+            $order->gatewayData(
                 array_merge(
-                    $order->gateway(),
+                    $order->gatewayData(),
                     [
                         'data' => $responseBody,
                     ]

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -129,8 +129,8 @@ class StripeGateway extends BaseGateway implements Gateway
 
         $paymentIntent = null;
 
-        if (isset($order->gateway()['data']['payment_intent'])) {
-            $paymentIntent = $order->gateway()['data']['payment_intent'];
+        if (isset($order->gatewayData()['data']['payment_intent'])) {
+            $paymentIntent = $order->gatewayData()['data']['payment_intent'];
         }
 
         if (isset($order->get('stripe')['intent'])) {

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -129,8 +129,8 @@ class StripeGateway extends BaseGateway implements Gateway
 
         $paymentIntent = null;
 
-        if (isset($order->gatewayData()['data']['payment_intent'])) {
-            $paymentIntent = $order->gatewayData()['data']['payment_intent'];
+        if ($order->gatewayData()->data()->has('payment_intent')) {
+            $paymentIntent = $order->gatewayData()->data()->get('payment_intent');
         }
 
         if (isset($order->get('stripe')['intent'])) {

--- a/src/Gateways/Manager.php
+++ b/src/Gateways/Manager.php
@@ -59,12 +59,7 @@ class Manager implements Contract
         }
 
         $order = Order::find($order->id());
-
-        $order->gatewayData([
-            'use' => $this->handle,
-            'data' => $checkout,
-        ]);
-
+        $order->gatewayData(gateway: $this->handle, data: $checkout);
         $order->save();
 
         return $checkout;

--- a/src/Gateways/Manager.php
+++ b/src/Gateways/Manager.php
@@ -60,7 +60,7 @@ class Manager implements Contract
 
         $order = Order::find($order->id());
 
-        $order->gateway([
+        $order->gatewayData([
             'use' => $this->handle,
             'data' => $checkout,
         ]);

--- a/src/Orders/EloquentOrderRepository.php
+++ b/src/Orders/EloquentOrderRepository.php
@@ -62,7 +62,7 @@ class EloquentOrderRepository implements RepositoryContract
             ->couponTotal($model->coupon_total)
             ->customer($model->customer_id)
             ->coupon($model->coupon)
-            ->gateway($model->gateway)
+            ->gatewayData($model->gateway)
             ->data(
                 collect($model->data)
                     ->merge([
@@ -116,7 +116,7 @@ class EloquentOrderRepository implements RepositoryContract
         $model->coupon_total = $order->couponTotal();
         $model->customer_id = $order->customer() instanceof CustomerContract ? $order->customer()->id() : $order->customer();
         $model->coupon = $order->coupon() instanceof CouponContract ? $order->coupon()->id() : $order->coupon();
-        $model->gateway = $order->gateway();
+        $model->gateway = $order->gatewayData();
 
         $model->shipping_name = $order->get('shipping_name');
         $model->shipping_address = $order->get('shipping_address');

--- a/src/Orders/EloquentOrderRepository.php
+++ b/src/Orders/EloquentOrderRepository.php
@@ -48,7 +48,7 @@ class EloquentOrderRepository implements RepositoryContract
 
     protected function fromModel(OrderModel $model)
     {
-        return app(Order::class)
+        $order = app(Order::class)
             ->resource($model)
             ->id($model->id)
             ->orderNumber($model->order_number)
@@ -62,7 +62,6 @@ class EloquentOrderRepository implements RepositoryContract
             ->couponTotal($model->coupon_total)
             ->customer($model->customer_id)
             ->coupon($model->coupon)
-            ->gatewayData($model->gateway)
             ->data(
                 collect($model->data)
                     ->merge([
@@ -90,6 +89,16 @@ class EloquentOrderRepository implements RepositoryContract
                             ->toArray()
                     )
             );
+
+        if ($model->gateway) {
+            $order->gatewayData(
+                gateway: $model->gateway['use'] ?? null,
+                data: $model->gateway['data'] ?? null,
+                refund: $model->gateway['refund'] ?? null
+            );
+        }
+
+        return $order;
     }
 
     public function make(): Order
@@ -116,7 +125,7 @@ class EloquentOrderRepository implements RepositoryContract
         $model->coupon_total = $order->couponTotal();
         $model->customer_id = $order->customer() instanceof CustomerContract ? $order->customer()->id() : $order->customer();
         $model->coupon = $order->coupon() instanceof CouponContract ? $order->coupon()->id() : $order->coupon();
-        $model->gateway = $order->gatewayData();
+        $model->gateway = $order->gatewayData()?->toArray();
 
         $model->shipping_name = $order->get('shipping_name');
         $model->shipping_address = $order->get('shipping_address');

--- a/src/Orders/EntryOrderRepository.php
+++ b/src/Orders/EntryOrderRepository.php
@@ -68,7 +68,7 @@ class EntryOrderRepository implements RepositoryContract
         }
 
         if ($entry->has('gateway')) {
-            $order->gateway($entry->get('gateway'));
+            $order->gatewayData($entry->get('gateway'));
         }
 
         return $order->data(array_merge(
@@ -124,7 +124,7 @@ class EntryOrderRepository implements RepositoryContract
                     'coupon_total' => $order->couponTotal(),
                     'customer' => $order->customer() instanceof CustomerContract ? $order->customer()->id() : $order->customer(),
                     'coupon' => $order->coupon() instanceof CouponContract ? $order->coupon()->id() : $order->coupon(),
-                    'gateway' => $order->gateway(),
+                    'gateway' => $order->gatewayData(),
                 ],
             )
         );

--- a/src/Orders/EntryOrderRepository.php
+++ b/src/Orders/EntryOrderRepository.php
@@ -67,8 +67,12 @@ class EntryOrderRepository implements RepositoryContract
             $order->coupon($entry->get('coupon'));
         }
 
-        if ($entry->has('gateway')) {
-            $order->gatewayData($entry->get('gateway'));
+        if ($gatewayData = $entry->get('gateway')) {
+            $order->gatewayData(
+                gateway: $gatewayData['use'] ?? null,
+                data: $gatewayData['data'] ?? null,
+                refund: $gatewayData['refund'] ?? null,
+            );
         }
 
         return $order->data(array_merge(
@@ -124,7 +128,7 @@ class EntryOrderRepository implements RepositoryContract
                     'coupon_total' => $order->couponTotal(),
                     'customer' => $order->customer() instanceof CustomerContract ? $order->customer()->id() : $order->customer(),
                     'coupon' => $order->coupon() instanceof CouponContract ? $order->coupon()->id() : $order->coupon(),
-                    'gateway' => $order->gatewayData(),
+                    'gateway' => $order->gatewayData()?->toArray(),
                 ],
             )
         );

--- a/src/Orders/GatewayData.php
+++ b/src/Orders/GatewayData.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Orders;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway as GatewayContract;
 use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
 use DoubleThreeDigital\SimpleCommerce\Gateways\Manager;
 use Illuminate\Support\Collection;
@@ -10,7 +9,9 @@ use Illuminate\Support\Collection;
 class GatewayData
 {
     public $gateway;
+
     public $data;
+
     public $refund;
 
     public function __construct(array $gatewayData)

--- a/src/Orders/GatewayData.php
+++ b/src/Orders/GatewayData.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\Orders;
+
+use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway as GatewayContract;
+use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
+use DoubleThreeDigital\SimpleCommerce\Gateways\Manager;
+use Illuminate\Support\Collection;
+
+class GatewayData
+{
+    public $gateway;
+    public $data;
+    public $refund;
+
+    public function __construct(array $gatewayData)
+    {
+        if (isset($gatewayData['use'])) {
+            $this->gateway = $gatewayData['use'];
+        }
+
+        if (isset($gatewayData['data'])) {
+            $this->data = collect($gatewayData['data']);
+        }
+
+        if (isset($gatewayData['refund'])) {
+            $this->refund = collect($gatewayData['refund']);
+        }
+    }
+
+    public function gateway(): Manager
+    {
+        if (! $this->gateway) {
+            return null;
+        }
+
+        return Gateway::use($this->gateway);
+    }
+
+    public function data(): Collection
+    {
+        return $this->data;
+    }
+
+    public function refund(): ?Collection
+    {
+        return $this->refund;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'use' => $this->gateway,
+            'data' => $this->data ? $this->data->toArray() : null,
+            'refund' => $this->refund ? $this->refund->toArray() : null,
+        ];
+    }
+}

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -206,7 +206,7 @@ class Order implements Contract
             ->args(func_get_args());
     }
 
-    public function gateway($gateway = null)
+    public function gatewayData($gateway = null)
     {
         return $this
             ->fluentlyGetOrSet('gateway')
@@ -215,7 +215,7 @@ class Order implements Contract
 
     public function currentGateway(): ?array
     {
-        return SimpleCommerce::gateways()->firstWhere('handle', $this->gateway()['use']);
+        return SimpleCommerce::gateways()->firstWhere('handle', $this->gatewayData()['use']);
     }
 
     public function resource($resource = null)
@@ -362,11 +362,11 @@ class Order implements Contract
     {
         $this->updatePaymentStatus(PaymentStatus::Refunded);
 
-        $data = array_merge($this->gateway(), [
+        $data = array_merge($this->gatewayData(), [
             'refund' => $refundData,
         ]);
 
-        $this->gateway($data);
+        $this->gatewayData($data);
 
         return $this;
     }

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -206,7 +206,7 @@ class Order implements Contract
             ->args(func_get_args());
     }
 
-    public function gatewayData(string $gateway = null, array $data = null, array $refund = null): ?GatewayData
+    public function gatewayData(?string $gateway = null, ?array $data = null, ?array $refund = null): ?GatewayData
     {
         if ($gateway) {
             $this->gateway = array_merge($this->gateway ?? [], ['use' => $gateway]);

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -206,16 +206,25 @@ class Order implements Contract
             ->args(func_get_args());
     }
 
-    public function gatewayData($gateway = null)
+    public function gatewayData(string $gateway = null, array $data = null, array $refund = null): ?GatewayData
     {
-        return $this
-            ->fluentlyGetOrSet('gateway')
-            ->args(func_get_args());
-    }
+        if ($gateway) {
+            $this->gateway = array_merge($this->gateway ?? [], ['use' => $gateway]);
+        }
 
-    public function currentGateway(): ?array
-    {
-        return SimpleCommerce::gateways()->firstWhere('handle', $this->gatewayData()['use']);
+        if ($data) {
+            $this->gateway = array_merge($this->gateway ?? [], ['data' => $data]);
+        }
+
+        if ($refund) {
+            $this->gateway = array_merge($this->gateway ?? [], ['refund' => $refund]);
+        }
+
+        if (! $this->gateway) {
+            return null;
+        }
+
+        return new GatewayData($this->gateway);
     }
 
     public function resource($resource = null)
@@ -362,11 +371,7 @@ class Order implements Contract
     {
         $this->updatePaymentStatus(PaymentStatus::Refunded);
 
-        $data = array_merge($this->gatewayData(), [
-            'refund' => $refundData,
-        ]);
-
-        $this->gatewayData($data);
+        $this->gatewayData(refund: $refundData);
 
         return $this;
     }

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -121,11 +121,7 @@ class CheckoutTags extends SubTag
 
         $prepare = $prepare->prepare(request(), $cart);
 
-        $cart->gatewayData([
-            ...$cart->gatewayData() ?? [],
-            'use' => $gateway['class']::handle(),
-        ]);
-
+        $cart->gatewayData(gateway: $gateway['class']::handle());
         $cart->set($gateway['handle'], $prepare);
 
         $cart->save();

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -121,8 +121,8 @@ class CheckoutTags extends SubTag
 
         $prepare = $prepare->prepare(request(), $cart);
 
-        $cart->gateway([
-            ...$cart->gateway() ?? [],
+        $cart->gatewayData([
+            ...$cart->gatewayData() ?? [],
             'use' => $gateway['class']::handle(),
         ]);
 

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -379,15 +379,15 @@ test('has checkout rules', function () {
 test('can refund charge', function () {
     Stripe::setApiKey(env('STRIPE_SECRET'));
 
-    $order = Order::make()->grandTotal(1234)->gatewayData([
-        'use' => StripeGateway::handle(),
-        'data' => [
+    $order = Order::make()->grandTotal(1234)->gatewayData(
+        use: StripeGateway::handle(),
+        data: [
             'payment_intent' => $paymentIntent = PaymentIntent::create([
                 'amount' => 1234,
                 'currency' => 'GBP',
             ])->id,
-        ],
-    ]);
+        ]
+    );
 
     $order->save();
 

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -380,7 +380,7 @@ test('can refund charge', function () {
     Stripe::setApiKey(env('STRIPE_SECRET'));
 
     $order = Order::make()->grandTotal(1234)->gatewayData(
-        use: StripeGateway::handle(),
+        gateway: StripeGateway::handle(),
         data: [
             'payment_intent' => $paymentIntent = PaymentIntent::create([
                 'amount' => 1234,

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -379,7 +379,9 @@ test('has checkout rules', function () {
 test('can refund charge', function () {
     Stripe::setApiKey(env('STRIPE_SECRET'));
 
-    $order = Order::make()->grandTotal(1234)->gatewayData(
+    $order = Order::make()->grandTotal(1234);
+
+    $order->gatewayData(
         gateway: StripeGateway::handle(),
         data: [
             'payment_intent' => $paymentIntent = PaymentIntent::create([

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -379,7 +379,7 @@ test('has checkout rules', function () {
 test('can refund charge', function () {
     Stripe::setApiKey(env('STRIPE_SECRET'));
 
-    $order = Order::make()->grandTotal(1234)->gateway([
+    $order = Order::make()->grandTotal(1234)->gatewayData([
         'use' => StripeGateway::handle(),
         'data' => [
             'payment_intent' => $paymentIntent = PaymentIntent::create([


### PR DESCRIPTION
This pull request refactors the gateway methods on orders.

Previously, orders had two gateway methods:

* `gateway` which would just return an array of gateway data.
* `currentGateway` which would give you an instance of a gateway.

This PR helps to tidy that up a little and makes it "friendlier" to work with by introducing a simple DTO.