### PR TITLE
[6.x] When customer exists in cart, update customer with provided email.

### DIFF
--- a/src/Http/Controllers/Concerns/HandlesCustomerInformation.php
+++ b/src/Http/Controllers/Concerns/HandlesCustomerInformation.php
@@ -62,6 +62,7 @@ trait HandlesCustomerInformation
         // If the order already has a customer assigned, update the email on the existing customer.
         if ($customer = $cart->customer()) {
             $customer->email($email)->save();
+
             return $cart;
         }
 

--- a/src/Http/Controllers/Concerns/HandlesCustomerInformation.php
+++ b/src/Http/Controllers/Concerns/HandlesCustomerInformation.php
@@ -59,6 +59,13 @@ trait HandlesCustomerInformation
 
     private function findOrCreateCustomer(OrderContract $cart, string $email): OrderContract
     {
+        // If the order already has a customer assigned, update the email on the existing customer.
+        if ($customer = $cart->customer()) {
+            $customer->email($email)->save();
+            return $cart;
+        }
+
+        // Otherwise, find or create a customer with the provided email.
         try {
             $customer = Customer::findByEmail($email);
             $cart->customer($customer->id());

--- a/tests/Http/Controllers/CartControllerTest.php
+++ b/tests/Http/Controllers/CartControllerTest.php
@@ -181,6 +181,35 @@ test('can update cart with customer already in cart', function () {
     expect($customer->id)->toBe($cart->customer()->id());
 });
 
+test('can update cart with customer already in cart and ensure the customer email is updated', function () {
+    $customer = Customer::make()
+        ->email('dan.smith@example.com')
+        ->data([
+            'name' => 'Dan Smith',
+        ]);
+
+    $customer->save();
+
+    $cart = Order::make()->customer($customer->id);
+    $cart->save();
+
+    $data = [
+        'customer' => ['email' => 'dan@smith.test'],
+    ];
+
+    $response = $this
+        ->from('/cart')
+        ->withSession(['simple-commerce-cart' => $cart->id])
+        ->post(route('statamic.simple-commerce.cart.update'), $data);
+
+    $response->assertRedirect('/cart');
+
+    $cart = $cart->fresh();
+
+    expect($customer->id)->toBe($cart->customer()->id());
+    expect('dan@smith.test')->toBe($cart->customer()->email());
+});
+
 /**
  * https://github.com/duncanmcclean/simple-commerce/issues/658
  */


### PR DESCRIPTION
This pull request makes a behaviour change to the way customer information is handled in the `{{ sc:cart:addItem }}`, `{{ sc:cart:update }}` and `{{ sc:checkout }}` forms.

Previously, when you had one of these forms with a `customer[email]` input & a customer was already assigned to the cart, submitting the form with a *different* email than the existing customers would create an entirely new customer in Simple Commerce.

```html
<input type="email" name="customer[email]" />
```

However, this PR changes that behaviour. Instead of a new customer being created, Simple Commerce will instead update the email of the existing customer. 

Related: #934