### PR TITLE
[6.x] Add native fetch example to Ajax docs

### DIFF
--- a/docs/ajax.md
+++ b/docs/ajax.md
@@ -40,7 +40,11 @@ let params = {
 };
 ```
 
-## Example
+## Examples
+
+To get you started, here's two examples of making requests to Simple Commerce endpoints using `axios` and Javascript's native `fetch` API:
+
+### `axios`
 
 Here's a quick & basic example of using Axios to make an HTTP request to one of Simple Commerce's endpoints.
 
@@ -52,11 +56,13 @@ let params = {
 };
 
 axios.post("/!/simple-commerce/cart-items", params).then((response) => {
-  console.log("Whoop! The product has been added to your cart");
+  console.log("Woo hoo! The product has been added to your cart");
 });
 ```
 
-Using a native the `fetch()` function, you’ll need to specify a few headers for the request.
+### `fetch`
+
+Here's a quick example of using JavaScript's native `fetch` API to make an HTTP request to one of Simple Commerce's endpoints. Make sure you pass the `Accept` & `Content-Type` headers, otherwise you won't receive the expected response.
 
 ```js
 let headers = {
@@ -76,7 +82,7 @@ fetch("/!/simple-commerce/cart-items", {
   headers: headers,
   body: JSON.stringify(body),
 }).then((response) => {
-  console.log("Whoop! The product has been added to your cart");
+  console.log("Woo hoo! The product has been added to your cart");
 });
 ```
 

--- a/docs/ajax.md
+++ b/docs/ajax.md
@@ -52,9 +52,34 @@ let params = {
 };
 
 axios.post("/!/simple-commerce/cart-items", params).then((response) => {
-  console.alert("Whoop! The product has been added to your cart");
+  console.log("Whoop! The product has been added to your cart");
 });
 ```
+
+Using a native the `fetch()` function, you’ll need to specify a few headers for the request.
+
+```js
+let headers = {
+  "Accept": "application/json",
+  "Content-Type": "application/json",
+};
+
+let body = {
+  _token: "{{ csrf_token }}",
+  _request: "Empty",
+  product: "your-product-id",
+  quantity: 1,
+};
+
+fetch("/!/simple-commerce/cart-items", {
+  method: "POST",
+  headers: headers,
+  body: JSON.stringify(body),
+}).then((response) => {
+  console.log("Whoop! The product has been added to your cart");
+});
+```
+
 
 ## Form Parameter Validation
 


### PR DESCRIPTION
Following issue https://github.com/duncanmcclean/simple-commerce/issues/975, I added an example of how to make an Ajax request to a Simple Commerce endpoint with the browser native `fetch` function.