### PR TITLE
[5.x] Fix "Top Customers" query when storing users in a database

### DIFF
--- a/src/Overview.php
+++ b/src/Overview.php
@@ -14,6 +14,7 @@ use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
 use DoubleThreeDigital\SimpleCommerce\Orders\StatusLogEvent;
 use DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository;
 use DoubleThreeDigital\SimpleCommerce\Support\Runway;
+use Illuminate\Database\SQLiteConnection;
 use Illuminate\Http\Request;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
@@ -213,7 +214,11 @@ class Overview
                     $query = $userModel::query()
                         ->where('orders', '!=', null)
                         ->orderBy(function ($query) {
-                            $query->selectRaw('JSON_ARRAY_LENGTH(orders)');
+                            $query->when($query->connection instanceof SQLiteConnection, function ($query) {
+                                $query->selectRaw('JSON_ARRAY_LENGTH(orders)');
+                            }, function ($query) {
+                                $query->selectRaw('JSON_LENGTH(orders)');
+                            });
                         }, 'desc')
                         ->limit(5)
                         ->get()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -80,7 +80,7 @@ abstract class TestCase extends OrchestraTestCase
         foreach ($configs as $config) {
             $app['config']->set(
                 "statamic.$config",
-                require(__DIR__."/../vendor/statamic/cms/config/{$config}.php")
+                require (__DIR__."/../vendor/statamic/cms/config/{$config}.php")
             );
         }
 
@@ -95,7 +95,7 @@ abstract class TestCase extends OrchestraTestCase
             'directory' => __DIR__.'/__fixtures__/users',
         ]);
 
-        $app['config']->set('simple-commerce', require(__DIR__.'/../config/simple-commerce.php'));
+        $app['config']->set('simple-commerce', require (__DIR__.'/../config/simple-commerce.php'));
         $app['config']->set('simple-commerce.cart.driver', SessionDriver::class);
 
         $app['config']->set('simple-commerce.tax_engine', StandardTaxEngine::class);


### PR DESCRIPTION
This pull request attempts to fix an issue where the query for the "Top Customers" widget on the Overview sometimes caused a database error, depending on the version of MySQL you have installed.

To resolve the issue for those using MySQL, I've adjusted the query to use the `JSON_LENGTH` function instead. However, since SQLite doesn't support this function, it'll continue to use the working `JSON_ARRAY_LENGTH` function.

Fixes #906.