### PR TITLE
[6.x] Re-do the `UpdateClassReferences` update script

### DIFF
--- a/src/UpdateScripts/v6_0/UpdateClassReferences.php
+++ b/src/UpdateScripts/v6_0/UpdateClassReferences.php
@@ -5,8 +5,8 @@ namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Statamic\UpdateScripts\UpdateScript;
 
 class UpdateClassReferences extends UpdateScript
@@ -27,7 +27,7 @@ class UpdateClassReferences extends UpdateScript
     {
         Order::query()->whereNotNull('gateway')->chunk(100, function (Collection $orders) {
             $orders
-                ->filter(fn (OrderContract $order) => str_contains(Arr::get($order->gateway, 'use'), "\\"))
+                ->filter(fn (OrderContract $order) => str_contains(Arr::get($order->gateway, 'use'), '\\'))
                 ->each(function (OrderContract $order) {
                     $class = Arr::get($order->gateway, 'use');
 
@@ -50,7 +50,7 @@ class UpdateClassReferences extends UpdateScript
     {
         Order::query()->whereNotNull('shipping_method')->chunk(100, function (Collection $orders) {
             $orders
-                ->filter(fn (OrderContract $order) => str_contains($order->get('shipping_method'), "\\"))
+                ->filter(fn (OrderContract $order) => str_contains($order->get('shipping_method'), '\\'))
                 ->each(function (OrderContract $order) {
                     $class = $order->get('shipping_method');
 

--- a/src/UpdateScripts/v6_0/UpdateClassReferences.php
+++ b/src/UpdateScripts/v6_0/UpdateClassReferences.php
@@ -2,7 +2,11 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0;
 
+use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use Statamic\UpdateScripts\UpdateScript;
 
 class UpdateClassReferences extends UpdateScript
@@ -14,24 +18,54 @@ class UpdateClassReferences extends UpdateScript
 
     public function update()
     {
-        Order::query()
-            ->where('gateway', '!=', null)
-            ->chunk(50, function ($orders) {
-                $orders->each(function ($order) {
-                    // When the gateway reference is still a class, change it to the handle.
-                    if ($order->gateway() && class_exists($order->gateway()['use'])) {
-                        $order->gateway(array_merge($order->gateway(), [
-                            'use' => $order->gateway()['use']::handle(),
-                        ]));
+        $this
+            ->updateReferencesToGateways()
+            ->updateReferencesToShippingMethods();
+    }
 
-                        $order->save();
+    protected function updateReferencesToGateways(): self
+    {
+        Order::query()->whereNotNull('gateway')->chunk(100, function (Collection $orders) {
+            $orders
+                ->filter(fn (OrderContract $order) => str_contains(Arr::get($order->gateway, 'use'), "\\"))
+                ->each(function (OrderContract $order) {
+                    $class = Arr::get($order->gateway, 'use');
+
+                    // Adjust the class name before new'ing it up since the namespace has changed.
+                    if (Str::startsWith($class, 'DoubleThreeDigital')) {
+                        // $class = str_replace('DoubleThreeDigital', 'DuncanMcClean', $class);
                     }
 
-                    // When the shipping method reference is still a class, change it to the handle.
-                    if ($order->has('shipping_method') && class_exists($order->get('shipping_method'))) {
-                        $order->set('shipping_method', $order->get('shipping_method')::handle())->saveQuietly();
-                    }
+                    $handle = $class::handle();
+
+                    $order->gatewayData(gateway: $handle);
+                    $order->save();
                 });
-            });
+        });
+
+        return $this;
+    }
+
+    protected function updateReferencesToShippingMethods(): self
+    {
+        Order::query()->whereNotNull('shipping_method')->chunk(100, function (Collection $orders) {
+            $orders
+                ->filter(fn (OrderContract $order) => str_contains($order->get('shipping_method'), "\\"))
+                ->each(function (OrderContract $order) {
+                    $class = $order->get('shipping_method');
+
+                    // Adjust the class name before new'ing it up since the namespace has changed.
+                    if (Str::startsWith($class, 'DoubleThreeDigital')) {
+                        // $class = str_replace('DoubleThreeDigital', 'DuncanMcClean', $class);
+                    }
+
+                    $handle = $class::handle();
+
+                    $order->set('shipping_method', $handle);
+                    $order->save();
+                });
+        });
+
+        return $this;
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -14,12 +14,12 @@ use Statamic\Facades\User;
 use Statamic\Statamic;
 
 uses(TestCase::class)
-    ->in('Actions', 'Console', 'Coupons', 'Customers', 'Data', 'Fieldtypes', '__fixtures__', 'Gateways', 'Helpers', 'Http', 'Listeners', 'Modifiers', 'Orders', 'Products', 'Rules', 'Tags', 'Tax');
+    ->in('Actions', 'Console', 'Coupons', 'Customers', 'Data', 'Fieldtypes', '__fixtures__', 'Gateways', 'Helpers', 'Http', 'Listeners', 'Modifiers', 'Orders', 'Products', 'Rules', 'Tags', 'Tax', 'UpdateScripts');
 
 uses(
     SetupCollections::class,
     RefreshContent::class
-)->in('Actions', 'Coupons', 'Customers', 'Listeners', 'Products');
+)->in('Actions', 'Coupons', 'Customers', 'Listeners', 'Products', 'UpdateScripts');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Products/EntryProductRepositoryTest.php
+++ b/tests/Products/EntryProductRepositoryTest.php
@@ -3,11 +3,6 @@
 use DoubleThreeDigital\SimpleCommerce\Contracts\Product as ProductContract;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Products\EntryQueryBuilder;
-use Statamic\Facades\Collection;
-
-afterEach(function () {
-    Collection::find('products')->queryEntries()->get()->each->delete();
-});
 
 it('can get all products', function () {
     Product::make()->id('one')->price(1500)->save();

--- a/tests/UpdateScripts/UpdateClassReferencesTest.php
+++ b/tests/UpdateScripts/UpdateClassReferencesTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Statamic\Facades\Entry;
 use DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0\UpdateClassReferences;
+use Statamic\Facades\Entry;
 
 it('updates reference to gateway class', function () {
     $orderEntry = Entry::make()

--- a/tests/UpdateScripts/UpdateClassReferencesTest.php
+++ b/tests/UpdateScripts/UpdateClassReferencesTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Statamic\Facades\Entry;
+use DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0\UpdateClassReferences;
+
+it('updates reference to gateway class', function () {
+    $orderEntry = Entry::make()
+        ->collection('orders')
+        ->id('test')
+        ->data(['gateway' => ['use' => 'DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway', 'data' => ['id' => 'pi_1234']]]);
+
+    $orderEntry->save();
+
+    (new UpdateClassReferences('doublethreedigital/simple-commerce', '6.0.0'))->update();
+
+    $orderEntry->fresh();
+
+    expect($orderEntry->get('gateway'))->toBe([
+        'use' => 'stripe',
+        'data' => ['id' => 'pi_1234'],
+        'refund' => null,
+    ]);
+});
+
+it('updates reference to shipping method class', function () {
+    $orderEntry = Entry::make()
+        ->collection('orders')
+        ->id('test')
+        ->data(['shipping_method' => 'DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping']);
+
+    $orderEntry->save();
+
+    (new UpdateClassReferences('doublethreedigital/simple-commerce', '6.0.0'))->update();
+
+    $orderEntry->fresh();
+
+    expect($orderEntry->get('shipping_method'))->toBe('free_shipping');
+});


### PR DESCRIPTION
This pull request re-does the `UpdateClassReferences` update script, responsible for replacing references to payment gateway & shipping method classes with handles. 

This update script was introduced in #968 but since it was built I've made API changes in a few places which caused it to error out. It was also missing tests, which this PR adds. 
