### PR TITLE
[6.x] Remove `$key` parameter from the `statusLog` method

### DIFF
--- a/docs/upgrade-guides/v5-x-to-v6-0.md
+++ b/docs/upgrade-guides/v5-x-to-v6-0.md
@@ -80,6 +80,23 @@ This saves you needing to `find` the order/product/customer to use any of Simple
 
 The "Overview" page has been removed in Simple Commerce v6, in favour of Dashboard Widgets. To configure Simple Commerce widgets, review the [Control Panel](/control-panel#content-widgets) page.
 
+### Medium: Changes to the `statusLog` method on Orders
+
+The `statusLog` method no longer accepts passing a status. Instead, you should query the status log for the event you're after, then get the `->last()` item in the collection.
+
+```php
+// Previously
+$order->statusLog('paid');
+
+// Now
+use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
+
+$order->statusLog()
+    ->where('status', OrderStatus::Placed)
+    ->map(fn ($statusLogEvent) => $statusLogEvent->data()->timestamp)
+    ->last();
+```
+
 ## Previous upgrade guides
 
 -   [v2.2 to v2.3](/upgrade-guides/v2-2-to-v2-3)

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -311,7 +311,7 @@ class Order implements Contract
         return $this;
     }
 
-    public function statusLog($key = null): Collection|string|null
+    public function statusLog(): Collection|string|null
     {
         // Convert the old format to the new format. We can probably remove this in the future.
         if (! empty($this->get('status_log')) && ! is_array(Arr::first($this->get('status_log')))) {
@@ -321,14 +321,6 @@ class Order implements Contract
                     timestamp: Carbon::parse($date)->timestamp
                 );
             })->values()->toArray());
-        }
-
-        // v5 compatability: when a $key is passed, we want to return the date of the status change. (v6 TODO: remove this)
-        if ($key) {
-            return collect($this->get('status_log'))
-                ->filter(fn (array $statusLogEvent) => $statusLogEvent['status'] === $key)
-                ->map(fn (array $statusLogEvent) => Carbon::parse($statusLogEvent['timestamp'])->format('Y-m-d H:i'))
-                ->first();
         }
 
         return collect($this->get('status_log'))->map(function (array $statusLogEvent) {


### PR DESCRIPTION
This pull request removes the `$key` parameter from being accepted by the `statusLog` method. This parameter was kept after the refactor in #954, since it'd require a breaking change to remove.