### PR TITLE
[6.x] Implement `findOrFail` methods on repositories

### DIFF
--- a/docs/upgrade-guides/v5-x-to-v6-0.md
+++ b/docs/upgrade-guides/v5-x-to-v6-0.md
@@ -174,6 +174,12 @@ As part of the update process, all of your products should be updated so `Produc
 
 Previously, the "Download History" functionality provided by the addon was opt-in. This feature is now always enabled.
 
+### Low: Repository `find` methods no longer throw exceptions
+
+The `find` method on the `Order`/`Product`/`Customer` facades will no longer throw an exception when the entry or model can't be found. Instead, it'll now return `null`.
+
+You can use the `findOrFail` methods instead if you wish exceptions to be thrown.
+
 ## Previous upgrade guides
 
 -   [v2.2 to v2.3](/upgrade-guides/v2-2-to-v2-3)

--- a/src/Contracts/CustomerRepository.php
+++ b/src/Contracts/CustomerRepository.php
@@ -10,6 +10,8 @@ interface CustomerRepository
 
     public function find($id): ?Customer;
 
+    public function findOrFail($id): Customer;
+
     public function findByEmail(string $email): ?Customer;
 
     public function make(): Customer;

--- a/src/Contracts/OrderRepository.php
+++ b/src/Contracts/OrderRepository.php
@@ -10,6 +10,8 @@ interface OrderRepository
 
     public function find($id): ?Order;
 
+    public function findOrFail($id): Order;
+
     public function make(): Order;
 
     public function save(Order $order): void;

--- a/src/Contracts/ProductRepository.php
+++ b/src/Contracts/ProductRepository.php
@@ -10,6 +10,8 @@ interface ProductRepository
 
     public function find($id): ?Product;
 
+    public function findOrFail($id): Product;
+
     public function make(): Product;
 
     public function save(Product $product): void;

--- a/src/Customers/EloquentCustomerRepository.php
+++ b/src/Customers/EloquentCustomerRepository.php
@@ -37,6 +37,17 @@ class EloquentCustomerRepository implements RepositoryContract
         $model = (new $this->model)->find($id);
 
         if (! $model) {
+            return null;
+        }
+
+        return $this->fromModel($model);
+    }
+
+    public function findOrFail($id): Customer
+    {
+        $model = (new $this->model)->find($id);
+
+        if (! $model) {
             throw new CustomerNotFound("Customer [{$id}] could not be found.");
         }
 

--- a/src/Customers/EntryCustomerRepository.php
+++ b/src/Customers/EntryCustomerRepository.php
@@ -36,10 +36,21 @@ class EntryCustomerRepository implements RepositoryContract
         $entry = Entry::find($id);
 
         if (! $entry) {
-            throw new CustomerNotFound("Customer [{$id}] could not be found.");
+            return null;
         }
 
         return $this->fromEntry($entry);
+    }
+
+    public function findOrFail($id): Customer
+    {
+        $customer = $this->find($id);
+
+        if (! $customer) {
+            throw new CustomerNotFound("Customer [{$id}] could not be found.");
+        }
+
+        return $customer;
     }
 
     public function findByEmail(string $email): ?Customer

--- a/src/Customers/UserCustomerRepository.php
+++ b/src/Customers/UserCustomerRepository.php
@@ -37,6 +37,17 @@ class UserCustomerRepository implements RepositoryContract
         $user = User::find($id);
 
         if (! $user) {
+            return null;
+        }
+
+        return $this->fromUser($user);
+    }
+
+    public function findOrFail($id): Customer
+    {
+        $user = User::find($id);
+
+        if (! $user) {
             throw new CustomerNotFound("Customer [{$id}] could not be found.");
         }
 

--- a/src/Orders/EloquentOrderRepository.php
+++ b/src/Orders/EloquentOrderRepository.php
@@ -47,10 +47,21 @@ class EloquentOrderRepository implements RepositoryContract
         $model = (new $this->model)->find($id);
 
         if (! $model) {
-            throw new OrderNotFound("Order [{$id}] could not be found.");
+            return null;
         }
 
         return $this->fromModel($model);
+    }
+
+    public function findOrFail($id): Order
+    {
+        $order = $this->find($id);
+
+        if (! $order) {
+            throw new OrderNotFound("Order [{$id}] could not be found.");
+        }
+
+        return $order;
     }
 
     public function fromModel(OrderModel $model)

--- a/src/Orders/EntryOrderRepository.php
+++ b/src/Orders/EntryOrderRepository.php
@@ -41,10 +41,21 @@ class EntryOrderRepository implements RepositoryContract
         $entry = Entry::find($id);
 
         if (! $entry) {
-            throw new OrderNotFound("Order [{$id}] could not be found.");
+            return null;
         }
 
         return $this->fromEntry($entry);
+    }
+
+    public function findOrFail($id): Order
+    {
+        $order = $this->find($id);
+
+        if (! $order) {
+            throw new OrderNotFound("Order [{$id}] could not be found.");
+        }
+
+        return $order;
     }
 
     public function fromEntry($entry): Order

--- a/src/Products/EntryProductRepository.php
+++ b/src/Products/EntryProductRepository.php
@@ -36,10 +36,21 @@ class EntryProductRepository implements RepositoryContract
         $entry = Entry::find($id);
 
         if (! $entry) {
-            throw new ProductNotFound("Product [{$id}] could not be found.");
+            return null;
         }
 
         return $this->fromEntry($entry);
+    }
+
+    public function findOrFail($id): Product
+    {
+        $product = $this->find($id);
+
+        if (! $product) {
+            throw new ProductNotFound("Product [{$id}] could not be found.");
+        }
+
+        return $product;
     }
 
     public function fromEntry($entry)

--- a/src/Rules/ProductExists.php
+++ b/src/Rules/ProductExists.php
@@ -10,13 +10,9 @@ class ProductExists implements Rule
 {
     public function passes($attribute, $value)
     {
-        try {
-            Product::find($value);
+        $product = Product::find($value);
 
-            return true;
-        } catch (ProductNotFound $e) {
-            return false;
-        }
+        return ! is_null($product);
     }
 
     public function message()

--- a/src/Rules/ProductExists.php
+++ b/src/Rules/ProductExists.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\SimpleCommerce\Rules;
 
-use DoubleThreeDigital\SimpleCommerce\Exceptions\ProductNotFound;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use Illuminate\Contracts\Validation\Rule;
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -463,13 +463,13 @@ class ServiceProvider extends AddonServiceProvider
             $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], \DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository::class)
         ) {
             Collection::computed(SimpleCommerce::orderDriver()['collection'], 'order_date', function ($entry, $value) {
-                try {
-                    $order = Order::find($entry->id());
+                $order = Order::find($entry->id());
 
-                    return $order->statusLog()->where('status', OrderStatus::Placed)->map->date()->last();
-                } catch (OrderNotFound $e) {
+                if (! $order) {
                     return Carbon::now();
                 }
+
+                return $order->statusLog()->where('status', OrderStatus::Placed)->map->date()->last();
             });
         }
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,7 +3,6 @@
 namespace DoubleThreeDigital\SimpleCommerce;
 
 use Barryvdh\Debugbar\Facade as Debugbar;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
 use DoubleThreeDigital\SimpleCommerce\Support\Runway;

--- a/tests/Customers/EloquentCustomerRepositoryTest.php
+++ b/tests/Customers/EloquentCustomerRepositoryTest.php
@@ -3,6 +3,7 @@
 use DoubleThreeDigital\SimpleCommerce\Contracts\Customer as CustomerContract;
 use DoubleThreeDigital\SimpleCommerce\Customers\CustomerModel;
 use DoubleThreeDigital\SimpleCommerce\Customers\EloquentQueryBuilder;
+use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
 use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
 use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\UseDatabaseContentDrivers;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -77,6 +78,25 @@ it('can find customer by id', function () {
     expect($customer->name)->toBe($find->name());
     expect($customer->email)->toBe($find->email());
     expect('Press Secretary')->toBe($find->get('role'));
+});
+
+it('can findOrFail customer by id', function () {
+    $customer = CustomerModel::create([
+        'name' => 'CJ Cregg',
+        'email' => 'cj@whitehouse.gov',
+        'data' => [
+            'role' => 'Press Secretary',
+        ],
+    ]);
+
+    $findOrFail = Customer::findOrFail($customer->id);
+
+    expect($customer->id)->toBe($findOrFail->id());
+    expect($customer->name)->toBe($findOrFail->name());
+    expect($customer->email)->toBe($findOrFail->email());
+    expect('Press Secretary')->toBe($findOrFail->get('role'));
+
+    expect(fn () => Customer::findOrFail(123))->toThrow(CustomerNotFound::class);
 });
 
 it('can find customer by email', function () {

--- a/tests/Customers/EntryCustomerRepositoryTest.php
+++ b/tests/Customers/EntryCustomerRepositoryTest.php
@@ -3,6 +3,7 @@
 use DoubleThreeDigital\SimpleCommerce\Contracts\Customer as CustomerContract;
 use DoubleThreeDigital\SimpleCommerce\Customers\Customer as CustomersCustomer;
 use DoubleThreeDigital\SimpleCommerce\Customers\EntryQueryBuilder;
+use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
 use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -52,13 +53,35 @@ it('can find customer by id', function () {
         ])
         ->save();
 
-    $findByEmail = Customer::find($id);
+    $find = Customer::find($id);
 
-    expect($findByEmail instanceof CustomersCustomer)->toBeTrue();
+    expect($find instanceof CustomersCustomer)->toBeTrue();
 
-    expect('Smoke Fire')->toBe($findByEmail->name());
-    expect('smoke@fire.com')->toBe($findByEmail->email());
-    expect('smoke-at-firecom')->toBe($findByEmail->get('slug'));
+    expect('Smoke Fire')->toBe($find->name());
+    expect('smoke@fire.com')->toBe($find->email());
+    expect('smoke-at-firecom')->toBe($find->get('slug'));
+});
+
+it('can findOrFail customer by id', function () {
+    Entry::make()
+        ->collection('customers')
+        ->id($id = Stache::generateId())
+        ->slug('smoke-at-firecom')
+        ->data([
+            'name' => 'Smoke Fire',
+            'email' => 'smoke@fire.com',
+        ])
+        ->save();
+
+    $find = Customer::findOrFail($id);
+
+    expect($find instanceof CustomersCustomer)->toBeTrue();
+
+    expect('Smoke Fire')->toBe($find->name());
+    expect('smoke@fire.com')->toBe($find->email());
+    expect('smoke-at-firecom')->toBe($find->get('slug'));
+
+    expect(fn () => Customer::findOrFail(123))->toThrow(CustomerNotFound::class);
 });
 
 it('can find customer by email', function () {

--- a/tests/Customers/UserCustomerRepositoryTest.php
+++ b/tests/Customers/UserCustomerRepositoryTest.php
@@ -3,6 +3,7 @@
 use DoubleThreeDigital\SimpleCommerce\Contracts\Customer as CustomerContract;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order as ContractsOrder;
 use DoubleThreeDigital\SimpleCommerce\Customers\StacheUserQueryBuilder;
+use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
 use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\Invader;
@@ -68,6 +69,21 @@ test('can find customer by id', function () {
     expect($user->id())->toBe($find->id());
     expect($user->get('name'))->toBe($find->name());
     expect($user->email())->toBe($find->email());
+});
+
+test('can findOrFail customer by id', function () {
+    $user = User::make()->email('james@example.com')->set('name', 'James Example');
+    $user->save();
+
+    $findOrFail = Customer::findOrFail($user->id());
+
+    // $this->assertTrue($find instanceof UserCustomer);
+
+    expect($user->id())->toBe($findOrFail->id());
+    expect($user->get('name'))->toBe($findOrFail->name());
+    expect($user->email())->toBe($findOrFail->email());
+
+    expect(fn () => Customer::findOrFail('123'))->toThrow(CustomerNotFound::class);
 });
 
 test('can find customer by email', function () {

--- a/tests/Orders/EloquentOrderRepositoryTest.php
+++ b/tests/Orders/EloquentOrderRepositoryTest.php
@@ -255,9 +255,7 @@ it('can findOrFail order', function () {
     expect($order->id)->toBe($find->id());
     expect(1)->toBe($find->lineItems()->count());
     expect('bar')->toBe($find->get('foo'));
-});
 
-it('can findOrFail order that does not exist', function () {
     expect(fn () => Order::findOrFail(123))->toThrow(OrderNotFound::class);
 });
 

--- a/tests/Orders/EloquentOrderRepositoryTest.php
+++ b/tests/Orders/EloquentOrderRepositoryTest.php
@@ -2,6 +2,7 @@
 
 use Carbon\Carbon;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
+use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Orders\EloquentQueryBuilder;
@@ -230,6 +231,34 @@ it('can find order with status log events', function () {
     expect(2)->toBe($find->statusLog()->count());
     expect(OrderStatus::Placed)->toBe($find->statusLog()->first()->status);
     expect(OrderStatus::Dispatched)->toBe($find->statusLog()->last()->status);
+});
+
+it('can findOrFail order', function () {
+    $product = Product::make()->price(1000);
+    $product->save();
+
+    $order = OrderModel::create([
+        'items' => [
+            [
+                'product' => $product->id(),
+                'quantity' => 1,
+                'total' => 1000,
+            ],
+        ],
+        'data' => [
+            'foo' => 'bar',
+        ],
+    ]);
+
+    $find = Order::findOrFail($order->id);
+
+    expect($order->id)->toBe($find->id());
+    expect(1)->toBe($find->lineItems()->count());
+    expect('bar')->toBe($find->get('foo'));
+});
+
+it('can findOrFail order that does not exist', function () {
+    expect(fn () => Order::findOrFail(123))->toThrow(OrderNotFound::class);
 });
 
 it('can create order', function () {

--- a/tests/Orders/EntryOrderRepositoryTest.php
+++ b/tests/Orders/EntryOrderRepositoryTest.php
@@ -117,9 +117,7 @@ it('can findOrFail order', function () {
     $order = Order::findOrFail('one');
 
     expect($order)->toBeInstanceOf(OrderContract::class);
-});
 
-it('can findOrFail order that does not exist', function () {
     expect(fn () => Order::findOrFail('two'))->toThrow(OrderNotFound::class);
 });
 

--- a/tests/Orders/EntryOrderRepositoryTest.php
+++ b/tests/Orders/EntryOrderRepositoryTest.php
@@ -2,6 +2,7 @@
 
 use Carbon\Carbon;
 use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
+use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
 use DoubleThreeDigital\SimpleCommerce\Facades\Order;
 use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
 use DoubleThreeDigital\SimpleCommerce\Orders\EntryQueryBuilder;
@@ -108,6 +109,18 @@ it('can find order', function () {
     $order = Order::find('one');
 
     expect($order)->toBeInstanceOf(OrderContract::class);
+});
+
+it('can findOrFail order', function () {
+    Order::make()->id('one')->save();
+
+    $order = Order::findOrFail('one');
+
+    expect($order)->toBeInstanceOf(OrderContract::class);
+});
+
+it('can findOrFail order that does not exist', function () {
+    expect(fn () => Order::findOrFail('two'))->toThrow(OrderNotFound::class);
 });
 
 it('can make order', function () {

--- a/tests/Products/EntryProductRepositoryTest.php
+++ b/tests/Products/EntryProductRepositoryTest.php
@@ -41,12 +41,10 @@ it('can find product', function () {
 it('can findOrFail product', function () {
     Product::make()->id('one')->price(1500)->save();
 
-    $product = Product::find('one');
+    $product = Product::findOrFail('one');
 
     expect($product)->toBeInstanceOf(ProductContract::class);
-});
 
-it('can findOrFail product that does not exist', function () {
     expect(fn () => Product::findOrFail(123))->toThrow(ProductNotFound::class);
 });
 

--- a/tests/Products/EntryProductRepositoryTest.php
+++ b/tests/Products/EntryProductRepositoryTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use DoubleThreeDigital\SimpleCommerce\Contracts\Product as ProductContract;
+use DoubleThreeDigital\SimpleCommerce\Exceptions\ProductNotFound;
 use DoubleThreeDigital\SimpleCommerce\Facades\Product;
 use DoubleThreeDigital\SimpleCommerce\Products\EntryQueryBuilder;
 
@@ -35,6 +36,18 @@ it('can find product', function () {
     $product = Product::find('one');
 
     expect($product)->toBeInstanceOf(ProductContract::class);
+});
+
+it('can findOrFail product', function () {
+    Product::make()->id('one')->price(1500)->save();
+
+    $product = Product::find('one');
+
+    expect($product)->toBeInstanceOf(ProductContract::class);
+});
+
+it('can findOrFail product that does not exist', function () {
+    expect(fn () => Product::findOrFail(123))->toThrow(ProductNotFound::class);
 });
 
 it('can make product', function () {


### PR DESCRIPTION
This pull request makes two changes to the `find` methods in Simple Commerce's repositories:

* When using `find`, if an entry/model can't be found, `null` will be returned instead of an exception.
* Added a new `findOrFail` method, which does the same as `find`, however instead of returning `null` when an entry/model can't be found, it'll return an exception.

This brings things inline with Laravel and soon Statamic Core.

Fixes #988.