### PR TITLE
[6.x] Drop "Enabled" state from coupons

### DIFF
--- a/docs/upgrade-guides/v5-x-to-v6-0.md
+++ b/docs/upgrade-guides/v5-x-to-v6-0.md
@@ -110,6 +110,12 @@ $order->gatewayData()->data();
 $order->gatewayData()->refund();
 ```
 
+### Medium: The "Enabled" status has been removed from Coupons
+
+The "Enabled" status toggle has been removed from coupons, in favour of the Start/End dates.
+
+As part of the update process, Simple Commerce will attempt to update your existing disabled coupons and set an end date on them so they're no longer usable.
+
 ### Medium: Changes to the `statusLog` method on Orders
 
 The `statusLog` method no longer accepts passing a status. Instead, you should query the status log for the event you're after, then get the `->last()` item in the collection.

--- a/resources/js/components/Listings/CouponListing.vue
+++ b/resources/js/components/Listings/CouponListing.vue
@@ -187,27 +187,6 @@ export default {
             return row.editable
         },
 
-        getStatusClass(coupon) {
-            if (coupon.enabled) {
-                return 'bg-green-600';
-            } else {
-                return 'bg-gray-400';
-            }
-        },
-
-        getStatusLabel(coupon) {
-            if (coupon.enabled) {
-                return __('Enabled');
-            } else {
-                return __('Disabled');
-            }
-        },
-
-        // TODO: Implement this if we end up needing it
-        getStatusTooltip(coupon) {
-            return false;
-        },
-
         columnShowing(column) {
             return this.visibleColumns.find(c => c.field === column);
         },

--- a/resources/js/components/Listings/CouponListing.vue
+++ b/resources/js/components/Listings/CouponListing.vue
@@ -103,7 +103,6 @@
                         >
                             <template slot="cell-code" slot-scope="{ row, value }">
                                 <div class="title-index-field">
-                                    <div class="little-dot mr-2" v-tooltip="getStatusLabel(row)" :class="getStatusClass(row)" v-if="! columnShowing('enabled')" />
                                     <a :href="row.edit_url" @click.stop>{{ row.code }}</a>
                                 </div>
                             </template>

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -28,14 +28,11 @@ class Coupon implements Contract
 
     public $type;
 
-    public $enabled;
-
     protected $selectedQueryRelations = [];
 
     public function __construct()
     {
         $this->data = collect();
-        $this->enabled = true;
     }
 
     public function id($id = null)
@@ -96,20 +93,9 @@ class Coupon implements Contract
             ->args(func_get_args());
     }
 
-    public function enabled($enabled = null)
-    {
-        return $this
-            ->fluentlyGetOrSet('enabled')
-            ->args(func_get_args());
-    }
-
     public function isValid(Order $order): bool
     {
         $order = OrderFacade::find($order->id());
-
-        if (! $this->enabled()) {
-            return false;
-        }
 
         if ($this->get('valid_from') !== null) {
             if (Carbon::parse($this->get('valid_from'))->isFuture()) {
@@ -239,7 +225,6 @@ class Coupon implements Contract
         $this->code = $freshCoupon->code;
         $this->value = $freshCoupon->value;
         $this->type = $freshCoupon->type;
-        $this->enabled = $freshCoupon->enabled;
         $this->data = $freshCoupon->data();
 
         return $this;
@@ -252,7 +237,6 @@ class Coupon implements Contract
             'code' => $this->code,
             'value' => $this->value,
             'type' => $this->type,
-            'enabled' => $this->enabled,
         ]);
     }
 

--- a/src/Coupons/CouponBlueprint.php
+++ b/src/Coupons/CouponBlueprint.php
@@ -228,17 +228,6 @@ class CouponBlueprint
                         ],
                         [
                             'fields' => [
-                                // TODO: Remove this 'Enabled' state in favour of the start/end dates.
-                                [
-                                    'handle' => 'enabled',
-                                    'field' => [
-                                        'type' => 'toggle',
-                                        'instructions' => __('When disabled, this coupon will not be able to be redeemed. This setting overrides other settings.'),
-                                        'default' => true,
-                                        'listable' => 'hidden',
-                                        'display' => __('Enabled?'),
-                                    ],
-                                ],
                                 [
                                     'handle' => 'redeemed',
                                     'field' => [

--- a/src/Coupons/CouponStore.php
+++ b/src/Coupons/CouponStore.php
@@ -28,8 +28,7 @@ class CouponStore extends BasicStore
             ->code(array_pull($data, 'code'))
             ->type(array_pull($data, 'type'))
             ->value(array_pull($data, 'value'))
-            ->enabled(array_pull($data, 'enabled') ?? true)
-            ->data(Arr::except($data, ['code', 'type', 'value', 'enabled']));
+            ->data(Arr::except($data, ['code', 'type', 'value']));
 
         if (isset($idGenerated)) {
             $coupon->save();

--- a/src/Http/Controllers/CP/Coupons/CouponController.php
+++ b/src/Http/Controllers/CP/Coupons/CouponController.php
@@ -75,8 +75,7 @@ class CouponController
             ->code(Str::upper($fields->get('code')))
             ->type($fields->get('type'))
             ->value($fields->get('value'))
-            ->enabled($fields->get('enabled'))
-            ->data(Arr::except($fields, ['code', 'type', 'value', 'enabled']));
+            ->data(Arr::except($fields, ['code', 'type', 'value']));
 
         $coupon->save();
 
@@ -122,8 +121,7 @@ class CouponController
             ->code(Str::upper($fields->get('code')))
             ->type($fields->get('type'))
             ->value($fields->get('value'))
-            ->enabled($fields->get('enabled'))
-            ->data(Arr::except($fields, ['code', 'type', 'value', 'enabled']))
+            ->data(Arr::except($fields, ['code', 'type', 'value']))
             ->save();
 
         return [

--- a/src/Http/Requests/CP/Coupon/StoreRequest.php
+++ b/src/Http/Requests/CP/Coupon/StoreRequest.php
@@ -107,10 +107,6 @@ class StoreRequest extends FormRequest
             'expires_at.time' => [
                 'nullable',
             ],
-            'enabled' => [
-                'required',
-                'boolean',
-            ],
         ];
     }
 }

--- a/src/Http/Requests/CP/Coupon/UpdateRequest.php
+++ b/src/Http/Requests/CP/Coupon/UpdateRequest.php
@@ -101,10 +101,6 @@ class UpdateRequest extends FormRequest
             'expires_at.time' => [
                 'nullable',
             ],
-            'enabled' => [
-                'required',
-                'boolean',
-            ],
         ];
     }
 }

--- a/src/Http/Resources/CP/Coupons/ListedCoupon.php
+++ b/src/Http/Resources/CP/Coupons/ListedCoupon.php
@@ -33,7 +33,6 @@ class ListedCoupon extends JsonResource
         return array_merge(
             [
                 'id' => $coupon->id(),
-                'enabled' => $coupon->enabled(),
                 'discount_text' => $coupon->discountText(),
                 'edit_url' => cp_route('simple-commerce.coupons.edit', ['coupon' => $coupon->id()]),
                 'editable' => User::current()->can('edit coupons'),

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -119,6 +119,7 @@ class ServiceProvider extends AddonServiceProvider
         UpdateScripts\v6_0\MigrateProductType::class,
         UpdateScripts\v6_0\PublishMigrations::class,
         UpdateScripts\v6_0\UpdateClassReferences::class,
+        UpdateScripts\v6_0\UpdateCouponExpiryDate::class,
     ];
 
     protected $vite = [

--- a/src/UpdateScripts/v6_0/UpdateCouponExpiryDate.php
+++ b/src/UpdateScripts/v6_0/UpdateCouponExpiryDate.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0;
+
+use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
+use Illuminate\Support\Carbon;
+use Statamic\UpdateScripts\UpdateScript;
+
+class UpdateCouponExpiryDate extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('6.0.0');
+    }
+
+    public function update()
+    {
+        Coupon::all()
+            ->filter(function ($coupon) {
+                return $coupon->get('enabled') === false
+                    && $coupon->get('expires_at') === null;
+            })
+            ->each(function ($coupon) {
+                $coupon->set('expires_at', Carbon::now()->format('Y-m-d'))->save();
+            });
+    }
+}

--- a/tests/Coupons/CouponTest.php
+++ b/tests/Coupons/CouponTest.php
@@ -240,28 +240,6 @@ test('is not valid when limited to customers and current customer is not in allo
     expect($isValid)->toBeFalse();
 });
 
-test('is not valid when coupon is disabled', function () {
-    [$product, $order] = buildCartWithProducts();
-
-    $coupon = Coupon::make()
-        ->id(Stache::generateId())
-        ->code('halv-price')
-        ->value(50)
-        ->type('percentage')
-        ->enabled(false)
-        ->data([
-            'description' => 'Halv Price',
-            'redeemed' => 0,
-            'minimum_cart_value' => null,
-        ]);
-
-    $coupon->save();
-
-    $isValid = $coupon->isValid($order);
-
-    expect($isValid)->toBeFalse();
-});
-
 test('is not valid before coupon valid_from timestamp', function () {
     [$product, $order] = buildCartWithProducts();
 

--- a/tests/Http/Controllers/CP/CouponControllerTest.php
+++ b/tests/Http/Controllers/CP/CouponControllerTest.php
@@ -40,7 +40,6 @@ test('can store coupon', function () {
     $coupon = Coupon::findByCode('thursday-thirty');
 
     expect(30)->toBe($coupon->value());
-    expect(true)->toBe($coupon->enabled());
     expect('30% discount on a Thursday!')->toBe($coupon->get('description'));
     expect(6500)->toBe($coupon->get('minimum_cart_value'));
 });
@@ -172,7 +171,6 @@ test('can update coupon', function () {
     $coupon->fresh();
 
     expect(51)->toBe($coupon->value());
-    expect(false)->toBe($coupon->enabled());
     expect('You can actually get a 51% discount on Friday!')->toBe($coupon->get('description'));
     expect(7600)->toBe($coupon->get('minimum_cart_value'));
 });

--- a/tests/Http/Controllers/CP/CouponControllerTest.php
+++ b/tests/Http/Controllers/CP/CouponControllerTest.php
@@ -29,7 +29,6 @@ test('can store coupon', function () {
             ],
             'description' => '30% discount on a Thursday!',
             'minimum_cart_value' => '65.00',
-            'enabled' => true,
             'expires_at' => null,
             'customer_eligibility' => 'all',
         ])
@@ -58,7 +57,6 @@ test('can store coupon with expiry date', function () {
             ],
             'description' => '30% discount on a Thursday!',
             'minimum_cart_value' => '65.00',
-            'enabled' => true,
             'expires_at' => [
                 'date' => '2024-01-01',
                 'time' => null,
@@ -163,7 +161,6 @@ test('can update coupon', function () {
                 'value' => 51,
             ],
             'description' => 'You can actually get a 51% discount on Friday!',
-            'enabled' => false,
             'minimum_cart_value' => '76.00',
             'expires_at' => null,
             'customer_eligibility' => 'all',
@@ -205,7 +202,6 @@ test('can update coupon with expriry date', function () {
                 'value' => 51,
             ],
             'description' => 'You can actually get a 51% discount on Friday!',
-            'enabled' => false,
             'minimum_cart_value' => '76.00',
             'expires_at' => [
                 'date' => '2024-01-01',

--- a/tests/Tags/CheckoutTagTest.php
+++ b/tests/Tags/CheckoutTagTest.php
@@ -114,7 +114,7 @@ test('can redirect user to confirmation page instead of offsite gateway when ord
 
     $cart->save();
 
-    $coupon = Coupon::make()->code('FREEBIE')->value(100)->type('percentage')->enabled(true);
+    $coupon = Coupon::make()->code('FREEBIE')->value(100)->type('percentage');
     $coupon->save();
 
     $cart->coupon($coupon);

--- a/tests/UpdateScripts/UpdateCouponExpiryDateTest.php
+++ b/tests/UpdateScripts/UpdateCouponExpiryDateTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Carbon\Carbon;
+use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
+use DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0\UpdateCouponExpiryDate;
+use Spatie\TestTime\TestTime;
+
+it('sets the expiry date for a disabled coupon', function () {
+    TestTime::freeze(Carbon::parse('2024-01-01'));
+
+    $coupon = Coupon::make()
+        ->code('test')
+        ->type('percentage')
+        ->value(10)
+        ->set('enabled', false)
+        ->set('expires_at', null)
+        ->save();
+
+    $coupon->save();
+
+    (new UpdateCouponExpiryDate('doublethreedigital/simple-commerce', '6.0.0'))->update();
+
+    $coupon->fresh();
+
+    expect($coupon->get('expires_at'))->toBe('2024-01-01');
+});
+
+it('does not set the expiry date for an enabled coupon', function () {
+    TestTime::freeze(Carbon::parse('2024-01-01'));
+
+    $coupon = Coupon::make()
+        ->code('test')
+        ->type('percentage')
+        ->value(10)
+        ->set('enabled', true)
+        ->set('expires_at', null)
+        ->save();
+
+    $coupon->save();
+
+    (new UpdateCouponExpiryDate('doublethreedigital/simple-commerce', '6.0.0'))->update();
+
+    $coupon->fresh();
+
+    expect($coupon->get('expires_at'))->toBeNull();
+});
+
+it('does not set the expiry date for an already expired coupon', function () {
+    TestTime::freeze(Carbon::parse('2024-01-01'));
+
+    $coupon = Coupon::make()
+        ->code('test')
+        ->type('percentage')
+        ->value(10)
+        ->set('enabled', true)
+        ->set('expires_at', '2023-12-12')
+        ->save();
+
+    $coupon->save();
+
+    (new UpdateCouponExpiryDate('doublethreedigital/simple-commerce', '6.0.0'))->update();
+
+    $coupon->fresh();
+
+    expect($coupon->get('expires_at'))->toBe('2023-12-12');
+});


### PR DESCRIPTION
This pull request drops the "Enabled" status/toggle from coupons in favour of the "Expiry Date" setting. 

This PR includes an update script which will update any disabled coupons & set an expiry date on them so they're not usable. 