### PR TITLE
[6.x] Change namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,16 @@
 {
-    "name": "doublethreedigital/simple-commerce",
+    "name": "duncanmcclean/simple-commerce",
     "description": "A perfectly simple e-commerce addon for Statamic",
     "license": "proprietary",
     "autoload": {
         "psr-4": {
-            "DoubleThreeDigital\\SimpleCommerce\\": "src"
+            "DuncanMcClean\\SimpleCommerce\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "DoubleThreeDigital\\SimpleCommerce\\Tests\\": "tests",
-            "DoubleThreeDigital\\SimpleCommerce\\Tests\\Fixtures\\": "tests/__fixtures__/app"
+            "DuncanMcClean\\SimpleCommerce\\Tests\\": "tests",
+            "DuncanMcClean\\SimpleCommerce\\Tests\\Fixtures\\": "tests/__fixtures__/app"
         }
     },
     "extra": {
@@ -24,7 +24,7 @@
         },
         "laravel": {
             "providers": [
-                "DoubleThreeDigital\\SimpleCommerce\\ServiceProvider"
+                "DuncanMcClean\\SimpleCommerce\\ServiceProvider"
             ]
         }
     },

--- a/config/simple-commerce.php
+++ b/config/simple-commerce.php
@@ -20,7 +20,7 @@ return [
 
             'shipping' => [
                 'methods' => [
-                    \DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping::class => [],
+                    \DuncanMcClean\SimpleCommerce\Shipping\FreeShipping::class => [],
                 ],
             ],
         ],
@@ -39,7 +39,7 @@ return [
     */
 
     'gateways' => [
-        \DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\DummyGateway::class => [
+        \DuncanMcClean\SimpleCommerce\Gateways\Builtin\DummyGateway::class => [
             'display' => 'Card',
         ],
     ],
@@ -59,17 +59,17 @@ return [
 
     'notifications' => [
         'order_paid' => [
-            // \DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderPaid::class => [
+            // \DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderPaid::class => [
             //     'to' => 'customer',
             // ],
 
-            // \DoubleThreeDigital\SimpleCommerce\Notifications\BackOfficeOrderPaid::class => [
+            // \DuncanMcClean\SimpleCommerce\Notifications\BackOfficeOrderPaid::class => [
             //     'to' => 'duncan@example.com',
             // ],
         ],
 
         'order_dispatched' => [
-            // \DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderShipped::class => ['to' => 'customer'],
+            // \DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderShipped::class => ['to' => 'customer'],
         ],
     ],
 
@@ -110,7 +110,7 @@ return [
     |
     */
 
-    'tax_engine' => \DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxEngine::class,
+    'tax_engine' => \DuncanMcClean\SimpleCommerce\Tax\Standard\TaxEngine::class,
 
     'tax_engine_config' => [
         // Basic Engine
@@ -149,17 +149,17 @@ return [
 
     'content' => [
         'customers' => [
-            'repository' => \DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository::class,
+            'repository' => \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class,
             'collection' => 'customers',
         ],
 
         'orders' => [
-            'repository' => \DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository::class,
+            'repository' => \DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository::class,
             'collection' => 'orders',
         ],
 
         'products' => [
-            'repository' => \DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository::class,
+            'repository' => \DuncanMcClean\SimpleCommerce\Products\EntryProductRepository::class,
             'collection' => 'products',
         ],
     ],

--- a/docs/customers.md
+++ b/docs/customers.md
@@ -35,7 +35,7 @@ They live in their own `customers` collection, which you can change if you need 
 	// All the other bits..
 
     'customers' => [
-        'repository' => \DoubleThreeDigital\SimpleCommerce\Customers\Customer::class,
+        'repository' => \DuncanMcClean\SimpleCommerce\Customers\Customer::class,
         'collection' => 'customers', // [tl! --]
         'collection' => 'members', // [tl! ++]
     ],
@@ -50,7 +50,7 @@ Storing your customers as users can often be handy if you're building some sort 
 You'll need to enable [Statamic Pro](https://statamic.com/pricing) if you want to store your customers as users.
 :::
 
-To enable, change `\DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository::class` to `\DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository::class`.
+To enable, change `\DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class` to `\DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class`.
 
 ```php
 /*
@@ -70,8 +70,8 @@ To enable, change `\DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRep
 	// All the other bits..
 
     'customers' => [
-        'repository' => \DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository::class, // [tl! --]
-        'repository' => \DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository::class, // [tl! ++]
+        'repository' => \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class, // [tl! --]
+        'repository' => \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class, // [tl! ++]
     ],
 ],
 ```
@@ -86,7 +86,7 @@ This is where you store your customers in the database. Simple Commerce supports
 
 ### Get orders made by a customer
 
-You can loop through orders made by a specific customer using the Antlers Tag. All you need to do is provide the ID of the customer. 
+You can loop through orders made by a specific customer using the Antlers Tag. All you need to do is provide the ID of the customer.
 
 If you're using the [#entries] driver, that'll be the entry ID of your customer or if you're storing customers as users, that might be the ID of the currently logged in user.
 

--- a/docs/database-orders.md
+++ b/docs/database-orders.md
@@ -61,22 +61,22 @@ If you receive an error running the `sc:migrate-to-database` command, please ens
 
 'content' => [
     'coupons' => [
-        'repository' => \DoubleThreeDigital\SimpleCommerce\Coupons\EntryCouponRepository::class,
+        'repository' => \DuncanMcClean\SimpleCommerce\Coupons\EntryCouponRepository::class,
         'collection' => 'coupons',
     ],
 
     'customers' => [
-        'repository' => \DoubleThreeDigital\SimpleCommerce\Customers\EloquentCustomerRepository::class,
-        'model' => \DoubleThreeDigital\SimpleCommerce\Customers\CustomerModel::class,
+        'repository' => \DuncanMcClean\SimpleCommerce\Customers\EloquentCustomerRepository::class,
+        'model' => \DuncanMcClean\SimpleCommerce\Customers\CustomerModel::class,
     ],
 
     'orders' => [
-        'repository' => \DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository::class,
-        'model' => \DoubleThreeDigital\SimpleCommerce\Orders\OrderModel::class,
+        'repository' => \DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository::class,
+        'model' => \DuncanMcClean\SimpleCommerce\Orders\OrderModel::class,
     ],
 
     'products' => [
-        'repository' => \DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository::class,
+        'repository' => \DuncanMcClean\SimpleCommerce\Products\EntryProductRepository::class,
         'collection' => 'products',
     ],
 ],
@@ -133,13 +133,13 @@ First, in order to customise the Eloquent model, you'll need to create your own 
 2. In your `simple-commerce.php` config file, replace the `model` reference with your own:
 
 ```php
-'model' => \DoubleThreeDigital\SimpleCommerce\Orders\OrderModel::class, // [tl! remove]
+'model' => \DuncanMcClean\SimpleCommerce\Orders\OrderModel::class, // [tl! remove]
 'model' => \App\Models\Order::class, // [tl! add]
 ```
 3. Finally, update the reference to the `Order` model in the Runway config (`config/runway.php`):
 
 ```php
-\DoubleThreeDigital\SimpleCommerce\Orders\OrderModel::class => [ // [tl! remove]
+\DuncanMcClean\SimpleCommerce\Orders\OrderModel::class => [ // [tl! remove]
 \App\Models\Order::class => [ // [tl! remove]
     // ...
 ],
@@ -153,7 +153,7 @@ And there you go... that's you using a custom version of the Eloquent model.
 2. In your `simple-commerce.php` config file, with a reference to your new repository:
 
 ```
-'repository' => \DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository::class, // [tl! remove]
+'repository' => \DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository::class, // [tl! remove]
 'repository' => \App\SimpleCommerce\EloquentOrderRepository::class, // [tl! add]
 ```
 

--- a/docs/digital-products.md
+++ b/docs/digital-products.md
@@ -26,7 +26,7 @@ If you'd like to send your customers an email notification after they've purchas
 ```php
 'notifications' => [
     'digital_download_ready' => [
-        \DoubleThreeDigital\SimpleCommerce\Notifications\DigitalDownloadsNotification::class => [
+        \DuncanMcClean\SimpleCommerce\Notifications\DigitalDownloadsNotification::class => [
             'to' => 'customer',
         ],
     ],
@@ -87,7 +87,7 @@ And an invalid one will be like this.
 
 By default, we create a serial license key which you can give to your customers. However, you may want to customise where the code comes from or maybe you want to send it away to a third party service.
 
-To do this, you can create your own license key repository which [implements the one provided by this addon](https://github.com/doublethreedigital/simple-commerce/blob/main/src/Contracts/LicenseKeyRepository.php).
+To do this, you can create your own license key repository which [implements the one provided by this addon](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Contracts/LicenseKeyRepository.php).
 
 To register your repository, you'll need to bind it to our `LicenseKey` facade. You can do this in your `AppServiceProvider`.
 

--- a/docs/dynamic-pricing.md
+++ b/docs/dynamic-pricing.md
@@ -7,8 +7,8 @@ Depending on your use case, there may be situations where you need to use 'dynam
 Essentially, the way it works is we provide a method for you to register a callback. Inside that callback you can do whatever decisioning you need to do to determine the price. I'd recommend adding this code to your `app/Providers/AppServiceProvider.php`, inside the `boot` method.
 
 ```php
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Product;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Product;
 
 SimpleCommerce::productPriceHook(function (Order $order, Product $product) {
     if (now()->isWeekend()) {
@@ -24,9 +24,9 @@ Remember that you'll need to return the price as an integer. The above example r
 An alternative method is also available for [variant products](/product-variants).
 
 ```php
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Product;
-use DoubleThreeDigital\SimpleCommerce\Products\ProductVariant;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Product;
+use DuncanMcClean\SimpleCommerce\Products\ProductVariant;
 
 SimpleCommerce::productVariantPriceHook(function (Order $order, Product $product, ProductVariant $variant) {
     if (now()->isWeekend()) {

--- a/docs/events.md
+++ b/docs/events.md
@@ -40,7 +40,7 @@ For more documentation around events and event listeners, consider reading [the 
 
 ### CouponRedeemed
 
-[**`DoubleThreeDigital\SimpleCommerce\Events\CouponRedeemed`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/CouponRedeemed.php)
+[**`DuncanMcClean\SimpleCommerce\Events\CouponRedeemed`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/CouponRedeemed.php)
 
 This event is fired when a customer adds a coupon to their cart/order.
 
@@ -53,7 +53,7 @@ public function handle(CouponRedeemed $event)
 
 ### OrderPaymentFailed
 
-[**`DoubleThreeDigital\SimpleCommerce\Events\OrderPaymentFailed`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/OrderPaymentFailed.php)
+[**`DuncanMcClean\SimpleCommerce\Events\OrderPaymentFailed`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/OrderPaymentFailed.php)
 
 This event is fired whenever a payment fails to go through.
 
@@ -66,7 +66,7 @@ public function handle(OrderPaymentFailed $event)
 
 ### OrderSaved
 
-[**`DoubleThreeDigital\SimpleCommerce\Events\OrderSaved`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/OrderSaved.php)
+[**`DuncanMcClean\SimpleCommerce\Events\OrderSaved`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/OrderSaved.php)
 
 This event is fired when an order has been saved. This event will only be fired when an order is saved via Simple Commerce, not via the Control Panel.
 
@@ -79,7 +79,7 @@ public function handle(OrderSaved $event)
 
 ### OrderStatusUpdated
 
-[**`DoubleThreeDigital\SimpleCommerce\Events\OrderStatusUpdated`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/OrderStatusUpdated.php)
+[**`DuncanMcClean\SimpleCommerce\Events\OrderStatusUpdated`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/OrderStatusUpdated.php)
 
 This event is fired whenever the status of an order changes.
 
@@ -93,7 +93,7 @@ public function handle(OrderStatusUpdated $event)
 
 ### PaymentStatusUpdated
 
-[**`DoubleThreeDigital\SimpleCommerce\Events\PaymentStatusUpdated`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/PaymentStatusUpdated.php)
+[**`DuncanMcClean\SimpleCommerce\Events\PaymentStatusUpdated`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/PaymentStatusUpdated.php)
 
 This event is fired whenever the payment status of an order changes.
 
@@ -107,7 +107,7 @@ public function handle(PaymentStatusUpdated $event)
 
 ### PostCheckout
 
-[**`DoubleThreeDigital\SimpleCommerce\Events\PostCheckout`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/PostCheckout.php)
+[**`DuncanMcClean\SimpleCommerce\Events\PostCheckout`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/PostCheckout.php)
 
 This event is fired after the checkout process has been completed.
 
@@ -121,7 +121,7 @@ public function handle(PostCheckout $event)
 
 ### PreCheckout
 
-[**`DoubleThreeDigital\SimpleCommerce\Events\PreCheckout`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/PreCheckout.php)
+[**`DuncanMcClean\SimpleCommerce\Events\PreCheckout`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/PreCheckout.php)
 
 This event is fired before the checkout process begins.
 
@@ -135,7 +135,7 @@ public function handle(PreCheckout $event)
 
 ### GatewayWebhookReceived
 
-[**`DoubleThreeDigital\SimpleCommerce\Events\GatewayWebhookReceived`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/GatewayWebhookReceived.php)
+[**`DuncanMcClean\SimpleCommerce\Events\GatewayWebhookReceived`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/GatewayWebhookReceived.php)
 
 This event is fired whenever a webhook request from a gateway is received.
 
@@ -148,7 +148,7 @@ public function handle(GatewayWebhookReceived $event)
 
 ### StockRunningLow
 
-[**`DoubleThreeDigital\SimpleCommerce\Events\StockRunningLow`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/StockRunningLow.php)
+[**`DuncanMcClean\SimpleCommerce\Events\StockRunningLow`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/StockRunningLow.php)
 
 This event is fired when the [stock](/stock) for a product is running low.
 
@@ -163,7 +163,7 @@ public function handle(StockRunningLow $event)
 
 ### StockRunOut
 
-[**`DoubleThreeDigital\SimpleCommerce\Events\StockRunOut`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/StockRunOut.php)
+[**`DuncanMcClean\SimpleCommerce\Events\StockRunOut`**](https://github.com/duncanmcclean/simple-commerce/blob/main/src/Events/StockRunOut.php)
 
 This event is fired when the [stock](/stock) for a product has ran out.
 

--- a/docs/guides/different-collection-for-products.md
+++ b/docs/guides/different-collection-for-products.md
@@ -37,7 +37,7 @@ return [
 
     'content' => [
         'products' => [
-            'repository' => \DoubleThreeDigital\SimpleCommerce\Products\Product::class,
+            'repository' => \DuncanMcClean\SimpleCommerce\Products\Product::class,
             'collection' => 'products', // handle of your collection
         ],
     ],

--- a/docs/guides/multisite.md
+++ b/docs/guides/multisite.md
@@ -30,7 +30,7 @@ Each Statamic site you have setup in your `config/statamic/sites.php` config sho
 
         'shipping' => [
             'methods' => [
-                \DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping::class,
+                \DuncanMcClean\SimpleCommerce\Shipping\FreeShipping::class,
             ],
         ],
     ],
@@ -97,7 +97,7 @@ If, for whatever reason you find yourself needing to use the same cart between a
 */
 
 'cart' => [
-    'repository' => \DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CookieDriver::class,
+    'repository' => \DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CookieDriver::class,
     'key' => 'simple-commerce-cart',
     'single_cart' => false, // [tl! add]
 ],

--- a/docs/guides/showing-multiple-on-site-gateways-on-the-checkout-form.md
+++ b/docs/guides/showing-multiple-on-site-gateways-on-the-checkout-form.md
@@ -28,7 +28,7 @@ In the below example, we're using Alpine.js to react to the value of the `<selec
 
     <button
     	type="button"
-        @click.prevent="if(typeof confirmPayment == 'function' && document.getElementsByName('gateway')[0].value == 'DoubleThreeDigital\\SimpleCommerce\\Gateways\\Builtin\\StripeGateway') { confirmPayment(); } else { document.querySelector('form').submit() }">
+        @click.prevent="if(typeof confirmPayment == 'function' && document.getElementsByName('gateway')[0].value == 'DuncanMcClean\\SimpleCommerce\\Gateways\\Builtin\\StripeGateway') { confirmPayment(); } else { document.querySelector('form').submit() }">
         Complete Checkout
 	</button>
 </div>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,7 +47,7 @@ Now that you're up and running with the Starter Kit, you're probably wanting to 
 **1.** Install Simple Commerce with Composer
 
 ```shell
-composer require doublethreedigital/simple-commerce
+composer require duncanmcclean/simple-commerce
 ```
 
 **2.** Next, run the `sc:install` command to publish Simple Commerce's config file, collections & blueprints.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -27,10 +27,10 @@ Simple Commerce uses [Laravel Notifications](https://laravel.com/docs/master/not
 
 'notifications' => [
     'order_paid' => [
-        \DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderPaid::class => [
+        \DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderPaid::class => [
             'to' => 'customer',
         ],
-        \DoubleThreeDigital\SimpleCommerce\Notifications\BackOfficeOrderPaid::class => [
+        \DuncanMcClean\SimpleCommerce\Notifications\BackOfficeOrderPaid::class => [
             'to' => 'cj.cregg@whitehouse.gov',
         ],
     ],
@@ -92,7 +92,7 @@ php artisan make:notification OrderPaidNotification
 
 Simple Commerce doesn't make any changes to the email template that ships with Laravel.
 
-It's pretty generic but you may wish to switch it up a bit when working on a bespoke e-commerce site. 
+It's pretty generic but you may wish to switch it up a bit when working on a bespoke e-commerce site.
 
 All you need to do is publish Laravel's notification views:
 
@@ -108,6 +108,6 @@ While you're in development, you'll probably want to test out your emails withou
 
 Tools like [HELO](https://a.paddle.com/v2/click/103161/130785?link=2990) and [Mailtrap](https://mailtrap.io/) let you catch all emails coming out of your site during development.
 
-![HELO Screenshot](/img/simple-commerce/helo-screenshot.png) 
+![HELO Screenshot](/img/simple-commerce/helo-screenshot.png)
 
 *Disclaimer:* The HELO link above is an affiliate link.

--- a/docs/order-statuses.md
+++ b/docs/order-statuses.md
@@ -41,8 +41,8 @@ If you wish to update the order status programatically, simply use the `updateOr
 You should pass in an option from the `OrderStatus` enum as the first & only parameter.
 
 ```php
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
 
 Order::find('order-id')->updateOrderStatus(OrderStatus::Placed);
 ```

--- a/docs/payment-gateways/dummy.md
+++ b/docs/payment-gateways/dummy.md
@@ -20,7 +20,7 @@ You can configure the gateway in your `config/simple-commerce.php` config file.
 */
 
 'gateways' => [
-    \DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\DummyGateway::class => [],
+    \DuncanMcClean\SimpleCommerce\Gateways\Builtin\DummyGateway::class => [],
 ],
 ```
 

--- a/docs/payment-gateways/mollie.md
+++ b/docs/payment-gateways/mollie.md
@@ -12,7 +12,7 @@ You can obtain your API keys from the Mollie Dashboard.
 
 ```php
 'gateways' => [
-	\DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\MollieGateway::class => [
+	\DuncanMcClean\SimpleCommerce\Gateways\Builtin\MollieGateway::class => [
     	'key' => env('MOLLIE_KEY'),
         'profile' => env('MOLLIE_PROFILE'),
     ],

--- a/docs/payment-gateways/paypal.md
+++ b/docs/payment-gateways/paypal.md
@@ -14,7 +14,7 @@ You can then create a sandbox/live application. At the end of the app creation p
 
 ```php
 'gateways' => [
-	\DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\PayPalGateway::class => [
+	\DuncanMcClean\SimpleCommerce\Gateways\Builtin\PayPalGateway::class => [
         'client_id' => env('PAYPAL_CLIENT_ID'),
         'client_secret' => env('PAYPAL_CLIENT_SECRET'),
         'environment' => env('PAYPAL_ENVIRONMENT', 'production'),
@@ -77,7 +77,7 @@ A rough example of a PayPal implementation is provided below.
 ```antlers
 <div id="paypal-button"></div>
 <input id="paypal-payment-id" type="hidden" name="payment_id">
-<input type="hidden" name="gateway" value="DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\PayPalGateway">
+<input type="hidden" name="gateway" value="DuncanMcClean\SimpleCommerce\Gateways\Builtin\PayPalGateway">
 <script src="https://www.paypal.com/sdk/js?client-id={{ paypal:config:client_id }}&currency={{ result.currency_code }}"></script>
 <script>
     paypal.Buttons({

--- a/docs/payment-gateways/stripe.md
+++ b/docs/payment-gateways/stripe.md
@@ -10,7 +10,7 @@ You can obtain [your API keys](https://dashboard.stripe.com/test/apikeys) from t
 
 ```php
 'gateways' => [
-	\DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway::class => [
+	\DuncanMcClean\SimpleCommerce\Gateways\Builtin\StripeGateway::class => [
     	'key' => env('STRIPE_KEY'),
         'secret' => env('STRIPE_SECRET'),
     ],
@@ -171,7 +171,7 @@ You may do this easily by providing a closure in the Stripe gateway config:
 
 ```php
 'gateways' => [
-	\DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway::class => [
+	\DuncanMcClean\SimpleCommerce\Gateways\Builtin\StripeGateway::class => [
     	'key' => env('STRIPE_KEY'),
         'secret' => env('STRIPE_SECRET'),
         'payment_intent_data' => function ($order) {

--- a/docs/php-api.md
+++ b/docs/php-api.md
@@ -11,7 +11,7 @@ If you've ever used Statamic's `Entry` facade, a lot of the syntax and methodolo
 You can use the `Product` facade to get products out of Simple Commerce.
 
 ```php
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
 
 $product = Product::find('id-of-product');
 ```
@@ -70,7 +70,7 @@ $product->save();
 You can use the `Order` facade to get orders out of Simple Commerce.
 
 ```php
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
 
 $order = Order::find('id-of-order');
 ```
@@ -204,7 +204,7 @@ $order->withoutRecalculating(function () use (&$order) {
 You can use the `Customer` facade to get customers out of Simple Commerce.
 
 ```php
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
 
 $customer = Customer::find('id-of-customer');
 ```
@@ -212,7 +212,7 @@ $customer = Customer::find('id-of-customer');
 You can also use the `findByEmail` method on the `Customer` facade to find a customer by their email address:
 
 ```php
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
 
 $customer = Customer::findByEmail('email@example.com');
 ```

--- a/docs/shipping.md
+++ b/docs/shipping.md
@@ -4,7 +4,7 @@ title: Shipping
 
 When selling physical products, you'll need a way to ship those products to your customers. Sometimes you may want to offer multiple shipping options & the prices may vary on the customer's location.
 
-Simple Commerce includes the concept of **Shipping Methods**. Allowing you to create shipping methods for different shipping options (eg. one for Next Day Delivery, another for Standard delivery or in-store pickup). 
+Simple Commerce includes the concept of **Shipping Methods**. Allowing you to create shipping methods for different shipping options (eg. one for Next Day Delivery, another for Standard delivery or in-store pickup).
 
 ## Configuration
 
@@ -19,7 +19,7 @@ Shipping Methods can be configured on a site-by-site basis which is helpful if y
 
         'shipping' => [
             'methods' => [
-                \DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping::class => [],
+                \DuncanMcClean\SimpleCommerce\Shipping\FreeShipping::class => [],
             ],
         ],
     ],
@@ -62,7 +62,7 @@ To let your customer enter their details, simply update those fields using the `
 {{ /sc:cart:update }}
 ```
 
-If you're using the Starter Kit, customers will be asked to enter their shipping details at the [first step of the checkout process](https://github.com/duncanmcclean/sc-starter-kit/blob/main/resources/views/cart.antlers.html). 
+If you're using the Starter Kit, customers will be asked to enter their shipping details at the [first step of the checkout process](https://github.com/duncanmcclean/sc-starter-kit/blob/main/resources/views/cart.antlers.html).
 
 :::tip Hot Tip
 As mentioned, the default order blueprint also has Billing Address fields. You may do the same thing to allow customers update them - the field names are just `billing_` instead of `shipping_`.
@@ -72,7 +72,7 @@ As mentioned, the default order blueprint also has Billing Address fields. You m
 
 You should also use the `{{ sc:cart:update }}` tag to allow customers to select the shipping method they wish to use.
 
-You can use the `{{ sc:shipping:methods }}` tag to loop through the available shipping methods for the order. 
+You can use the `{{ sc:shipping:methods }}` tag to loop through the available shipping methods for the order.
 
 It'll provide you with variables like name & cost for each of the available shipping methods.
 
@@ -107,10 +107,10 @@ The default shipping method will be used when calculating the Shipping Total for
         ...
 
         'shipping' => [
-            'default_method' => \DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping::class,
+            'default_method' => \DuncanMcClean\SimpleCommerce\Shipping\FreeShipping::class,
 
             'methods' => [
-                \DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping::class => [],
+                \DuncanMcClean\SimpleCommerce\Shipping\FreeShipping::class => [],
             ],
         ],
     ],
@@ -137,10 +137,10 @@ That command will create a Shipping Method class in your `app\ShippingMethods` f
 
 namespace App\ShippingMethods;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
-use DoubleThreeDigital\SimpleCommerce\Data\Address;
-use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\ShippingMethod;
+use DuncanMcClean\SimpleCommerce\Data\Address;
+use DuncanMcClean\SimpleCommerce\Shipping\BaseShippingMethod;
 
 class FirstClass extends BaseShippingMethod implements ShippingMethod
 {

--- a/docs/tax.md
+++ b/docs/tax.md
@@ -18,7 +18,7 @@ To enable the Basic Tax Engine, your config should look like this:
 ```php
 // config/simple-commerce.php
 
-'tax_engine' => \DoubleThreeDigital\SimpleCommerce\Tax\BasicTaxEngine::class,
+'tax_engine' => \DuncanMcClean\SimpleCommerce\Tax\BasicTaxEngine::class,
 
 'tax_engine_config' => [
     'rate'               => 20,
@@ -52,7 +52,7 @@ The Standard Tax Engine is enabled by default in new Simple Commerce sites. You 
 ```php
 // config/simple-commerce.php
 
-'tax_engine' => \DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxEngine::class,
+'tax_engine' => \DuncanMcClean\SimpleCommerce\Tax\Standard\TaxEngine::class,
 
 'tax_engine_config' => [
     'address' => 'billing',

--- a/docs/upgrade-guides/v2-2-to-v2-3.md
+++ b/docs/upgrade-guides/v2-2-to-v2-3.md
@@ -44,7 +44,7 @@ This is one of the upgrade steps that's automated for you.
 */
 
 'gateways' => [
-    \DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\DummyGateway::class => [
+    \DuncanMcClean\SimpleCommerce\Gateways\Builtin\DummyGateway::class => [
         'display' => 'Card',
     ],
 ],
@@ -56,16 +56,16 @@ If you're using a custom gateway, please update the namespaces of the Data Trans
 
 ```
 // Before
-use DoubleThreeDigital\SimpleCommerce\Data\Gateways\BaseGateway;
-use DoubleThreeDigital\SimpleCommerce\Data\Gateways\GatewayPrep;
-use DoubleThreeDigital\SimpleCommerce\Data\Gateways\GatewayPurchase;
-use DoubleThreeDigital\SimpleCommerce\Data\Gateways\GatewayResponse;
+use DuncanMcClean\SimpleCommerce\Data\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Data\Gateways\GatewayPrep;
+use DuncanMcClean\SimpleCommerce\Data\Gateways\GatewayPurchase;
+use DuncanMcClean\SimpleCommerce\Data\Gateways\GatewayResponse;
 
 // Now
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Prepare;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Purchase;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Response;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Gateways\Prepare;
+use DuncanMcClean\SimpleCommerce\Gateways\Purchase;
+use DuncanMcClean\SimpleCommerce\Gateways\Response;
 ```
 
 ## High: Email notifications
@@ -95,8 +95,8 @@ You may now specifiy multiple notifications for an 'event'. You can also specify
 
 'notifications' => [
     'order_paid' => [
-        \DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderPaid::class   => ['to' => 'customer'],
-        \DoubleThreeDigital\SimpleCommerce\Notifications\BackOfficeOrderPaid::class => ['to' => 'duncan@example.com'],
+        \DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderPaid::class   => ['to' => 'customer'],
+        \DuncanMcClean\SimpleCommerce\Notifications\BackOfficeOrderPaid::class => ['to' => 'duncan@example.com'],
     ],
 ],
 ```
@@ -205,22 +205,22 @@ Instead of directly binding to the service container in your `AppServiceProvider
 
 'content' => [
     'orders' => [
-        'driver' => \DoubleThreeDigital\SimpleCommerce\Orders\Order::class,
+        'driver' => \DuncanMcClean\SimpleCommerce\Orders\Order::class,
         'collection' => 'orders',
     ],
 
     'products' => [
-        'driver' => \DoubleThreeDigital\SimpleCommerce\Products\Product::class,
+        'driver' => \DuncanMcClean\SimpleCommerce\Products\Product::class,
         'collection' => 'products',
     ],
 
     'coupons' => [
-        'driver' => \DoubleThreeDigital\SimpleCommerce\Coupons\Coupon::class,
+        'driver' => \DuncanMcClean\SimpleCommerce\Coupons\Coupon::class,
         'collection' => 'coupons',
     ],
 
     'customers' => [
-        'driver' => \DoubleThreeDigital\SimpleCommerce\Customers\Customer::class,
+        'driver' => \DuncanMcClean\SimpleCommerce\Customers\Customer::class,
         'collection' => 'customers',
     ],
 ],
@@ -295,7 +295,7 @@ This is one of the upgrade steps that's automated for you.
 */
 
 'gateways' => [
-    \DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\DummyGateway::class => [
+    \DuncanMcClean\SimpleCommerce\Gateways\Builtin\DummyGateway::class => [
         'display' => 'Card',
     ],
 ],
@@ -307,16 +307,16 @@ If you're using a custom gateway, please update the namespaces of the Data Trans
 
 ```
 // Before
-use DoubleThreeDigital\SimpleCommerce\Data\Gateways\BaseGateway;
-use DoubleThreeDigital\SimpleCommerce\Data\Gateways\GatewayPrep;
-use DoubleThreeDigital\SimpleCommerce\Data\Gateways\GatewayPurchase;
-use DoubleThreeDigital\SimpleCommerce\Data\Gateways\GatewayResponse;
+use DuncanMcClean\SimpleCommerce\Data\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Data\Gateways\GatewayPrep;
+use DuncanMcClean\SimpleCommerce\Data\Gateways\GatewayPurchase;
+use DuncanMcClean\SimpleCommerce\Data\Gateways\GatewayResponse;
 
 // Now
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Prepare;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Purchase;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Response;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Gateways\Prepare;
+use DuncanMcClean\SimpleCommerce\Gateways\Purchase;
+use DuncanMcClean\SimpleCommerce\Gateways\Response;
 ```
 
 ## High: Email notifications
@@ -346,8 +346,8 @@ You may now specifiy multiple notifications for an 'event'. You can also specify
 
 'notifications' => [
     'order_paid' => [
-        \DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderPaid::class   => ['to' => 'customer'],
-        \DoubleThreeDigital\SimpleCommerce\Notifications\BackOfficeOrderPaid::class => ['to' => 'duncan@example.com'],
+        \DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderPaid::class   => ['to' => 'customer'],
+        \DuncanMcClean\SimpleCommerce\Notifications\BackOfficeOrderPaid::class => ['to' => 'duncan@example.com'],
     ],
 ],
 ```
@@ -456,22 +456,22 @@ Instead of directly binding to the service container in your `AppServiceProvider
 
 'content' => [
     'orders' => [
-        'driver' => \DoubleThreeDigital\SimpleCommerce\Orders\Order::class,
+        'driver' => \DuncanMcClean\SimpleCommerce\Orders\Order::class,
         'collection' => 'orders',
     ],
 
     'products' => [
-        'driver' => \DoubleThreeDigital\SimpleCommerce\Products\Product::class,
+        'driver' => \DuncanMcClean\SimpleCommerce\Products\Product::class,
         'collection' => 'products',
     ],
 
     'coupons' => [
-        'driver' => \DoubleThreeDigital\SimpleCommerce\Coupons\Coupon::class,
+        'driver' => \DuncanMcClean\SimpleCommerce\Coupons\Coupon::class,
         'collection' => 'coupons',
     ],
 
     'customers' => [
-        'driver' => \DoubleThreeDigital\SimpleCommerce\Customers\Customer::class,
+        'driver' => \DuncanMcClean\SimpleCommerce\Customers\Customer::class,
         'collection' => 'customers',
     ],
 ],

--- a/docs/upgrade-guides/v2-3-to-v2-4.md
+++ b/docs/upgrade-guides/v2-3-to-v2-4.md
@@ -56,7 +56,7 @@ Any multi-sites migrated to v2.4 will continue to use the v2.3 behaviour. To opt
 
 ```php
 'cart' => [
-    'driver' => \DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CookieDriver::class,
+    'driver' => \DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CookieDriver::class,
     'key' => 'simple-commerce-cart',
     'single_cart' => true, // [tl! --]
 ],
@@ -67,7 +67,7 @@ Any multi-sites migrated to v2.4 will continue to use the v2.3 behaviour. To opt
 Previously, the data from a gateway would look something like this in your order entry:
 
 ```yaml
-gateway: DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway
+gateway: DuncanMcClean\SimpleCommerce\Gateways\Builtin\StripeGateway
 stripe:
   intent: pi_whatever
   client_secret: pi_whateveragain_secret_something
@@ -79,7 +79,7 @@ We've improved this, so the `gateway` and `gateway_data` values are under a sing
 
 ```yaml
 gateway:
-  use: DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway
+  use: DuncanMcClean\SimpleCommerce\Gateways\Builtin\StripeGateway
   data:
     id: pm_whatever
 stripe:
@@ -100,7 +100,7 @@ The signature of the `checkAvailability` method on shipping methods has changed.
 **Previously:**
 
 ```php
-use DoubleThreeDigital\SimpleCommerce\Orders\Address;
+use DuncanMcClean\SimpleCommerce\Orders\Address;
 
 public function checkAvailability(Address $address): bool;
 ```
@@ -108,8 +108,8 @@ public function checkAvailability(Address $address): bool;
 **Now:**
 
 ```php
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\Address;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Orders\Address;
 
 public function checkAvailability(Order $order, Address $address): bool;
 ```

--- a/docs/upgrade-guides/v2-4-to-v3-0.md
+++ b/docs/upgrade-guides/v2-4-to-v3-0.md
@@ -46,22 +46,22 @@ During the upgrade process, Simple Commerce should have updated your config to r
 ```php
 'content' => [
     'coupons' => [
-        'repository' => \DoubleThreeDigital\SimpleCommerce\Coupons\EntryCouponRepository::class,
+        'repository' => \DuncanMcClean\SimpleCommerce\Coupons\EntryCouponRepository::class,
         'collection' => 'coupons',
     ],
 
     'customers' => [
-        'repository' => \DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository::class,
+        'repository' => \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class,
         'collection' => 'customers',
     ],
 
     'orders' => [
-        'repository' => \DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository::class,
+        'repository' => \DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository::class,
         'collection' => 'orders',
     ],
 
     'products' => [
-        'repository' => \DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository::class,
+        'repository' => \DuncanMcClean\SimpleCommerce\Products\EntryProductRepository::class,
         'collection' => 'products',
     ],
 ],
@@ -180,9 +180,9 @@ $giftNote = $lineItem->metdata()->get('gift_note');
 
 If you were previously referencing any of these classes, you should update your references to their new namespaces:
 
--   `DoubleThreeDigital\SimpleCommerce\Support\Currency` -> `DoubleThreeDigital\SimpleCommerce\Currency`
--   `DoubleThreeDigital\SimpleCommerce\Support\Country` -> `DoubleThreeDigital\SimpleCommerce\Country`
--   `DoubleThreeDigital\SimpleCommerce\Support\Regions` -> `DoubleThreeDigital\SimpleCommerce\Regions`
+-   `DuncanMcClean\SimpleCommerce\Support\Currency` -> `DuncanMcClean\SimpleCommerce\Currency`
+-   `DuncanMcClean\SimpleCommerce\Support\Country` -> `DuncanMcClean\SimpleCommerce\Country`
+-   `DuncanMcClean\SimpleCommerce\Support\Regions` -> `DuncanMcClean\SimpleCommerce\Regions`
 
 You should also note that any references to the Currency/Country/Region facades should now be updated to these new namespaces. The usage remains the same.
 
@@ -234,8 +234,8 @@ Simple Commerce now allows for passing configuration arrays for shipping methods
 
 namespace App\ShippingMethods;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
-use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
+use DuncanMcClean\SimpleCommerce\Contracts\ShippingMethod;
+use DuncanMcClean\SimpleCommerce\Shipping\BaseShippingMethod;
 
 class FirstClass extends BaseShippingMethod implements ShippingMethod
 {
@@ -252,7 +252,7 @@ If you wish to start passing in config variables to your shipping methods, you m
 
         'shipping' => [
             'methods' => [
-                \DoubleThreeDigital\SimpleCommerce\Shipping\StandardPost::class => [
+                \DuncanMcClean\SimpleCommerce\Shipping\StandardPost::class => [
                     'config' => 'setting',
                     'foo' => 'bar',
                 ],
@@ -282,11 +282,11 @@ If you wish to continue using the previous behaviour (where you get a simple ema
 ```php
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Notifications; // [tl! remove]
+namespace DuncanMcClean\SimpleCommerce\Notifications; // [tl! remove]
 namespace App\Notifications; // [tl! add]
 
 use Barryvdh\DomPDF\Facade as PDF;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -308,7 +308,7 @@ composer require dompdf/dompdf
 
 'notifications' => [
     'order_paid' => [
-        \DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderPaid::class => [ // [tl! remove]
+        \DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderPaid::class => [ // [tl! remove]
         \App\Notifications\CustomerOrderPaid::class => [ // [tl! add]
             'to' => 'customer',
         ],

--- a/docs/upgrade-guides/v4-x-to-v5-0.md
+++ b/docs/upgrade-guides/v4-x-to-v5-0.md
@@ -125,13 +125,13 @@ Any existing sites though will be using Card Elements, which just gives you a ba
 */
 
 'gateways' => [
-    \DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway::class => [ // [tl! focus]
+    \DuncanMcClean\SimpleCommerce\Gateways\Builtin\StripeGateway::class => [ // [tl! focus]
         'key' => env('STRIPE_KEY'), // [tl! focus]
         'secret' => env('STRIPE_SECRET'), // [tl! focus]
         'mode' => 'card_elements',  // [tl! add] [tl! focus]
     ], // [tl! focus]
 
-    \DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\DummyGateway::class => [
+    \DuncanMcClean\SimpleCommerce\Gateways\Builtin\DummyGateway::class => [
         'display' => 'Card',
     ],
 ],

--- a/docs/upgrade-guides/v5-x-to-v6-0.md
+++ b/docs/upgrade-guides/v5-x-to-v6-0.md
@@ -10,28 +10,23 @@ Please don't upgrade multiple versions at once (eg. from v4 to v6). Please upgra
 
 To get started with the upgrade process, follow the below steps:
 
-**1.** In your `composer.json` file, update the `doublethreedigital/simple-commerce` version constraint:
+**1.** As part of the v6 update, Simple Commerce's namespace has changed. You should uninstall the addon under its old name and re-install under its new name:
 
-```json
-"doublethreedigital/simple-commerce": "^6.0"
+```sh
+composer remove doublethreedigital/simple-commerce
+composer require duncanmcclean/simple-commerce:^6.0
 ```
 
-**2.** Then run:
+**2.** If you're storing your orders in the database, you should also uninstall & re-install Runway since it has moved to The Rad Pack:
 
-```
-composer update doublethreedigital/simple-commerce --with-dependencies
-```
-
-**3.** If you're storing your orders in the database, you should uninstall & re-install Runway. It has moved to the Rad Pack:
-
-```
+```sh
 composer remove doublethreedigital/runway
 composer require statamic-rad-pack/runway
 ```
 
-**4.** Next, manually run the update scripts. This step will make changes to your config files & order data.
+**3.** Next, manually run the update scripts. This step will make changes to your config files & order data.
 
-```
+```sh
 php please sc:run-update-scripts
 ```
 
@@ -39,14 +34,14 @@ php please sc:run-update-scripts
 If you have excluded your orders from Git or you're storing your orders in a database, you will need to re-run this command after deploying Simple Commerce v6.
 :::
 
-**5.** You may also want to clear your route & view caches:
+**4.** You may also want to clear your route & view caches:
 
 ```
 php artisan route:clear
 php artisan view:clear
 ```
 
-**6.** Simple Commerce will have attempted upgrading some things for you (like config files, blueprints, etc). However, it's possible you'll need to make some manual changes. Please review this guide for information on changes which may effect your site.
+**5.** Simple Commerce will have attempted upgrading some things for you (like config files, blueprints, etc). However, it's possible you'll need to make some manual changes. Please review this guide for information on changes which may effect your site.
 
 **Please test locally before deploying to production!**
 
@@ -69,7 +64,7 @@ php artisan migrate
 Previously, when referencing a Payment Gateway or Shipping Method in an order, Simple Commerce would use its fully-qualified class name, like so:
 
 ```yaml
-shipping_method: DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping
+shipping_method: DuncanMcClean\SimpleCommerce\Shipping\FreeShipping
 ```
 
 However, v6 changes this so Payment Gateways & Shipping Methods are now referenced by their handles:
@@ -125,7 +120,7 @@ The `statusLog` method no longer accepts passing a status. Instead, you should q
 $order->statusLog('paid');
 
 // Now
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
 
 $order->statusLog()
     ->where('status', OrderStatus::Placed)
@@ -152,8 +147,8 @@ The namespace for the `DigitalDownloadsReady` notification has changed. You shou
 ```php
 'notifications' => [
     'digital_download_ready' => [
-        \DoubleThreeDigital\DigitalProducts\Notifications\DigitalDownloadsNotification::class => [ // [tl! remove]
-        \DoubleThreeDigital\SimpleCommerce\Notifications\DigitalDownloadsNotification::class => [ // [tl! add]
+        \DuncanMcClean\DigitalProducts\Notifications\DigitalDownloadsNotification::class => [ // [tl! remove]
+        \DuncanMcClean\SimpleCommerce\Notifications\DigitalDownloadsNotification::class => [ // [tl! add]
             'to' => 'customer',
         ],
     ],

--- a/docs/upgrade-guides/v5-x-to-v6-0.md
+++ b/docs/upgrade-guides/v5-x-to-v6-0.md
@@ -47,16 +47,15 @@ php artisan view:clear
 
 ## Changes
 
-### High: Runway v6
+### High: Simple Commerce's Namespace has changed
 
-If you're storing orders & customers in the database, you should also follow the [Runway v6 Upgrade Guide](https://runway.duncanmcclean.com/upgrade-guides/v5-x-to-v6-0).
+Simple Commerce's namespace has changed from `DoubleThreeDigital` to `DuncanMcClean`.
 
-### High: Database Migrations
+During the update process, any references to `DoubleThreeDigital` in your config file should have been automatically updated. If you have any custom code, you will need to change the namespace:
 
-If you're storing orders in the database, you will need to run the migrations, both locally & when deploying to any other environments:
-
-```
-php artisan migrate
+```php
+use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway; // [tl! remove]
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway; // [tl! add]
 ```
 
 ## High: References to gateways & shipping methods in orders have changed
@@ -76,6 +75,18 @@ shipping_method: free_shipping
 Simple Commerce will automatically update your orders when you run the `sc:run-update-scripts` command.
 
 If you're manually referencing gateway / shipping method class names anywhere, you should instead reference the handle. To determine if you're referencing class names, search for `{{ class }}` in your site's shipping & checkout pages and change any instances to `{{ handle }}`.
+
+### High: Runway v6
+
+If you're storing orders & customers in the database, you should also follow the [Runway v6 Upgrade Guide](https://runway.duncanmcclean.com/upgrade-guides/v5-x-to-v6-0).
+
+### High: Database Migrations
+
+If you're storing orders in the database, you will need to run the migrations, both locally & when deploying to any other environments:
+
+```
+php artisan migrate
+```
 
 ### Medium: The `all` method on repositories has changed
 

--- a/resources/blueprints/collections/orders/orders.yaml
+++ b/resources/blueprints/collections/orders/orders.yaml
@@ -1,0 +1,3 @@
+tabs:
+  main:
+    fields: {  }

--- a/resources/blueprints/collections/products/product.yaml
+++ b/resources/blueprints/collections/products/product.yaml
@@ -1,7 +1,5 @@
-title: Product
 tabs:
   main:
-    display: Main
     sections:
       -
         fields:
@@ -10,24 +8,31 @@ tabs:
             field:
               type: text
               required: true
-              validate:
-                - required
-              width: 50
           -
-            handle: price
+            handle: product_variants
             field:
-              type: money
-              display: Price
-              save_zero_value: true
-              listable: hidden
-              width: 50
-              instructions_position: above
-              visibility: visible
-              always_save: false
-              validate:
-                - required
+              type: product_variants
+              handle: product_variants
+              width: 100
+              option_fields:
+                -
+                  handle: downloadable_asset
+                  field:
+                    type: assets
+                    mode: grid
+                    display: 'Downloadable Asset'
+                    container: test
+                    if:
+                      root.product_type: 'equals digital'
+                -
+                  handle: download_limit
+                  field:
+                    type: integer
+                    display: 'Download Limit'
+                    instructions: "If you'd like to limit the amount if times this product can be downloaded, set it here. Keep it blank if you'd like it to be unlimited."
+                    if:
+                      root.product_type: 'equals digital'
   sidebar:
-    display: Sidebar
     sections:
       -
         fields:
@@ -45,25 +50,4 @@ tabs:
             field:
               type: slug
               localizable: true
-              validate:
-                - required
-      -
-        display: 'Digital Product'
-        fields:
-          -
-            handle: downloadable_asset
-            field:
-              type: assets
-              mode: grid
-              display: 'Downloadable Asset'
-              container: assets
-              if:
-                root.product_type: 'equals digital'
-          -
-            handle: download_limit
-            field:
-              type: integer
-              display: 'Download Limit'
-              instructions: "If you'd like to limit the amount if times this product can be downloaded, set it here. Keep it blank if you'd like it to be unlimited."
-              if:
-                root.product_type: 'equals digital'
+              validate: 'max:200'

--- a/resources/views/cp/widgets/recent-orders.blade.php
+++ b/resources/views/cp/widgets/recent-orders.blade.php
@@ -3,7 +3,7 @@
         <h2>
             <a class="flex items-center" href="{{ $url }}">
                 <div class="h-6 w-6 mr-2 text-gray-800">
-                    {!! \DoubleThreeDigital\SimpleCommerce\SimpleCommerce::svg('shop') !!}
+                    {!! \DuncanMcClean\SimpleCommerce\SimpleCommerce::svg('shop') !!}
                 </div>
                 <span>{{ __('Recent Orders') }}</span>
             </a>

--- a/resources/views/emails/backoffice_order_paid.blade.php
+++ b/resources/views/emails/backoffice_order_paid.blade.php
@@ -11,17 +11,17 @@
 | {{ __('Items') }}       | {{ __('Quantity') }}         | {{ __('Total') }} |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
-| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $lineItem->totalIncludingTax() : $lineItem->total(), $site) }} |
+| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $lineItem->totalIncludingTax() : $lineItem->total(), $site) }} |
 @endforeach
-| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->itemsTotalWithTax() : $order->itemsTotal(), $site) }}
+| | {{ __('Subtotal') }}: | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->itemsTotalWithTax() : $order->itemsTotal(), $site) }}
 @if($order->coupon())
-| | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
+| | {{ __('Coupon') }}: | -{{ \DuncanMcClean\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
-| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->shippingTotalWithTax() : $order->shippingTotal(), $site) }}
+| | {{ __('Shipping') }}: | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->shippingTotalWithTax() : $order->shippingTotal(), $site) }}
 @if(!$taxIncludedInPrices)
-| | {{ __('Tax') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
+| | {{ __('Tax') }}: | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
 @endif
-| | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
+| | **{{ __('Total') }}:** | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent
 

--- a/resources/views/emails/customer_order_paid.blade.php
+++ b/resources/views/emails/customer_order_paid.blade.php
@@ -11,17 +11,17 @@
 | {{ __('Items') }}       | {{ __('Quantity') }}         | {{ __('Total') }} |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
-| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $lineItem->totalIncludingTax() : $lineItem->total(), $site) }} |
+| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $lineItem->totalIncludingTax() : $lineItem->total(), $site) }} |
 @endforeach
-| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->itemsTotalWithTax() : $order->itemsTotal(), $site) }}
+| | {{ __('Subtotal') }}: | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->itemsTotalWithTax() : $order->itemsTotal(), $site) }}
 @if($order->coupon())
-| | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
+| | {{ __('Coupon') }}: | -{{ \DuncanMcClean\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
-| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->shippingTotalWithTax() : $order->shippingTotal(), $site) }}
+| | {{ __('Shipping') }}: | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->shippingTotalWithTax() : $order->shippingTotal(), $site) }}
 @if(!$taxIncludedInPrices)
-| | {{ __('Tax') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
+| | {{ __('Tax') }}: | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
 @endif
-| | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
+| | **{{ __('Total') }}:** | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent
 

--- a/resources/views/emails/customer_order_shipped.blade.php
+++ b/resources/views/emails/customer_order_shipped.blade.php
@@ -11,17 +11,17 @@
 | {{ __('Items') }}       | {{ __('Quantity') }}         | {{ __('Total') }} |
 | :--------- | :------------- | :----- |
 @foreach ($order->lineItems() as $lineItem)
-| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $lineItem->totalIncludingTax() : $lineItem->total(), $site) }} |
+| [{{ $lineItem->product()->get('title') }}]({{ optional($lineItem->product()->resource())->absoluteUrl() }}) | {{ $lineItem->quantity() }} | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $lineItem->totalIncludingTax() : $lineItem->total(), $site) }} |
 @endforeach
-| | {{ __('Subtotal') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->itemsTotalWithTax() : $order->itemsTotal(), $site) }}
+| | {{ __('Subtotal') }}: | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->itemsTotalWithTax() : $order->itemsTotal(), $site) }}
 @if($order->coupon())
-| | {{ __('Coupon') }}: | -{{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
+| | {{ __('Coupon') }}: | -{{ \DuncanMcClean\SimpleCommerce\Currency::parse($order->couponTotal(), $site) }}
 @endif
-| | {{ __('Shipping') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->shippingTotalWithTax() : $order->shippingTotal(), $site) }}
+| | {{ __('Shipping') }}: | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($taxIncludedInPrices ? $order->shippingTotalWithTax() : $order->shippingTotal(), $site) }}
 @if(!$taxIncludedInPrices)
-| | {{ __('Tax') }}: | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
+| | {{ __('Tax') }}: | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($order->taxTotal(), $site) }}
 @endif
-| | **{{ __('Total') }}:** | {{ \DoubleThreeDigital\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
+| | **{{ __('Total') }}:** | {{ \DuncanMcClean\SimpleCommerce\Currency::parse($order->grandTotal(), $site) }}
 | | |
 @endcomponent
 

--- a/routes/actions.php
+++ b/routes/actions.php
@@ -1,15 +1,15 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CartController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CartItemController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CheckoutController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CouponController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CustomerController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\DigitalProducts\DownloadController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\DigitalProducts\VerificationController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\GatewayCallbackController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\GatewayWebhookController;
-use DoubleThreeDigital\SimpleCommerce\Http\Middleware\EnsureFormParametersArriveIntact;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CartController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CartItemController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CheckoutController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CouponController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CustomerController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\DigitalProducts\DownloadController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\DigitalProducts\VerificationController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\GatewayCallbackController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\GatewayWebhookController;
+use DuncanMcClean\SimpleCommerce\Http\Middleware\EnsureFormParametersArriveIntact;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Support\Facades\Route;
 

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -1,16 +1,16 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP\Coupons\CouponActionController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP\Coupons\CouponController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP\Coupons\CouponListingController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP\RegionController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP\ResendNotificationsController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP\StatusLogController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP\TaxCategoryController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP\TaxRateController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP\TaxZoneController;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP\VariantFieldtypeController;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CP\Coupons\CouponActionController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CP\Coupons\CouponController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CP\Coupons\CouponListingController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CP\RegionController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CP\ResendNotificationsController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CP\StatusLogController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CP\TaxCategoryController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CP\TaxRateController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CP\TaxZoneController;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\CP\VariantFieldtypeController;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('simple-commerce')->name('simple-commerce.')->group(function () {

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Actions;
+namespace DuncanMcClean\SimpleCommerce\Actions;
 
 use Statamic\Actions\Action;
 
@@ -18,7 +18,7 @@ class Delete extends Action
     public function visibleTo($item)
     {
         switch (true) {
-            case $item instanceof \DoubleThreeDigital\SimpleCommerce\Coupons\Coupon:
+            case $item instanceof \DuncanMcClean\SimpleCommerce\Coupons\Coupon:
                 return true;
             default:
                 return false;
@@ -28,7 +28,7 @@ class Delete extends Action
     public function authorize($user, $item)
     {
         switch (true) {
-            case $item instanceof \DoubleThreeDigital\SimpleCommerce\Coupons\Coupon:
+            case $item instanceof \DuncanMcClean\SimpleCommerce\Coupons\Coupon:
                 return $user->can('delete coupons');
             default:
                 return false;

--- a/src/Actions/RefundAction.php
+++ b/src/Actions/RefundAction.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Actions;
+namespace DuncanMcClean\SimpleCommerce\Actions;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Statamic\Actions\Action;
 use Statamic\Entries\Entry;
 

--- a/src/Actions/UpdateOrderStatus.php
+++ b/src/Actions/UpdateOrderStatus.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Actions;
+namespace DuncanMcClean\SimpleCommerce\Actions;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Facades\Config;
 use Statamic\Actions\Action;
 use Statamic\Entries\Entry;

--- a/src/Console/Commands/GeneratorCommand.php
+++ b/src/Console/Commands/GeneratorCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Console\Commands;
+namespace DuncanMcClean\SimpleCommerce\Console\Commands;
 
 use Statamic\Console\Commands\GeneratorCommand as StatamicGeneratorCommand;
 

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Console\Commands;
+namespace DuncanMcClean\SimpleCommerce\Console\Commands;
 
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;

--- a/src/Console/Commands/MakeGateway.php
+++ b/src/Console/Commands/MakeGateway.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Console\Commands;
+namespace DuncanMcClean\SimpleCommerce\Console\Commands;
 
 use Statamic\Console\RunsInPlease;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Console/Commands/MakeShippingMethod.php
+++ b/src/Console/Commands/MakeShippingMethod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Console\Commands;
+namespace DuncanMcClean\SimpleCommerce\Console\Commands;
 
 use Statamic\Console\RunsInPlease;
 

--- a/src/Console/Commands/MigrateOrderStatuses.php
+++ b/src/Console/Commands/MigrateOrderStatuses.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Console\Commands;
+namespace DuncanMcClean\SimpleCommerce\Console\Commands;
 
 use Carbon\Carbon;
-use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\OrderModel;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Support\Facades\Artisan;

--- a/src/Console/Commands/MigrateOrdersToDatabase.php
+++ b/src/Console/Commands/MigrateOrdersToDatabase.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Console\Commands;
+namespace DuncanMcClean\SimpleCommerce\Console\Commands;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Statamic\Console\RunsInPlease;

--- a/src/Console/Commands/PurgeCartOrdersCommand.php
+++ b/src/Console/Commands/PurgeCartOrdersCommand.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Console\Commands;
+namespace DuncanMcClean\SimpleCommerce\Console\Commands;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Statamic\Console\RunsInPlease;

--- a/src/Console/Commands/RunUpdateScripts.php
+++ b/src/Console/Commands/RunUpdateScripts.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Console\Commands;
+namespace DuncanMcClean\SimpleCommerce\Console\Commands;
 
 use Illuminate\Console\Command;
 use Statamic\Console\RunsInPlease;
@@ -21,7 +21,7 @@ class RunUpdateScripts extends Command
         // doing it manually here.
         app('statamic.update-scripts')
             ->filter(function (array $script) {
-                return $script['package'] === 'doublethreedigital/simple-commerce';
+                return $script['package'] === 'duncanmcclean/simple-commerce';
             })
             ->each(function (array $script) {
                 $updateScript = new $script['class']($script['package'], $this);

--- a/src/Console/Commands/SwitchToDatabase.php
+++ b/src/Console/Commands/SwitchToDatabase.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Console\Commands;
+namespace DuncanMcClean\SimpleCommerce\Console\Commands;
 
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Statamic\Console\Processes\Composer;
@@ -112,12 +112,12 @@ class SwitchToDatabase extends Command
 
         ConfigWriter::edit('simple-commerce')
             ->replace('content.orders', [
-                'repository' => \DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository::class,
-                'model' => \DoubleThreeDigital\SimpleCommerce\Orders\OrderModel::class,
+                'repository' => \DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository::class,
+                'model' => \DuncanMcClean\SimpleCommerce\Orders\OrderModel::class,
             ])
             ->replace('content.customers', [
-                'repository' => \DoubleThreeDigital\SimpleCommerce\Customers\EloquentCustomerRepository::class,
-                'model' => \DoubleThreeDigital\SimpleCommerce\Customers\CustomerModel::class,
+                'repository' => \DuncanMcClean\SimpleCommerce\Customers\EloquentCustomerRepository::class,
+                'model' => \DuncanMcClean\SimpleCommerce\Customers\CustomerModel::class,
             ])
             ->save();
 

--- a/src/Console/Commands/stubs/create_status_log_table.php
+++ b/src/Console/Commands/stubs/create_status_log_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
+use DuncanMcClean\SimpleCommerce\Orders\OrderModel;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Arr;

--- a/src/Console/Commands/stubs/gateway-offsite.php.stub
+++ b/src/Console/Commands/stubs/gateway-offsite.php.stub
@@ -2,9 +2,9 @@
 
 namespace DummyNamespace;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Gateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
 use Illuminate\Http\Request;
 
 class DummyClass extends BaseGateway implements Gateway

--- a/src/Console/Commands/stubs/gateway-onsite.php.stub
+++ b/src/Console/Commands/stubs/gateway-onsite.php.stub
@@ -2,9 +2,9 @@
 
 namespace DummyNamespace;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Gateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
 use Illuminate\Http\Request;
 
 class DummyClass extends BaseGateway implements Gateway

--- a/src/Console/Commands/stubs/runway_config.php
+++ b/src/Console/Commands/stubs/runway_config.php
@@ -12,13 +12,13 @@ return [
     */
 
     'resources' => [
-        \DoubleThreeDigital\SimpleCommerce\Customers\CustomerModel::class => [
+        \DuncanMcClean\SimpleCommerce\Customers\CustomerModel::class => [
             'name' => 'Customers',
             'handle' => 'customers',
             'hidden' => true,
         ],
 
-        \DoubleThreeDigital\SimpleCommerce\Orders\OrderModel::class => [
+        \DuncanMcClean\SimpleCommerce\Orders\OrderModel::class => [
             'name' => 'Orders',
             'handle' => 'orders',
             'hidden' => true,

--- a/src/Console/Commands/stubs/shipping.php.stub
+++ b/src/Console/Commands/stubs/shipping.php.stub
@@ -2,10 +2,10 @@
 
 namespace DummyNamespace;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
-use DoubleThreeDigital\SimpleCommerce\Orders\Address;
-use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\ShippingMethod;
+use DuncanMcClean\SimpleCommerce\Orders\Address;
+use DuncanMcClean\SimpleCommerce\Shipping\BaseShippingMethod;
 
 class DummyClass extends BaseShippingMethod implements ShippingMethod
 {

--- a/src/Contracts/Calculator.php
+++ b/src/Contracts/Calculator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
 interface Calculator
 {

--- a/src/Contracts/CartDriver.php
+++ b/src/Contracts/CartDriver.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
 interface CartDriver
 {

--- a/src/Contracts/Coupon.php
+++ b/src/Contracts/Coupon.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
 /**
- * @mixin \DoubleThreeDigital\SimpleCommerce\Coupons\Coupon
+ * @mixin \DuncanMcClean\SimpleCommerce\Coupons\Coupon
  */
 interface Coupon
 {

--- a/src/Contracts/CouponRepository.php
+++ b/src/Contracts/CouponRepository.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
-use DoubleThreeDigital\SimpleCommerce\Coupons\CouponQueryBuilder;
+use DuncanMcClean\SimpleCommerce\Coupons\CouponQueryBuilder;
 use Statamic\Data\DataCollection;
 
 interface CouponRepository

--- a/src/Contracts/Customer.php
+++ b/src/Contracts/Customer.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
 /**
- * @mixin \DoubleThreeDigital\SimpleCommerce\Customers\Customer
+ * @mixin \DuncanMcClean\SimpleCommerce\Customers\Customer
  */
 interface Customer
 {

--- a/src/Contracts/CustomerRepository.php
+++ b/src/Contracts/CustomerRepository.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
 interface CustomerRepository
 {

--- a/src/Contracts/Gateway.php
+++ b/src/Contracts/Gateway.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
 use Illuminate\Http\Request;
 

--- a/src/Contracts/GatewayManager.php
+++ b/src/Contracts/GatewayManager.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
 use Illuminate\Http\Request;
 

--- a/src/Contracts/LicenseKeyRepository.php
+++ b/src/Contracts/LicenseKeyRepository.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
 /**
- * @mixin \DoubleThreeDigital\SimpleCommerce\Products\DigitalProducts\LicenseKeyRepository
+ * @mixin \DuncanMcClean\SimpleCommerce\Products\DigitalProducts\LicenseKeyRepository
  */
 interface LicenseKeyRepository
 {

--- a/src/Contracts/Order.php
+++ b/src/Contracts/Order.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
 /**
- * @mixin \DoubleThreeDigital\SimpleCommerce\Orders\Order
+ * @mixin \DuncanMcClean\SimpleCommerce\Orders\Order
  */
 interface Order
 {

--- a/src/Contracts/OrderRepository.php
+++ b/src/Contracts/OrderRepository.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
 interface OrderRepository
 {

--- a/src/Contracts/Product.php
+++ b/src/Contracts/Product.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
 /**
- * @mixin \DoubleThreeDigital\SimpleCommerce\Products\Product
+ * @mixin \DuncanMcClean\SimpleCommerce\Products\Product
  */
 interface Product
 {

--- a/src/Contracts/ProductRepository.php
+++ b/src/Contracts/ProductRepository.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
 interface ProductRepository
 {

--- a/src/Contracts/ShippingManager.php
+++ b/src/Contracts/ShippingManager.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\Address;
+use DuncanMcClean\SimpleCommerce\Orders\Address;
 
 interface ShippingManager
 {

--- a/src/Contracts/ShippingMethod.php
+++ b/src/Contracts/ShippingMethod.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\Address;
+use DuncanMcClean\SimpleCommerce\Orders\Address;
 
 interface ShippingMethod
 {

--- a/src/Contracts/TaxCategoryRepository.php
+++ b/src/Contracts/TaxCategoryRepository.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
-use DoubleThreeDigital\SimpleCommerce\Tax\Standard\Stache\TaxCategory\TaxCategoryQueryBuilder;
-use DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\Stache\TaxCategory\TaxCategoryQueryBuilder;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\TaxCategory;
 use Statamic\Data\DataCollection;
 
 interface TaxCategoryRepository

--- a/src/Contracts/TaxEngine.php
+++ b/src/Contracts/TaxEngine.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
-use DoubleThreeDigital\SimpleCommerce\Tax\TaxCalculation;
+use DuncanMcClean\SimpleCommerce\Orders\LineItem;
+use DuncanMcClean\SimpleCommerce\Tax\TaxCalculation;
 
 interface TaxEngine
 {

--- a/src/Contracts/TaxRateRepository.php
+++ b/src/Contracts/TaxRateRepository.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
-use DoubleThreeDigital\SimpleCommerce\Tax\Standard\Stache\TaxRate\TaxRateQueryBuilder;
-use DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxRate;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\Stache\TaxRate\TaxRateQueryBuilder;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\TaxRate;
 use Statamic\Data\DataCollection;
 
 interface TaxRateRepository

--- a/src/Contracts/TaxZoneRepository.php
+++ b/src/Contracts/TaxZoneRepository.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Contracts;
+namespace DuncanMcClean\SimpleCommerce\Contracts;
 
-use DoubleThreeDigital\SimpleCommerce\Tax\Standard\Stache\TaxZone\TaxZoneQueryBuilder;
-use DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxZone;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\Stache\TaxZone\TaxZoneQueryBuilder;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\TaxZone;
 use Statamic\Data\DataCollection;
 
 interface TaxZoneRepository

--- a/src/Countries.php
+++ b/src/Countries.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce;
+namespace DuncanMcClean\SimpleCommerce;
 
 use Illuminate\Support\Facades\File;
 

--- a/src/Coupons/Coupon.php
+++ b/src/Coupons/Coupon.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Coupons;
+namespace DuncanMcClean\SimpleCommerce\Coupons;
 
 use Carbon\Carbon;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Coupon as Contract;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Currency;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon as CouponFacade;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderFacade;
+use DuncanMcClean\SimpleCommerce\Contracts\Coupon as Contract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Currency;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon as CouponFacade;
+use DuncanMcClean\SimpleCommerce\Facades\Order as OrderFacade;
 use Illuminate\Support\Str;
 use Statamic\Data\ContainsData;
 use Statamic\Data\ExistsAsFile;

--- a/src/Coupons/CouponBlueprint.php
+++ b/src/Coupons/CouponBlueprint.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Coupons;
+namespace DuncanMcClean\SimpleCommerce\Coupons;
 
-use DoubleThreeDigital\SimpleCommerce\Customers\EloquentCustomerRepository;
-use DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Customers\EloquentCustomerRepository;
+use DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Statamic\Facades\Blueprint;
 use Statamic\Fields\Blueprint as FieldsBlueprint;
 

--- a/src/Coupons/CouponQueryBuilder.php
+++ b/src/Coupons/CouponQueryBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Coupons;
+namespace DuncanMcClean\SimpleCommerce\Coupons;
 
 use Statamic\Data\DataCollection;
 use Statamic\Stache\Query\Builder;

--- a/src/Coupons/CouponRepository.php
+++ b/src/Coupons/CouponRepository.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Coupons;
+namespace DuncanMcClean\SimpleCommerce\Coupons;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\CouponRepository as ContractsCouponRepository;
+use DuncanMcClean\SimpleCommerce\Contracts\CouponRepository as ContractsCouponRepository;
 use Statamic\Data\DataCollection;
 use Statamic\Stache\Stache;
 

--- a/src/Coupons/CouponStore.php
+++ b/src/Coupons/CouponStore.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Coupons;
+namespace DuncanMcClean\SimpleCommerce\Coupons;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
 use Illuminate\Support\Arr;
 use Statamic\Facades\YAML;
 use Statamic\Stache\Stores\BasicStore;

--- a/src/Coupons/CouponType.php
+++ b/src/Coupons/CouponType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Coupons;
+namespace DuncanMcClean\SimpleCommerce\Coupons;
 
 enum CouponType: string
 {

--- a/src/Currencies.php
+++ b/src/Currencies.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce;
+namespace DuncanMcClean\SimpleCommerce;
 
 class Currencies
 {

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce;
+namespace DuncanMcClean\SimpleCommerce;
 
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CurrencyFormatterNotWorking;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\SiteNotConfiguredException;
+use DuncanMcClean\SimpleCommerce\Exceptions\CurrencyFormatterNotWorking;
+use DuncanMcClean\SimpleCommerce\Exceptions\SiteNotConfiguredException;
 use Illuminate\Support\Facades\Config;
 use Money\Currencies\ISOCurrencies;
 use Money\Currency as MoneyCurrency;

--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Customers;
+namespace DuncanMcClean\SimpleCommerce\Customers;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Customer as Contract;
-use DoubleThreeDigital\SimpleCommerce\Data\HasData;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer as CustomerFacade;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Http\Resources\BaseResource;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Customer as Contract;
+use DuncanMcClean\SimpleCommerce\Data\HasData;
+use DuncanMcClean\SimpleCommerce\Exceptions\OrderNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Customer as CustomerFacade;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Http\Resources\BaseResource;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection;

--- a/src/Customers/CustomerModel.php
+++ b/src/Customers/CustomerModel.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Customers;
+namespace DuncanMcClean\SimpleCommerce\Customers;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
+use DuncanMcClean\SimpleCommerce\Orders\OrderModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;

--- a/src/Customers/EloquentCustomerRepository.php
+++ b/src/Customers/EloquentCustomerRepository.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Customers;
+namespace DuncanMcClean\SimpleCommerce\Customers;
 
 use Doctrine\DBAL\Schema\Column;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Customer;
-use DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository as RepositoryContract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Customer;
+use DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository as RepositoryContract;
+use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Facades\Schema;
 
 class EloquentCustomerRepository implements RepositoryContract

--- a/src/Customers/EloquentQueryBuilder.php
+++ b/src/Customers/EloquentQueryBuilder.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Customers;
+namespace DuncanMcClean\SimpleCommerce\Customers;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
 use Statamic\Query\EloquentQueryBuilder as QueryEloquentQueryBuilder;
 
 class EloquentQueryBuilder extends QueryEloquentQueryBuilder

--- a/src/Customers/EloquentUserQueryBuilder.php
+++ b/src/Customers/EloquentUserQueryBuilder.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Customers;
+namespace DuncanMcClean\SimpleCommerce\Customers;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
 use Statamic\Auth\Eloquent\UserQueryBuilder;
 
 class EloquentUserQueryBuilder extends UserQueryBuilder

--- a/src/Customers/EntryCustomerRepository.php
+++ b/src/Customers/EntryCustomerRepository.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Customers;
+namespace DuncanMcClean\SimpleCommerce\Customers;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Customer;
-use DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository as RepositoryContract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Customer;
+use DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository as RepositoryContract;
+use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Arr;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Stache;

--- a/src/Customers/EntryQueryBuilder.php
+++ b/src/Customers/EntryQueryBuilder.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Customers;
+namespace DuncanMcClean\SimpleCommerce\Customers;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
 use Statamic\Stache\Query\EntryQueryBuilder as QueryEntryQueryBuilder;
 
 class EntryQueryBuilder extends QueryEntryQueryBuilder

--- a/src/Customers/StacheUserQueryBuilder.php
+++ b/src/Customers/StacheUserQueryBuilder.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Customers;
+namespace DuncanMcClean\SimpleCommerce\Customers;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
 use Statamic\Stache\Query\UserQueryBuilder;
 
 class StacheUserQueryBuilder extends UserQueryBuilder

--- a/src/Customers/UserCustomerRepository.php
+++ b/src/Customers/UserCustomerRepository.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Customers;
+namespace DuncanMcClean\SimpleCommerce\Customers;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Customer;
-use DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository as RepositoryContract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
+use DuncanMcClean\SimpleCommerce\Contracts\Customer;
+use DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository as RepositoryContract;
+use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
 use Illuminate\Support\Arr;
 use Statamic\Facades\User;
 

--- a/src/Data/HasData.php
+++ b/src/Data/HasData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Data;
+namespace DuncanMcClean\SimpleCommerce\Data;
 
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 

--- a/src/DebugbarDataCollector.php
+++ b/src/DebugbarDataCollector.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce;
+namespace DuncanMcClean\SimpleCommerce;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use Statamic\Facades\Site;
 
 class DebugbarDataCollector extends \DebugBar\DataCollector\DataCollector implements \DebugBar\DataCollector\Renderable

--- a/src/Events/CouponRedeemed.php
+++ b/src/Events/CouponRedeemed.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Events;
+namespace DuncanMcClean\SimpleCommerce\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Coupon;
+use DuncanMcClean\SimpleCommerce\Contracts\Coupon;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 

--- a/src/Events/DigitalDownloadReady.php
+++ b/src/Events/DigitalDownloadReady.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Events;
+namespace DuncanMcClean\SimpleCommerce\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 
 class DigitalDownloadReady
 {

--- a/src/Events/GatewayWebhookReceived.php
+++ b/src/Events/GatewayWebhookReceived.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Events;
+namespace DuncanMcClean\SimpleCommerce\Events;
 
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;

--- a/src/Events/OrderPaymentFailed.php
+++ b/src/Events/OrderPaymentFailed.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Events;
+namespace DuncanMcClean\SimpleCommerce\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 

--- a/src/Events/OrderSaved.php
+++ b/src/Events/OrderSaved.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Events;
+namespace DuncanMcClean\SimpleCommerce\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 

--- a/src/Events/OrderStatusUpdated.php
+++ b/src/Events/OrderStatusUpdated.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Events;
+namespace DuncanMcClean\SimpleCommerce\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 

--- a/src/Events/PaymentStatusUpdated.php
+++ b/src/Events/PaymentStatusUpdated.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Events;
+namespace DuncanMcClean\SimpleCommerce\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 

--- a/src/Events/PostCheckout.php
+++ b/src/Events/PostCheckout.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Events;
+namespace DuncanMcClean\SimpleCommerce\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 

--- a/src/Events/PreCheckout.php
+++ b/src/Events/PreCheckout.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Events;
+namespace DuncanMcClean\SimpleCommerce\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 

--- a/src/Events/StockRunOut.php
+++ b/src/Events/StockRunOut.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Events;
+namespace DuncanMcClean\SimpleCommerce\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Product;
+use DuncanMcClean\SimpleCommerce\Contracts\Product;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 

--- a/src/Events/StockRunningLow.php
+++ b/src/Events/StockRunningLow.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Events;
+namespace DuncanMcClean\SimpleCommerce\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Product;
+use DuncanMcClean\SimpleCommerce\Contracts\Product;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 

--- a/src/Exceptions/CheckoutProductHasNoStockException.php
+++ b/src/Exceptions/CheckoutProductHasNoStockException.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Product;
+use DuncanMcClean\SimpleCommerce\Contracts\Product;
 
 class CheckoutProductHasNoStockException extends PreventCheckout
 {

--- a/src/Exceptions/CouponNotFound.php
+++ b/src/Exceptions/CouponNotFound.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/CurrencyFormatterNotWorking.php
+++ b/src/Exceptions/CurrencyFormatterNotWorking.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 use Exception;
 use Facade\IgnitionContracts\BaseSolution;

--- a/src/Exceptions/CustomerNotFound.php
+++ b/src/Exceptions/CustomerNotFound.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/GatewayCallbackMethodDoesNotExist.php
+++ b/src/Exceptions/GatewayCallbackMethodDoesNotExist.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 class GatewayCallbackMethodDoesNotExist extends \Exception
 {

--- a/src/Exceptions/GatewayCheckoutFailed.php
+++ b/src/Exceptions/GatewayCheckoutFailed.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/GatewayDoesNotExist.php
+++ b/src/Exceptions/GatewayDoesNotExist.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 use Exception;
 use Facade\IgnitionContracts\BaseSolution;

--- a/src/Exceptions/GatewayException.php
+++ b/src/Exceptions/GatewayException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 class GatewayException extends \Exception
 {

--- a/src/Exceptions/GatewayHasNotImplementedMethod.php
+++ b/src/Exceptions/GatewayHasNotImplementedMethod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 class GatewayHasNotImplementedMethod extends \Exception
 {

--- a/src/Exceptions/GatewayNotProvided.php
+++ b/src/Exceptions/GatewayNotProvided.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 use Exception;
 use Facade\IgnitionContracts\BaseSolution;

--- a/src/Exceptions/InvalidFormParametersException.php
+++ b/src/Exceptions/InvalidFormParametersException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 class InvalidFormParametersException extends \Exception
 {

--- a/src/Exceptions/OrderNotFound.php
+++ b/src/Exceptions/OrderNotFound.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/PayPalDetailsMissingOnOrderException.php
+++ b/src/Exceptions/PayPalDetailsMissingOnOrderException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 class PayPalDetailsMissingOnOrderException extends \Exception
 {

--- a/src/Exceptions/PreventCheckout.php
+++ b/src/Exceptions/PreventCheckout.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 class PreventCheckout extends \Exception
 {

--- a/src/Exceptions/ProductNotFound.php
+++ b/src/Exceptions/ProductNotFound.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/RefundFailed.php
+++ b/src/Exceptions/RefundFailed.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 class RefundFailed extends \Exception
 {

--- a/src/Exceptions/ShippingMethodDoesNotExist.php
+++ b/src/Exceptions/ShippingMethodDoesNotExist.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/SiteNotConfiguredException.php
+++ b/src/Exceptions/SiteNotConfiguredException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 use Exception;
 use Facade\IgnitionContracts\BaseSolution;

--- a/src/Exceptions/StripeSecretMissing.php
+++ b/src/Exceptions/StripeSecretMissing.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Exceptions;
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
 
 use Exception;
 

--- a/src/Facades/Coupon.php
+++ b/src/Facades/Coupon.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Facades;
+namespace DuncanMcClean\SimpleCommerce\Facades;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\CouponRepository;
+use DuncanMcClean\SimpleCommerce\Contracts\CouponRepository;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \DoubleThreeDigital\SimpleCommerce\Contracts\CouponRepository
+ * @see \DuncanMcClean\SimpleCommerce\Contracts\CouponRepository
  */
 class Coupon extends Facade
 {

--- a/src/Facades/Customer.php
+++ b/src/Facades/Customer.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Facades;
+namespace DuncanMcClean\SimpleCommerce\Facades;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository;
+use DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository
+ * @see \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository
  */
 class Customer extends Facade
 {

--- a/src/Facades/Gateway.php
+++ b/src/Facades/Gateway.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Facades;
+namespace DuncanMcClean\SimpleCommerce\Facades;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\GatewayManager as Contract;
+use DuncanMcClean\SimpleCommerce\Contracts\GatewayManager as Contract;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static \DoubleThreeDigital\SimpleCommerce\Contracts\GatewayManager use($className)
- * @method static \DoubleThreeDigital\SimpleCommerce\Contracts\GatewayManager withRedirectUrl(string $redirectUrl)
- * @method static \DoubleThreeDigital\SimpleCommerce\Contracts\GatewayManager withErrorRedirectUrl(string $errorRedirectUrl)
+ * @method static \DuncanMcClean\SimpleCommerce\Contracts\GatewayManager use($className)
+ * @method static \DuncanMcClean\SimpleCommerce\Contracts\GatewayManager withRedirectUrl(string $redirectUrl)
+ * @method static \DuncanMcClean\SimpleCommerce\Contracts\GatewayManager withErrorRedirectUrl(string $errorRedirectUrl)
  */
 class Gateway extends Facade
 {

--- a/src/Facades/LicenseKey.php
+++ b/src/Facades/LicenseKey.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Facades;
+namespace DuncanMcClean\SimpleCommerce\Facades;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\LicenseKeyRepository;
+use DuncanMcClean\SimpleCommerce\Contracts\LicenseKeyRepository;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \DoubleThreeDigital\SimpleCommerce\Products\DigitalProducts\LicenseKeyRepository
+ * @see \DuncanMcClean\SimpleCommerce\Products\DigitalProducts\LicenseKeyRepository
  */
 class LicenseKey extends Facade
 {

--- a/src/Facades/Order.php
+++ b/src/Facades/Order.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Facades;
+namespace DuncanMcClean\SimpleCommerce\Facades;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\OrderRepository;
+use DuncanMcClean\SimpleCommerce\Contracts\OrderRepository;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \DoubleThreeDigital\SimpleCommerce\Contracts\OrderRepository
+ * @see \DuncanMcClean\SimpleCommerce\Contracts\OrderRepository
  */
 class Order extends Facade
 {

--- a/src/Facades/Product.php
+++ b/src/Facades/Product.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Facades;
+namespace DuncanMcClean\SimpleCommerce\Facades;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\ProductRepository;
+use DuncanMcClean\SimpleCommerce\Contracts\ProductRepository;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \DoubleThreeDigital\SimpleCommerce\Contracts\ProductRepository
+ * @see \DuncanMcClean\SimpleCommerce\Contracts\ProductRepository
  */
 class Product extends Facade
 {

--- a/src/Facades/Shipping.php
+++ b/src/Facades/Shipping.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Facades;
+namespace DuncanMcClean\SimpleCommerce\Facades;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingManager;
+use DuncanMcClean\SimpleCommerce\Contracts\ShippingManager;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static \DoubleThreeDigital\SimpleCommerce\Contracts\ShippingManager use($className)
+ * @method static \DuncanMcClean\SimpleCommerce\Contracts\ShippingManager use($className)
  */
 class Shipping extends Facade
 {

--- a/src/Facades/TaxCategory.php
+++ b/src/Facades/TaxCategory.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Facades;
+namespace DuncanMcClean\SimpleCommerce\Facades;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\TaxCategoryRepository;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\TaxCategoryRepository;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Facades\Facade;
 
 class TaxCategory extends Facade

--- a/src/Facades/TaxRate.php
+++ b/src/Facades/TaxRate.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Facades;
+namespace DuncanMcClean\SimpleCommerce\Facades;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\TaxRateRepository;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\TaxRateRepository;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Facades\Facade;
 
 class TaxRate extends Facade

--- a/src/Facades/TaxZone.php
+++ b/src/Facades/TaxZone.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Facades;
+namespace DuncanMcClean\SimpleCommerce\Facades;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\TaxZoneRepository;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\TaxZoneRepository;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Facades\Facade;
 
 class TaxZone extends Facade

--- a/src/Fieldtypes/CountryFieldtype.php
+++ b/src/Fieldtypes/CountryFieldtype.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
-use DoubleThreeDigital\SimpleCommerce\Countries;
+use DuncanMcClean\SimpleCommerce\Countries;
 use Statamic\CP\Column;
 use Statamic\Fieldtypes\Relationship;
 

--- a/src/Fieldtypes/CouponCodeFieldtype.php
+++ b/src/Fieldtypes/CouponCodeFieldtype.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
 use Illuminate\Support\Str;
 use Statamic\Fieldtypes\Text;

--- a/src/Fieldtypes/CouponFieldtype.php
+++ b/src/Fieldtypes/CouponFieldtype.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
 use Statamic\CP\Column;
 use Statamic\Fieldtypes\Relationship;
 

--- a/src/Fieldtypes/CouponSummaryFieldtype.php
+++ b/src/Fieldtypes/CouponSummaryFieldtype.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
-use DoubleThreeDigital\SimpleCommerce\Currency;
+use DuncanMcClean\SimpleCommerce\Currency;
 use Statamic\Facades\Site;
 use Statamic\Fields\Fieldtype;
 

--- a/src/Fieldtypes/CouponValueFieldtype.php
+++ b/src/Fieldtypes/CouponValueFieldtype.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
 use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;

--- a/src/Fieldtypes/GatewayFieldtype.php
+++ b/src/Fieldtypes/GatewayFieldtype.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
-use DoubleThreeDigital\SimpleCommerce\Actions\RefundAction;
-use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Support\Runway;
+use DuncanMcClean\SimpleCommerce\Actions\RefundAction;
+use DuncanMcClean\SimpleCommerce\Facades\Gateway;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Support\Runway;
 use Statamic\Facades\Action;
 use Statamic\Fields\Fieldtype;
 

--- a/src/Fieldtypes/MoneyFieldtype.php
+++ b/src/Fieldtypes/MoneyFieldtype.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
-use DoubleThreeDigital\SimpleCommerce\Currency;
+use DuncanMcClean\SimpleCommerce\Currency;
 use Statamic\Facades\Site;
 use Statamic\Fields\Fieldtype;
 

--- a/src/Fieldtypes/OrderStatusFieldtype.php
+++ b/src/Fieldtypes/OrderStatusFieldtype.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
 use Statamic\Fields\Fieldtype;
 
 class OrderStatusFieldtype extends Fieldtype

--- a/src/Fieldtypes/PaymentStatusFieldtype.php
+++ b/src/Fieldtypes/PaymentStatusFieldtype.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
 use Statamic\Fields\Fieldtype;
 
 class PaymentStatusFieldtype extends Fieldtype

--- a/src/Fieldtypes/ProductVariantFieldtype.php
+++ b/src/Fieldtypes/ProductVariantFieldtype.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Products\ProductType;
 use Statamic\Fields\Fieldtype;
 
 class ProductVariantFieldtype extends Fieldtype

--- a/src/Fieldtypes/ProductVariantsFieldtype.php
+++ b/src/Fieldtypes/ProductVariantsFieldtype.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
 use Illuminate\Support\Arr;
 use Statamic\Fields\Field;

--- a/src/Fieldtypes/RegionFieldtype.php
+++ b/src/Fieldtypes/RegionFieldtype.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
-use DoubleThreeDigital\SimpleCommerce\Countries;
-use DoubleThreeDigital\SimpleCommerce\Regions;
+use DuncanMcClean\SimpleCommerce\Countries;
+use DuncanMcClean\SimpleCommerce\Regions;
 use Statamic\CP\Column;
 use Statamic\Fieldtypes\Relationship;
 

--- a/src/Fieldtypes/ShippingMethodFieldtype.php
+++ b/src/Fieldtypes/ShippingMethodFieldtype.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Validation\Rule;
 use Statamic\CP\Column;
 use Statamic\Facades\Site;

--- a/src/Fieldtypes/StatusLogFieldtype.php
+++ b/src/Fieldtypes/StatusLogFieldtype.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
 use Carbon\Carbon;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\StatusLogEvent;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Orders\StatusLogEvent;
 use Illuminate\Support\Arr;
 use Statamic\Fields\Fieldtype;
 

--- a/src/Fieldtypes/TaxCategoryFieldtype.php
+++ b/src/Fieldtypes/TaxCategoryFieldtype.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory;
 use Statamic\CP\Column;
 use Statamic\Fieldtypes\Relationship;
 

--- a/src/Fieldtypes/Variables/LineItemTax.php
+++ b/src/Fieldtypes/Variables/LineItemTax.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes\Variables;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes\Variables;
 
-use DoubleThreeDigital\SimpleCommerce\Currency;
+use DuncanMcClean\SimpleCommerce\Currency;
 use Statamic\Facades\Site;
 
 class LineItemTax extends VariableFieldtype

--- a/src/Fieldtypes/Variables/VariableFieldtype.php
+++ b/src/Fieldtypes/Variables/VariableFieldtype.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Fieldtypes\Variables;
+namespace DuncanMcClean\SimpleCommerce\Fieldtypes\Variables;
 
 use Statamic\Fieldtypes\Hidden;
 

--- a/src/Gateways/BaseGateway.php
+++ b/src/Gateways/BaseGateway.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Gateways;
+namespace DuncanMcClean\SimpleCommerce\Gateways;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Events\PostCheckout;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayHasNotImplementedMethod;
-use DoubleThreeDigital\SimpleCommerce\Orders\Checkout\CheckoutPipeline;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Events\PostCheckout;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayHasNotImplementedMethod;
+use DuncanMcClean\SimpleCommerce\Orders\Checkout\CheckoutPipeline;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;

--- a/src/Gateways/Builtin/DummyGateway.php
+++ b/src/Gateways/Builtin/DummyGateway.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Gateways\Builtin;
+namespace DuncanMcClean\SimpleCommerce\Gateways\Builtin;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Gateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
 use Illuminate\Http\Request;
 
 class DummyGateway extends BaseGateway implements Gateway

--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Gateways\Builtin;
+namespace DuncanMcClean\SimpleCommerce\Gateways\Builtin;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Currency;
-use DoubleThreeDigital\SimpleCommerce\Events\OrderPaymentFailed;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderFacade;
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Gateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Currency;
+use DuncanMcClean\SimpleCommerce\Events\OrderPaymentFailed;
+use DuncanMcClean\SimpleCommerce\Exceptions\OrderNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Order as OrderFacade;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Mollie\Api\MollieApiClient;

--- a/src/Gateways/Builtin/PayPalGateway.php
+++ b/src/Gateways/Builtin/PayPalGateway.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Gateways\Builtin;
+namespace DuncanMcClean\SimpleCommerce\Gateways\Builtin;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Currency;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayCheckoutFailed;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\PayPalDetailsMissingOnOrderException;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderFacade;
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Response;
+use DuncanMcClean\SimpleCommerce\Contracts\Gateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Currency;
+use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayCheckoutFailed;
+use DuncanMcClean\SimpleCommerce\Exceptions\PayPalDetailsMissingOnOrderException;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Order as OrderFacade;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Gateways\Response;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response as HttpResponse;
 use PayPalCheckoutSdk\Core\PayPalHttpClient;

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Gateways\Builtin;
+namespace DuncanMcClean\SimpleCommerce\Gateways\Builtin;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
-use DoubleThreeDigital\SimpleCommerce\Currency;
-use DoubleThreeDigital\SimpleCommerce\Events\OrderPaymentFailed;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\RefundFailed;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\StripeSecretMissing;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Gateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Currency;
+use DuncanMcClean\SimpleCommerce\Events\OrderPaymentFailed;
+use DuncanMcClean\SimpleCommerce\Exceptions\RefundFailed;
+use DuncanMcClean\SimpleCommerce\Exceptions\StripeSecretMissing;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Str;

--- a/src/Gateways/Manager.php
+++ b/src/Gateways/Manager.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Gateways;
+namespace DuncanMcClean\SimpleCommerce\Gateways;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\GatewayManager as Contract;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayCallbackMethodDoesNotExist;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayCheckoutFailed;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayDoesNotExist;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayNotProvided;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\GatewayManager as Contract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayCallbackMethodDoesNotExist;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayCheckoutFailed;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayDoesNotExist;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayNotProvided;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 

--- a/src/Http/Controllers/BaseActionController.php
+++ b/src/Http/Controllers/BaseActionController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Statamic\Http\Controllers\Controller;

--- a/src/Http/Controllers/CP/Coupons/CouponActionController.php
+++ b/src/Http/Controllers/CP/Coupons/CouponActionController.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP\Coupons;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers\CP\Coupons;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
 use Illuminate\Http\Request;
 use Statamic\Http\Controllers\CP\ActionController;
 

--- a/src/Http/Controllers/CP/Coupons/CouponController.php
+++ b/src/Http/Controllers/CP/Coupons/CouponController.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP\Coupons;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers\CP\Coupons;
 
-use DoubleThreeDigital\SimpleCommerce\Coupons\CouponBlueprint;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\Coupon\CreateRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\Coupon\EditRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\Coupon\IndexRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\Coupon\StoreRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\Coupon\UpdateRequest;
+use DuncanMcClean\SimpleCommerce\Coupons\CouponBlueprint;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\Coupon\CreateRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\Coupon\EditRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\Coupon\IndexRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\Coupon\StoreRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\Coupon\UpdateRequest;
 use Statamic\Facades\Scope;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;

--- a/src/Http/Controllers/CP/Coupons/CouponListingController.php
+++ b/src/Http/Controllers/CP/Coupons/CouponListingController.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP\Coupons;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers\CP\Coupons;
 
-use DoubleThreeDigital\SimpleCommerce\Coupons\CouponBlueprint;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Http\Resources\CP\Coupons\Coupons;
+use DuncanMcClean\SimpleCommerce\Coupons\CouponBlueprint;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Http\Resources\CP\Coupons\Coupons;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;

--- a/src/Http/Controllers/CP/RegionController.php
+++ b/src/Http/Controllers/CP/RegionController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers\CP;
 
-use DoubleThreeDigital\SimpleCommerce\Countries;
-use DoubleThreeDigital\SimpleCommerce\Regions;
+use DuncanMcClean\SimpleCommerce\Countries;
+use DuncanMcClean\SimpleCommerce\Regions;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 

--- a/src/Http/Controllers/CP/ResendNotificationsController.php
+++ b/src/Http/Controllers/CP/ResendNotificationsController.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers\CP;
 
-use DoubleThreeDigital\SimpleCommerce\Events\OrderStatusUpdated;
-use DoubleThreeDigital\SimpleCommerce\Events\PaymentStatusUpdated;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Listeners\SendConfiguredNotifications;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Events\OrderStatusUpdated;
+use DuncanMcClean\SimpleCommerce\Events\PaymentStatusUpdated;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Listeners\SendConfiguredNotifications;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
 use Illuminate\Http\Request;
 
 class ResendNotificationsController

--- a/src/Http/Controllers/CP/StatusLogController.php
+++ b/src/Http/Controllers/CP/StatusLogController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers\CP;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\StatusLogEvent;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\StatusLogEvent;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Statamic\Facades\User;

--- a/src/Http/Controllers/CP/TaxCategoryController.php
+++ b/src/Http/Controllers/CP/TaxCategoryController.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers\CP;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxCategory\CreateRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxCategory\EditRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxCategory\IndexRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxCategory\StoreRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxCategory\UpdateRequest;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxCategory\CreateRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxCategory\EditRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxCategory\IndexRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxCategory\StoreRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxCategory\UpdateRequest;
 use Illuminate\Http\Request;
 use Statamic\Facades\Stache;
 

--- a/src/Http/Controllers/CP/TaxRateController.php
+++ b/src/Http/Controllers/CP/TaxRateController.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers\CP;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxRate\CreateRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxRate\DeleteRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxRate\EditRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxRate\IndexRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxRate\StoreRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxRate\UpdateRequest;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Facades\TaxRate;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxRate\CreateRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxRate\DeleteRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxRate\EditRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxRate\IndexRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxRate\StoreRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxRate\UpdateRequest;
 use Statamic\Facades\Stache;
 
 class TaxRateController

--- a/src/Http/Controllers/CP/TaxZoneController.php
+++ b/src/Http/Controllers/CP/TaxZoneController.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers\CP;
 
-use DoubleThreeDigital\SimpleCommerce\Countries;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxZone\CreateRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxZone\DeleteRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxZone\EditRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxZone\IndexRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxZone\StoreRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxZone\UpdateRequest;
+use DuncanMcClean\SimpleCommerce\Countries;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxZone\CreateRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxZone\DeleteRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxZone\EditRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxZone\IndexRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxZone\StoreRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxZone\UpdateRequest;
 use Statamic\Facades\Stache;
 
 class TaxZoneController

--- a/src/Http/Controllers/CP/VariantFieldtypeController.php
+++ b/src/Http/Controllers/CP/VariantFieldtypeController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers\CP;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers\CP;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Rules\ProductExists;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Rules\ProductExists;
 use Illuminate\Http\Request;
 
 class VariantFieldtypeController

--- a/src/Http/Controllers/CartController.php
+++ b/src/Http/Controllers/CartController.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers;
 
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\Concerns\HandlesCustomerInformation;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\Cart\DestroyRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\Cart\IndexRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\Cart\UpdateRequest;
-use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\Concerns\HandlesCustomerInformation;
+use DuncanMcClean\SimpleCommerce\Http\Requests\Cart\DestroyRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\Cart\IndexRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\Cart\UpdateRequest;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use Illuminate\Support\Str;
 use Statamic\Facades\Site;
 use Statamic\Sites\Site as SitesSite;

--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\Concerns\HandlesCustomerInformation;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CartItem\DestroyRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CartItem\StoreRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CartItem\UpdateRequest;
-use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\Concerns\HandlesCustomerInformation;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CartItem\DestroyRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CartItem\StoreRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CartItem\UpdateRequest;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Products\ProductType;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Statamic\Facades\Site;
@@ -47,7 +47,7 @@ class CartItemController extends BaseActionController
 
         // If this product requires another one, ensure the customer has already purchased it...
         if ($product->has('prerequisite_product')) {
-            /** @var \DoubleThreeDigital\SimpleCommerce\Contracts\Customer $customer */
+            /** @var \DuncanMcClean\SimpleCommerce\Contracts\Customer $customer */
             $customer = $cart->customer();
 
             if (! $customer) {

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers;
 
-use DoubleThreeDigital\SimpleCommerce\Events\PostCheckout;
-use DoubleThreeDigital\SimpleCommerce\Events\PreCheckout;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayNotProvided;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\PreventCheckout;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Http\Controllers\Concerns\HandlesCustomerInformation;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\AcceptsFormRequests;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\CheckoutRequest;
-use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
-use DoubleThreeDigital\SimpleCommerce\Orders\Checkout\CheckoutPipeline;
-use DoubleThreeDigital\SimpleCommerce\Orders\Checkout\CheckoutValidationPipeline;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Events\PostCheckout;
+use DuncanMcClean\SimpleCommerce\Events\PreCheckout;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayNotProvided;
+use DuncanMcClean\SimpleCommerce\Exceptions\PreventCheckout;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Gateway;
+use DuncanMcClean\SimpleCommerce\Http\Controllers\Concerns\HandlesCustomerInformation;
+use DuncanMcClean\SimpleCommerce\Http\Requests\AcceptsFormRequests;
+use DuncanMcClean\SimpleCommerce\Http\Requests\CheckoutRequest;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DuncanMcClean\SimpleCommerce\Orders\Checkout\CheckoutPipeline;
+use DuncanMcClean\SimpleCommerce\Orders\Checkout\CheckoutValidationPipeline;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Statamic\Facades\Site;

--- a/src/Http/Controllers/Concerns/HandlesCustomerInformation.php
+++ b/src/Http/Controllers/Concerns/HandlesCustomerInformation.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers\Concerns;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers\Concerns;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
@@ -17,7 +17,7 @@ trait HandlesCustomerInformation
         // When the customer driver is set to users, a user is logged in, and the cart doesn't have a customer,
         // we'll set the customer to the logged in user.
         if (
-            $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository::class)
+            $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class)
             && Auth::check()
             && ! $cart->customer()
         ) {

--- a/src/Http/Controllers/CouponController.php
+++ b/src/Http/Controllers/CouponController.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers;
 
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\Coupon\DestroyRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\Coupon\StoreRequest;
-use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DuncanMcClean\SimpleCommerce\Http\Requests\Coupon\DestroyRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\Coupon\StoreRequest;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 
 class CouponController extends BaseActionController
 {

--- a/src/Http/Controllers/CustomerController.php
+++ b/src/Http/Controllers/CustomerController.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\Customer\IndexRequest;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\Customer\UpdateRequest;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Http\Requests\Customer\IndexRequest;
+use DuncanMcClean\SimpleCommerce\Http\Requests\Customer\UpdateRequest;
 use Illuminate\Support\Arr;
 
 class CustomerController extends BaseActionController

--- a/src/Http/Controllers/DigitalProducts/DownloadController.php
+++ b/src/Http/Controllers/DigitalProducts/DownloadController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers\DigitalProducts;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers\DigitalProducts;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Products\ProductType;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Statamic\Assets\Asset;

--- a/src/Http/Controllers/DigitalProducts/VerificationController.php
+++ b/src/Http/Controllers/DigitalProducts/VerificationController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers\DigitalProducts;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers\DigitalProducts;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Statamic\Facades\Entry;

--- a/src/Http/Controllers/GatewayCallbackController.php
+++ b/src/Http/Controllers/GatewayCallbackController.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers;
 
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayCallbackMethodDoesNotExist;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayDoesNotExist;
-use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayCallbackMethodDoesNotExist;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayDoesNotExist;
+use DuncanMcClean\SimpleCommerce\Facades\Gateway;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Http\Request;
 
 class GatewayCallbackController extends BaseActionController

--- a/src/Http/Controllers/GatewayWebhookController.php
+++ b/src/Http/Controllers/GatewayWebhookController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Controllers;
+namespace DuncanMcClean\SimpleCommerce\Http\Controllers;
 
-use DoubleThreeDigital\SimpleCommerce\Events\GatewayWebhookReceived;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayDoesNotExist;
-use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Events\GatewayWebhookReceived;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayDoesNotExist;
+use DuncanMcClean\SimpleCommerce\Facades\Gateway;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Http\Request;
 
 class GatewayWebhookController extends BaseActionController

--- a/src/Http/Middleware/EnsureFormParametersArriveIntact.php
+++ b/src/Http/Middleware/EnsureFormParametersArriveIntact.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Middleware;
+namespace DuncanMcClean\SimpleCommerce\Http\Middleware;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\InvalidFormParametersException;
+use DuncanMcClean\SimpleCommerce\Exceptions\InvalidFormParametersException;
 use Illuminate\Contracts\Encryption\DecryptException;
 
 class EnsureFormParametersArriveIntact

--- a/src/Http/Requests/AcceptsFormRequests.php
+++ b/src/Http/Requests/AcceptsFormRequests.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Request;

--- a/src/Http/Requests/CP/Coupon/CreateRequest.php
+++ b/src/Http/Requests/CP/Coupon/CreateRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\Coupon;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\Coupon;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/Coupon/EditRequest.php
+++ b/src/Http/Requests/CP/Coupon/EditRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\Coupon;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\Coupon;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/Coupon/IndexRequest.php
+++ b/src/Http/Requests/CP/Coupon/IndexRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\Coupon;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\Coupon;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/Coupon/StoreRequest.php
+++ b/src/Http/Requests/CP/Coupon/StoreRequest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\Coupon;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\Coupon;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 

--- a/src/Http/Requests/CP/Coupon/UpdateRequest.php
+++ b/src/Http/Requests/CP/Coupon/UpdateRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\Coupon;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\Coupon;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;

--- a/src/Http/Requests/CP/TaxCategory/CreateRequest.php
+++ b/src/Http/Requests/CP/TaxCategory/CreateRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxCategory;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxCategory;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxCategory/DeleteRequest.php
+++ b/src/Http/Requests/CP/TaxCategory/DeleteRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxCategory;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxCategory;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxCategory/EditRequest.php
+++ b/src/Http/Requests/CP/TaxCategory/EditRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxCategory;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxCategory;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxCategory/IndexRequest.php
+++ b/src/Http/Requests/CP/TaxCategory/IndexRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxCategory;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxCategory;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxCategory/StoreRequest.php
+++ b/src/Http/Requests/CP/TaxCategory/StoreRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxCategory;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxCategory;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxCategory/UpdateRequest.php
+++ b/src/Http/Requests/CP/TaxCategory/UpdateRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxCategory;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxCategory;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxRate/CreateRequest.php
+++ b/src/Http/Requests/CP/TaxRate/CreateRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxRate;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxRate;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxRate/DeleteRequest.php
+++ b/src/Http/Requests/CP/TaxRate/DeleteRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxRate;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxRate;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxRate/EditRequest.php
+++ b/src/Http/Requests/CP/TaxRate/EditRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxRate;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxRate;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxRate/IndexRequest.php
+++ b/src/Http/Requests/CP/TaxRate/IndexRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxRate;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxRate;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxRate/StoreRequest.php
+++ b/src/Http/Requests/CP/TaxRate/StoreRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxRate;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxRate;
 
-use DoubleThreeDigital\SimpleCommerce\Rules\TaxCategoryExists;
-use DoubleThreeDigital\SimpleCommerce\Rules\TaxZoneExists;
+use DuncanMcClean\SimpleCommerce\Rules\TaxCategoryExists;
+use DuncanMcClean\SimpleCommerce\Rules\TaxZoneExists;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreRequest extends FormRequest

--- a/src/Http/Requests/CP/TaxRate/UpdateRequest.php
+++ b/src/Http/Requests/CP/TaxRate/UpdateRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxRate;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxRate;
 
-use DoubleThreeDigital\SimpleCommerce\Rules\TaxCategoryExists;
-use DoubleThreeDigital\SimpleCommerce\Rules\TaxZoneExists;
+use DuncanMcClean\SimpleCommerce\Rules\TaxCategoryExists;
+use DuncanMcClean\SimpleCommerce\Rules\TaxZoneExists;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateRequest extends FormRequest

--- a/src/Http/Requests/CP/TaxZone/CreateRequest.php
+++ b/src/Http/Requests/CP/TaxZone/CreateRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxZone;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxZone;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxZone/DeleteRequest.php
+++ b/src/Http/Requests/CP/TaxZone/DeleteRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxZone;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxZone;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxZone/EditRequest.php
+++ b/src/Http/Requests/CP/TaxZone/EditRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxZone;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxZone;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxZone/IndexRequest.php
+++ b/src/Http/Requests/CP/TaxZone/IndexRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxZone;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxZone;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CP/TaxZone/StoreRequest.php
+++ b/src/Http/Requests/CP/TaxZone/StoreRequest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxZone;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxZone;
 
-use DoubleThreeDigital\SimpleCommerce\Countries;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
-use DoubleThreeDigital\SimpleCommerce\Regions;
-use DoubleThreeDigital\SimpleCommerce\Rules\CountryExists;
-use DoubleThreeDigital\SimpleCommerce\Rules\RegionExists;
+use DuncanMcClean\SimpleCommerce\Countries;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\Regions;
+use DuncanMcClean\SimpleCommerce\Rules\CountryExists;
+use DuncanMcClean\SimpleCommerce\Rules\RegionExists;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreRequest extends FormRequest

--- a/src/Http/Requests/CP/TaxZone/UpdateRequest.php
+++ b/src/Http/Requests/CP/TaxZone/UpdateRequest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CP\TaxZone;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CP\TaxZone;
 
-use DoubleThreeDigital\SimpleCommerce\Countries;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
-use DoubleThreeDigital\SimpleCommerce\Regions;
-use DoubleThreeDigital\SimpleCommerce\Rules\CountryExists;
-use DoubleThreeDigital\SimpleCommerce\Rules\RegionExists;
+use DuncanMcClean\SimpleCommerce\Countries;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\Regions;
+use DuncanMcClean\SimpleCommerce\Rules\CountryExists;
+use DuncanMcClean\SimpleCommerce\Rules\RegionExists;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateRequest extends FormRequest

--- a/src/Http/Requests/Cart/DestroyRequest.php
+++ b/src/Http/Requests/Cart/DestroyRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\Cart;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\Cart;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/Cart/IndexRequest.php
+++ b/src/Http/Requests/Cart/IndexRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\Cart;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\Cart;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/Cart/UpdateRequest.php
+++ b/src/Http/Requests/Cart/UpdateRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\Cart;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\Cart;
 
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\AcceptsFormRequests;
-use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DuncanMcClean\SimpleCommerce\Http\Requests\AcceptsFormRequests;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateRequest extends FormRequest

--- a/src/Http/Requests/CartItem/DestroyRequest.php
+++ b/src/Http/Requests/CartItem/DestroyRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CartItem;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CartItem;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/CartItem/StoreRequest.php
+++ b/src/Http/Requests/CartItem/StoreRequest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CartItem;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CartItem;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\AcceptsFormRequests;
-use DoubleThreeDigital\SimpleCommerce\Orders\Order as EntryOrder;
-use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
-use DoubleThreeDigital\SimpleCommerce\Rules\ProductExists;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Http\Requests\AcceptsFormRequests;
+use DuncanMcClean\SimpleCommerce\Orders\Order as EntryOrder;
+use DuncanMcClean\SimpleCommerce\Products\ProductType;
+use DuncanMcClean\SimpleCommerce\Rules\ProductExists;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 

--- a/src/Http/Requests/CartItem/UpdateRequest.php
+++ b/src/Http/Requests/CartItem/UpdateRequest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\CartItem;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\CartItem;
 
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\AcceptsFormRequests;
+use DuncanMcClean\SimpleCommerce\Http\Requests\AcceptsFormRequests;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateRequest extends FormRequest

--- a/src/Http/Requests/CheckoutRequest.php
+++ b/src/Http/Requests/CheckoutRequest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
-use DoubleThreeDigital\SimpleCommerce\Rules\ValidCoupon;
-use DoubleThreeDigital\SimpleCommerce\Rules\ValidGateway;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Facades\Gateway;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DuncanMcClean\SimpleCommerce\Rules\ValidCoupon;
+use DuncanMcClean\SimpleCommerce\Rules\ValidGateway;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Foundation\Http\FormRequest;
 
 class CheckoutRequest extends FormRequest

--- a/src/Http/Requests/Coupon/DestroyRequest.php
+++ b/src/Http/Requests/Coupon/DestroyRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\Coupon;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\Coupon;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/Coupon/StoreRequest.php
+++ b/src/Http/Requests/Coupon/StoreRequest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\Coupon;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\Coupon;
 
-use DoubleThreeDigital\SimpleCommerce\Rules\CouponExists;
+use DuncanMcClean\SimpleCommerce\Rules\CouponExists;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreRequest extends FormRequest

--- a/src/Http/Requests/Customer/IndexRequest.php
+++ b/src/Http/Requests/Customer/IndexRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\Customer;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\Customer;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Requests/Customer/UpdateRequest.php
+++ b/src/Http/Requests/Customer/UpdateRequest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests\Customer;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests\Customer;
 
-use DoubleThreeDigital\SimpleCommerce\Http\Requests\AcceptsFormRequests;
+use DuncanMcClean\SimpleCommerce\Http\Requests\AcceptsFormRequests;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateRequest extends FormRequest

--- a/src/Http/Requests/ReceiptShowRequest.php
+++ b/src/Http/Requests/ReceiptShowRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Requests;
+namespace DuncanMcClean\SimpleCommerce\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/src/Http/Resources/BaseResource.php
+++ b/src/Http/Resources/BaseResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Resources;
+namespace DuncanMcClean\SimpleCommerce\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 

--- a/src/Http/Resources/CP/Coupons/Coupons.php
+++ b/src/Http/Resources/CP/Coupons/Coupons.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Resources\CP\Coupons;
+namespace DuncanMcClean\SimpleCommerce\Http\Resources\CP\Coupons;
 
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Statamic\Http\Resources\CP\Concerns\HasRequestedColumns;

--- a/src/Http/Resources/CP/Coupons/ListedCoupon.php
+++ b/src/Http/Resources/CP/Coupons/ListedCoupon.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Http\Resources\CP\Coupons;
+namespace DuncanMcClean\SimpleCommerce\Http\Resources\CP\Coupons;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 use Statamic\Facades\Action;

--- a/src/Listeners/AddHiddenFields.php
+++ b/src/Listeners/AddHiddenFields.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Listeners;
+namespace DuncanMcClean\SimpleCommerce\Listeners;
 
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Statamic\Events\EntryBlueprintFound;
 
 class AddHiddenFields

--- a/src/Listeners/EnforceEntryBlueprintFields.php
+++ b/src/Listeners/EnforceEntryBlueprintFields.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Listeners;
+namespace DuncanMcClean\SimpleCommerce\Listeners;
 
-use DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository;
+use DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Statamic\Events\EntryBlueprintFound;
 use Statamic\Facades\AssetContainer;
 use Statamic\Fields\Blueprint;

--- a/src/Listeners/EnforceUserBlueprintFields.php
+++ b/src/Listeners/EnforceUserBlueprintFields.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Listeners;
+namespace DuncanMcClean\SimpleCommerce\Listeners;
 
-use DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository;
+use DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Statamic\Events\UserBlueprintFound;
 use Statamic\Fields\Blueprint;
 

--- a/src/Listeners/SendConfiguredNotifications.php
+++ b/src/Listeners/SendConfiguredNotifications.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Listeners;
+namespace DuncanMcClean\SimpleCommerce\Listeners;
 
-use DoubleThreeDigital\SimpleCommerce\Events\OrderStatusUpdated;
-use DoubleThreeDigital\SimpleCommerce\Events\PaymentStatusUpdated;
+use DuncanMcClean\SimpleCommerce\Events\OrderStatusUpdated;
+use DuncanMcClean\SimpleCommerce\Events\PaymentStatusUpdated;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Notification;

--- a/src/Listeners/TidyTemporaryGatewayData.php
+++ b/src/Listeners/TidyTemporaryGatewayData.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Listeners;
+namespace DuncanMcClean\SimpleCommerce\Listeners;
 
-use DoubleThreeDigital\SimpleCommerce\Events\PostCheckout;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Events\PostCheckout;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 
 class TidyTemporaryGatewayData
 {

--- a/src/Modifiers/Currency.php
+++ b/src/Modifiers/Currency.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Modifiers;
+namespace DuncanMcClean\SimpleCommerce\Modifiers;
 
-use DoubleThreeDigital\SimpleCommerce\Currency as CurrencyFacade;
+use DuncanMcClean\SimpleCommerce\Currency as CurrencyFacade;
 use Statamic\Facades\Site;
 use Statamic\Modifiers\Modifier;
 

--- a/src/Notifications/BackOfficeOrderPaid.php
+++ b/src/Notifications/BackOfficeOrderPaid.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Notifications;
+namespace DuncanMcClean\SimpleCommerce\Notifications;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;

--- a/src/Notifications/CustomerOrderPaid.php
+++ b/src/Notifications/CustomerOrderPaid.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Notifications;
+namespace DuncanMcClean\SimpleCommerce\Notifications;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;

--- a/src/Notifications/CustomerOrderShipped.php
+++ b/src/Notifications/CustomerOrderShipped.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Notifications;
+namespace DuncanMcClean\SimpleCommerce\Notifications;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;

--- a/src/Notifications/DigitalDownloadsNotification.php
+++ b/src/Notifications/DigitalDownloadsNotification.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Notifications;
+namespace DuncanMcClean\SimpleCommerce\Notifications;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;

--- a/src/Orders/Address.php
+++ b/src/Orders/Address.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
-use DoubleThreeDigital\SimpleCommerce\Countries;
-use DoubleThreeDigital\SimpleCommerce\Regions;
+use DuncanMcClean\SimpleCommerce\Countries;
+use DuncanMcClean\SimpleCommerce\Regions;
 use Illuminate\Support\Arr;
 
 class Address

--- a/src/Orders/Calculator/CalculateGrandTotal.php
+++ b/src/Orders/Calculator/CalculateGrandTotal.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
+namespace DuncanMcClean\SimpleCommerce\Orders\Calculator;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 
 class CalculateGrandTotal
 {

--- a/src/Orders/Calculator/CalculateItemsTotal.php
+++ b/src/Orders/Calculator/CalculateItemsTotal.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
+namespace DuncanMcClean\SimpleCommerce\Orders\Calculator;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 
 class CalculateItemsTotal
 {

--- a/src/Orders/Calculator/Calculator.php
+++ b/src/Orders/Calculator/Calculator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
+namespace DuncanMcClean\SimpleCommerce\Orders\Calculator;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Calculator as Contract;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Calculator as Contract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 use Illuminate\Support\Facades\Pipeline;
 
 class Calculator implements Contract

--- a/src/Orders/Calculator/CouponCalculator.php
+++ b/src/Orders/Calculator/CouponCalculator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
+namespace DuncanMcClean\SimpleCommerce\Orders\Calculator;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Coupons\CouponType;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Coupons\CouponType;
 
 class CouponCalculator
 {

--- a/src/Orders/Calculator/LineItemCalculator.php
+++ b/src/Orders/Calculator/LineItemCalculator.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
+namespace DuncanMcClean\SimpleCommerce\Orders\Calculator;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
-use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Orders\LineItem;
+use DuncanMcClean\SimpleCommerce\Products\ProductType;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 
 class LineItemCalculator
 {

--- a/src/Orders/Calculator/LineItemTaxCalculator.php
+++ b/src/Orders/Calculator/LineItemTaxCalculator.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
+namespace DuncanMcClean\SimpleCommerce\Orders\Calculator;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Orders\LineItem;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 
 class LineItemTaxCalculator
 {

--- a/src/Orders/Calculator/ResetTotals.php
+++ b/src/Orders/Calculator/ResetTotals.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
+namespace DuncanMcClean\SimpleCommerce\Orders\Calculator;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Orders\LineItem;
 
 class ResetTotals
 {

--- a/src/Orders/Calculator/ShippingCalculator.php
+++ b/src/Orders/Calculator/ShippingCalculator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
+namespace DuncanMcClean\SimpleCommerce\Orders\Calculator;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Shipping;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Shipping;
 use Statamic\Facades\Site;
 
 class ShippingCalculator

--- a/src/Orders/Calculator/ShippingTaxCalculator.php
+++ b/src/Orders/Calculator/ShippingTaxCalculator.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Calculator;
+namespace DuncanMcClean\SimpleCommerce\Orders\Calculator;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Shipping;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Shipping;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Statamic\Facades\Site;
 
 class ShippingTaxCalculator

--- a/src/Orders/Cart/Drivers/CartDriver.php
+++ b/src/Orders/Cart/Drivers/CartDriver.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers;
+namespace DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\CartDriver as CartDriverContract;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
+use DuncanMcClean\SimpleCommerce\Contracts\CartDriver as CartDriverContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Exceptions\OrderNotFound;
 
 trait CartDriver
 {

--- a/src/Orders/Cart/Drivers/CookieDriver.php
+++ b/src/Orders/Cart/Drivers/CookieDriver.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers;
+namespace DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\CartDriver;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderAPI;
+use DuncanMcClean\SimpleCommerce\Contracts\CartDriver;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Exceptions\OrderNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Order as OrderAPI;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Str;

--- a/src/Orders/Cart/Drivers/PostCheckoutDriver.php
+++ b/src/Orders/Cart/Drivers/PostCheckoutDriver.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers;
+namespace DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers;
 
 class PostCheckoutDriver extends SessionDriver
 {

--- a/src/Orders/Cart/Drivers/SessionDriver.php
+++ b/src/Orders/Cart/Drivers/SessionDriver.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers;
+namespace DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\CartDriver;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderAPI;
+use DuncanMcClean\SimpleCommerce\Contracts\CartDriver;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Order as OrderAPI;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;

--- a/src/Orders/Checkout/CheckoutPipeline.php
+++ b/src/Orders/Checkout/CheckoutPipeline.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Checkout;
+namespace DuncanMcClean\SimpleCommerce\Orders\Checkout;
 
 use Illuminate\Pipeline\Pipeline;
 

--- a/src/Orders/Checkout/CheckoutValidationPipeline.php
+++ b/src/Orders/Checkout/CheckoutValidationPipeline.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Checkout;
+namespace DuncanMcClean\SimpleCommerce\Orders\Checkout;
 
 use Illuminate\Pipeline\Pipeline;
 

--- a/src/Orders/Checkout/HandleDigitalProducts.php
+++ b/src/Orders/Checkout/HandleDigitalProducts.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Checkout;
+namespace DuncanMcClean\SimpleCommerce\Orders\Checkout;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Events\DigitalDownloadReady;
-use DoubleThreeDigital\SimpleCommerce\Facades\LicenseKey;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Events\DigitalDownloadReady;
+use DuncanMcClean\SimpleCommerce\Facades\LicenseKey;
 use Illuminate\Support\Facades\URL;
 
 class HandleDigitalProducts

--- a/src/Orders/Checkout/RedeemCoupon.php
+++ b/src/Orders/Checkout/RedeemCoupon.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Checkout;
+namespace DuncanMcClean\SimpleCommerce\Orders\Checkout;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 
 class RedeemCoupon
 {

--- a/src/Orders/Checkout/StoreCustomerOrders.php
+++ b/src/Orders/Checkout/StoreCustomerOrders.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Checkout;
+namespace DuncanMcClean\SimpleCommerce\Orders\Checkout;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 
 class StoreCustomerOrders
 {

--- a/src/Orders/Checkout/UpdateProductStock.php
+++ b/src/Orders/Checkout/UpdateProductStock.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Checkout;
+namespace DuncanMcClean\SimpleCommerce\Orders\Checkout;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Events\StockRunningLow;
-use DoubleThreeDigital\SimpleCommerce\Events\StockRunOut;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
-use DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository;
-use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Events\StockRunningLow;
+use DuncanMcClean\SimpleCommerce\Events\StockRunOut;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\LineItem;
+use DuncanMcClean\SimpleCommerce\Products\EntryProductRepository;
+use DuncanMcClean\SimpleCommerce\Products\ProductType;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 
 class UpdateProductStock
 {

--- a/src/Orders/Checkout/ValidateProductStock.php
+++ b/src/Orders/Checkout/ValidateProductStock.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders\Checkout;
+namespace DuncanMcClean\SimpleCommerce\Orders\Checkout;
 
 use Closure;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CheckoutProductHasNoStockException;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
-use DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository;
-use DoubleThreeDigital\SimpleCommerce\Products\ProductType;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Exceptions\CheckoutProductHasNoStockException;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\LineItem;
+use DuncanMcClean\SimpleCommerce\Products\EntryProductRepository;
+use DuncanMcClean\SimpleCommerce\Products\ProductType;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 
 class ValidateProductStock
 {

--- a/src/Orders/EloquentOrderRepository.php
+++ b/src/Orders/EloquentOrderRepository.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
 use Doctrine\DBAL\Schema\Column;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Coupon as CouponContract;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Customer as CustomerContract;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\OrderRepository as RepositoryContract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Coupon as CouponContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Customer as CustomerContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\OrderRepository as RepositoryContract;
+use DuncanMcClean\SimpleCommerce\Exceptions\OrderNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Facades\Schema;
 
 class EloquentOrderRepository implements RepositoryContract

--- a/src/Orders/EloquentQueryBuilder.php
+++ b/src/Orders/EloquentQueryBuilder.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
 use Carbon\Carbon;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
 use Statamic\Query\EloquentQueryBuilder as QueryEloquentQueryBuilder;
 
 class EloquentQueryBuilder extends QueryEloquentQueryBuilder

--- a/src/Orders/EntryOrderRepository.php
+++ b/src/Orders/EntryOrderRepository.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Coupon as CouponContract;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Customer as CustomerContract;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\OrderRepository as RepositoryContract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Coupon as CouponContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Customer as CustomerContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\OrderRepository as RepositoryContract;
+use DuncanMcClean\SimpleCommerce\Exceptions\OrderNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Statamic\Facades\Entry;

--- a/src/Orders/EntryQueryBuilder.php
+++ b/src/Orders/EntryQueryBuilder.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
 use Carbon\Carbon;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
 use Statamic\Stache\Query\EntryQueryBuilder as QueryEntryQueryBuilder;
 
 class EntryQueryBuilder extends QueryEntryQueryBuilder

--- a/src/Orders/GatewayData.php
+++ b/src/Orders/GatewayData.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Manager;
+use DuncanMcClean\SimpleCommerce\Facades\Gateway;
+use DuncanMcClean\SimpleCommerce\Gateways\Manager;
 use Illuminate\Support\Collection;
 
 class GatewayData

--- a/src/Orders/HasLineItems.php
+++ b/src/Orders/HasLineItems.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
 use Illuminate\Support\Collection;
 

--- a/src/Orders/LineItem.php
+++ b/src/Orders/LineItem.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Product;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\ProductNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product as ProductFacade;
+use DuncanMcClean\SimpleCommerce\Contracts\Product;
+use DuncanMcClean\SimpleCommerce\Exceptions\ProductNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Product as ProductFacade;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class LineItem

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Coupon as CouponContract;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Customer as CustomerContract;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as Contract;
-use DoubleThreeDigital\SimpleCommerce\Data\HasData;
-use DoubleThreeDigital\SimpleCommerce\Events\CouponRedeemed;
-use DoubleThreeDigital\SimpleCommerce\Events\OrderSaved;
-use DoubleThreeDigital\SimpleCommerce\Events\OrderStatusUpdated;
-use DoubleThreeDigital\SimpleCommerce\Events\PaymentStatusUpdated;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderFacade;
-use DoubleThreeDigital\SimpleCommerce\Http\Resources\BaseResource;
-use DoubleThreeDigital\SimpleCommerce\Orders\Calculator\Calculator;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Coupon as CouponContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Customer as CustomerContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as Contract;
+use DuncanMcClean\SimpleCommerce\Data\HasData;
+use DuncanMcClean\SimpleCommerce\Events\CouponRedeemed;
+use DuncanMcClean\SimpleCommerce\Events\OrderSaved;
+use DuncanMcClean\SimpleCommerce\Events\OrderStatusUpdated;
+use DuncanMcClean\SimpleCommerce\Events\PaymentStatusUpdated;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Order as OrderFacade;
+use DuncanMcClean\SimpleCommerce\Http\Resources\BaseResource;
+use DuncanMcClean\SimpleCommerce\Orders\Calculator\Calculator;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;

--- a/src/Orders/OrderModel.php
+++ b/src/Orders/OrderModel.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
-use DoubleThreeDigital\SimpleCommerce\Customers\CustomerModel;
+use DuncanMcClean\SimpleCommerce\Customers\CustomerModel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;

--- a/src/Orders/OrderStatus.php
+++ b/src/Orders/OrderStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
 enum OrderStatus: string
 {

--- a/src/Orders/PaymentStatus.php
+++ b/src/Orders/PaymentStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
 enum PaymentStatus: string
 {

--- a/src/Orders/StatusLogEvent.php
+++ b/src/Orders/StatusLogEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Carbon;

--- a/src/Orders/StatusLogModel.php
+++ b/src/Orders/StatusLogModel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Orders;
+namespace DuncanMcClean\SimpleCommerce\Orders;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;

--- a/src/Products/DigitalProducts/LicenseKeyRepository.php
+++ b/src/Products/DigitalProducts/LicenseKeyRepository.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Products\DigitalProducts;
+namespace DuncanMcClean\SimpleCommerce\Products\DigitalProducts;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\LicenseKeyRepository as Contract;
+use DuncanMcClean\SimpleCommerce\Contracts\LicenseKeyRepository as Contract;
 
 class LicenseKeyRepository implements Contract
 {

--- a/src/Products/EntryProductRepository.php
+++ b/src/Products/EntryProductRepository.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Products;
+namespace DuncanMcClean\SimpleCommerce\Products;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Product;
-use DoubleThreeDigital\SimpleCommerce\Contracts\ProductRepository as RepositoryContract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\ProductNotFound;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Product;
+use DuncanMcClean\SimpleCommerce\Contracts\ProductRepository as RepositoryContract;
+use DuncanMcClean\SimpleCommerce\Exceptions\ProductNotFound;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Arr;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Stache;

--- a/src/Products/EntryQueryBuilder.php
+++ b/src/Products/EntryQueryBuilder.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Products;
+namespace DuncanMcClean\SimpleCommerce\Products;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
 use Statamic\Stache\Query\EntryQueryBuilder as QueryEntryQueryBuilder;
 
 class EntryQueryBuilder extends QueryEntryQueryBuilder

--- a/src/Products/Product.php
+++ b/src/Products/Product.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Products;
+namespace DuncanMcClean\SimpleCommerce\Products;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Product as Contract;
-use DoubleThreeDigital\SimpleCommerce\Data\HasData;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product as ProductFacade;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory as TaxCategoryFacade;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Contracts\Product as Contract;
+use DuncanMcClean\SimpleCommerce\Data\HasData;
+use DuncanMcClean\SimpleCommerce\Facades\Product as ProductFacade;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory as TaxCategoryFacade;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\TaxCategory;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Statamic\Http\Resources\API\EntryResource;

--- a/src/Products/ProductType.php
+++ b/src/Products/ProductType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Products;
+namespace DuncanMcClean\SimpleCommerce\Products;
 
 enum ProductType: string
 {

--- a/src/Products/ProductVariant.php
+++ b/src/Products/ProductVariant.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Products;
+namespace DuncanMcClean\SimpleCommerce\Products;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Product;
-use DoubleThreeDigital\SimpleCommerce\Data\HasData;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product as ProductFacade;
+use DuncanMcClean\SimpleCommerce\Contracts\Product;
+use DuncanMcClean\SimpleCommerce\Data\HasData;
+use DuncanMcClean\SimpleCommerce\Facades\Product as ProductFacade;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class ProductVariant

--- a/src/Query/Scopes/CouponTypeFilter.php
+++ b/src/Query/Scopes/CouponTypeFilter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Query\Scopes;
+namespace DuncanMcClean\SimpleCommerce\Query\Scopes;
 
-use DoubleThreeDigital\SimpleCommerce\Coupons\CouponType;
+use DuncanMcClean\SimpleCommerce\Coupons\CouponType;
 use Statamic\Query\Scopes\Filter;
 
 class CouponTypeFilter extends Filter

--- a/src/Query/Scopes/OrderContainsProduct.php
+++ b/src/Query/Scopes/OrderContainsProduct.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Query\Scopes;
+namespace DuncanMcClean\SimpleCommerce\Query\Scopes;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Statamic\Query\Scopes\Filter;
 
 class OrderContainsProduct extends Filter

--- a/src/Query/Scopes/OrderCustomer.php
+++ b/src/Query/Scopes/OrderCustomer.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Query\Scopes;
+namespace DuncanMcClean\SimpleCommerce\Query\Scopes;
 
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Support\Runway;
+use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Support\Runway;
 use Statamic\Query\Scopes\Filter;
 
 class OrderCustomer extends Filter

--- a/src/Query/Scopes/OrderStatusFilter.php
+++ b/src/Query/Scopes/OrderStatusFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Query\Scopes;
+namespace DuncanMcClean\SimpleCommerce\Query\Scopes;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Support\Runway;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Support\Runway;
 use Statamic\Query\Scopes\Filter;
 
 class OrderStatusFilter extends Filter

--- a/src/Query/Scopes/PaymentStatusFilter.php
+++ b/src/Query/Scopes/PaymentStatusFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Query\Scopes;
+namespace DuncanMcClean\SimpleCommerce\Query\Scopes;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Support\Runway;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Support\Runway;
 use Statamic\Query\Scopes\Filter;
 
 class PaymentStatusFilter extends Filter

--- a/src/Regions.php
+++ b/src/Regions.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce;
+namespace DuncanMcClean\SimpleCommerce;
 
 use Illuminate\Support\Facades\File;
 

--- a/src/Rules/CountryExists.php
+++ b/src/Rules/CountryExists.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Rules;
+namespace DuncanMcClean\SimpleCommerce\Rules;
 
-use DoubleThreeDigital\SimpleCommerce\Countries;
+use DuncanMcClean\SimpleCommerce\Countries;
 use Illuminate\Contracts\Validation\Rule;
 
 class CountryExists implements Rule

--- a/src/Rules/CouponExists.php
+++ b/src/Rules/CouponExists.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Rules;
+namespace DuncanMcClean\SimpleCommerce\Rules;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
 use Illuminate\Contracts\Validation\Rule;
 
 class CouponExists implements Rule

--- a/src/Rules/ProductExists.php
+++ b/src/Rules/ProductExists.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Rules;
+namespace DuncanMcClean\SimpleCommerce\Rules;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
 use Illuminate\Contracts\Validation\Rule;
 
 class ProductExists implements Rule

--- a/src/Rules/RegionExists.php
+++ b/src/Rules/RegionExists.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Rules;
+namespace DuncanMcClean\SimpleCommerce\Rules;
 
-use DoubleThreeDigital\SimpleCommerce\Regions;
+use DuncanMcClean\SimpleCommerce\Regions;
 use Illuminate\Contracts\Validation\Rule;
 
 class RegionExists implements Rule

--- a/src/Rules/TaxCategoryExists.php
+++ b/src/Rules/TaxCategoryExists.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Rules;
+namespace DuncanMcClean\SimpleCommerce\Rules;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory;
 use Illuminate\Contracts\Validation\Rule;
 
 class TaxCategoryExists implements Rule

--- a/src/Rules/TaxZoneExists.php
+++ b/src/Rules/TaxZoneExists.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Rules;
+namespace DuncanMcClean\SimpleCommerce\Rules;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
 use Illuminate\Contracts\Validation\Rule;
 
 class TaxZoneExists implements Rule

--- a/src/Rules/ValidCoupon.php
+++ b/src/Rules/ValidCoupon.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Rules;
+namespace DuncanMcClean\SimpleCommerce\Rules;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CouponNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Exceptions\CouponNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
 use Illuminate\Contracts\Validation\Rule;
 
 class ValidCoupon implements Rule

--- a/src/Rules/ValidGateway.php
+++ b/src/Rules/ValidGateway.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Rules;
+namespace DuncanMcClean\SimpleCommerce\Rules;
 
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Contracts\Validation\Rule;
 
 class ValidGateway implements Rule

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -115,6 +115,7 @@ class ServiceProvider extends AddonServiceProvider
     ];
 
     protected $updateScripts = [
+        UpdateScripts\v6_0\ReplaceOldVendorName::class,
         UpdateScripts\v6_0\MigrateProductType::class,
         UpdateScripts\v6_0\PublishMigrations::class,
         UpdateScripts\v6_0\UpdateClassReferences::class,

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce;
+namespace DuncanMcClean\SimpleCommerce;
 
 use Barryvdh\Debugbar\Facade as Debugbar;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Support\Runway;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Support\Runway;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Carbon;
 use Statamic\CP\Navigation\NavItem;
@@ -253,7 +253,7 @@ class ServiceProvider extends AddonServiceProvider
         if (! $this->app->bound(Contracts\CartDriver::class)) {
             $this->app->bind(
                 Contracts\CartDriver::class,
-                config('simple-commerce.cart.driver', \DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CookieDriver::class)
+                config('simple-commerce.cart.driver', \DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CookieDriver::class)
             );
         }
 
@@ -305,7 +305,7 @@ class ServiceProvider extends AddonServiceProvider
     {
         Nav::extend(function ($nav) {
             if (
-                $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], \DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository::class)
+                $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], \DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository::class)
             ) {
                 $nav->create(__('Orders'))
                     ->section(__('Simple Commerce'))
@@ -314,7 +314,7 @@ class ServiceProvider extends AddonServiceProvider
                     ->icon(SimpleCommerce::svg('shop'));
             } elseif (
                 class_exists('StatamicRadPack\Runway\Runway') &&
-                $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], \DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository::class)
+                $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], \DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository::class)
             ) {
                 $orderResource = Runway::orderModel();
 
@@ -326,7 +326,7 @@ class ServiceProvider extends AddonServiceProvider
             }
 
             if (
-                $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository::class)
+                $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class)
             ) {
                 $nav->create(__('Customers'))
                     ->section(__('Simple Commerce'))
@@ -334,7 +334,7 @@ class ServiceProvider extends AddonServiceProvider
                     ->can('view', Collection::find(SimpleCommerce::customerDriver()['collection']))
                     ->icon('user');
             } elseif (
-                $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository::class)
+                $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class)
             ) {
                 $nav->create(__('Customers'))
                     ->section(__('Simple Commerce'))
@@ -343,7 +343,7 @@ class ServiceProvider extends AddonServiceProvider
                     ->icon('user');
             } elseif (
                 class_exists('StatamicRadPack\Runway\Runway') &&
-                $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DoubleThreeDigital\SimpleCommerce\Customers\EloquentCustomerRepository::class)
+                $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DuncanMcClean\SimpleCommerce\Customers\EloquentCustomerRepository::class)
             ) {
                 $customerResource = Runway::customerModel();
 
@@ -452,7 +452,7 @@ class ServiceProvider extends AddonServiceProvider
     protected function registerComputedValues()
     {
         if (
-            $this->isOrExtendsClass(SimpleCommerce::productDriver()['repository'], \DoubleThreeDigital\SimpleCommerce\Products\EntryProductRepository::class)
+            $this->isOrExtendsClass(SimpleCommerce::productDriver()['repository'], \DuncanMcClean\SimpleCommerce\Products\EntryProductRepository::class)
         ) {
             Collection::computed(SimpleCommerce::productDriver()['collection'], 'raw_price', function ($entry, $value) {
                 return $entry->get('price');
@@ -460,7 +460,7 @@ class ServiceProvider extends AddonServiceProvider
         }
 
         if (
-            $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], \DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository::class)
+            $this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], \DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository::class)
         ) {
             Collection::computed(SimpleCommerce::orderDriver()['collection'], 'order_date', function ($entry, $value) {
                 $order = Order::find($entry->id());

--- a/src/Shipping/BaseShippingMethod.php
+++ b/src/Shipping/BaseShippingMethod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Shipping;
+namespace DuncanMcClean\SimpleCommerce\Shipping;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;

--- a/src/Shipping/FreeShipping.php
+++ b/src/Shipping/FreeShipping.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Shipping;
+namespace DuncanMcClean\SimpleCommerce\Shipping;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
-use DoubleThreeDigital\SimpleCommerce\Orders\Address;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\ShippingMethod;
+use DuncanMcClean\SimpleCommerce\Orders\Address;
 
 class FreeShipping extends BaseShippingMethod implements ShippingMethod
 {

--- a/src/Shipping/Manager.php
+++ b/src/Shipping/Manager.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Shipping;
+namespace DuncanMcClean\SimpleCommerce\Shipping;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingManager as Contract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\ShippingMethodDoesNotExist;
-use DoubleThreeDigital\SimpleCommerce\Orders\Address;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\ShippingManager as Contract;
+use DuncanMcClean\SimpleCommerce\Exceptions\ShippingMethodDoesNotExist;
+use DuncanMcClean\SimpleCommerce\Orders\Address;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Statamic\Facades\Site;
 
 class Manager implements Contract

--- a/src/SimpleCommerce.php
+++ b/src/SimpleCommerce.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce;
+namespace DuncanMcClean\SimpleCommerce;
 
 use Closure;
 use Illuminate\Support\Collection;
@@ -26,10 +26,10 @@ class SimpleCommerce
     public static function version(): string
     {
         if (app()->environment('testing')) {
-            return 'v4.0.0';
+            return 'v6.0.0';
         }
 
-        return Addon::get('doublethreedigital/simple-commerce')->version();
+        return Addon::get('duncanmcclean/simple-commerce')->version();
     }
 
     public static function bootGateways()

--- a/src/Support/Runway.php
+++ b/src/Support/Runway.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Support;
+namespace DuncanMcClean\SimpleCommerce\Support;
 
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 
 class Runway
 {

--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tags;
+namespace DuncanMcClean\SimpleCommerce\Tags;
 
-use DoubleThreeDigital\SimpleCommerce\Currency;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DuncanMcClean\SimpleCommerce\Currency;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Statamic\Facades\Site;
@@ -28,7 +28,7 @@ class CartTags extends SubTag
     {
         $cart = $this->getOrMakeCart();
 
-        return collect($cart->toAugmentedArray()['items']->value())->map->toArray();
+        return $cart->toAugmentedArray('items')['items']->value();
     }
 
     public function count()
@@ -160,15 +160,15 @@ class CartTags extends SubTag
 
     public function rawTaxTotalSplit(): Collection
     {
-        return $this->items()
+        return collect($this->items())
             ->groupBy(function ($item) {
-                return $item['tax']->value()['rate'];
+                return $item['tax']['rate'];
             })
             ->map(function ($group, $groupRate) {
                 return [
                     'rate' => $groupRate,
                     'amount' => $group->sum(function ($item) {
-                        return $item['tax']->raw()['amount'];
+                        return $item['tax']['amount'];
                     }),
                 ];
             })

--- a/src/Tags/CheckoutTags.php
+++ b/src/Tags/CheckoutTags.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tags;
+namespace DuncanMcClean\SimpleCommerce\Tags;
 
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayDoesNotExist;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\PreventCheckout;
-use DoubleThreeDigital\SimpleCommerce\Facades\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
-use DoubleThreeDigital\SimpleCommerce\Orders\Checkout\CheckoutValidationPipeline;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayDoesNotExist;
+use DuncanMcClean\SimpleCommerce\Exceptions\PreventCheckout;
+use DuncanMcClean\SimpleCommerce\Facades\Gateway;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DuncanMcClean\SimpleCommerce\Orders\Checkout\CheckoutValidationPipeline;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Exception;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;

--- a/src/Tags/Concerns/FormBuilder.php
+++ b/src/Tags/Concerns/FormBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tags\Concerns;
+namespace DuncanMcClean\SimpleCommerce\Tags\Concerns;
 
 use Illuminate\Support\Str;
 use Statamic\Tags\Concerns\RendersForms;

--- a/src/Tags/CouponTags.php
+++ b/src/Tags/CouponTags.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tags;
+namespace DuncanMcClean\SimpleCommerce\Tags;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DuncanMcClean\SimpleCommerce\Contracts\Coupon;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 
 class CouponTags extends SubTag
 {

--- a/src/Tags/CustomerTags.php
+++ b/src/Tags/CustomerTags.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tags;
+namespace DuncanMcClean\SimpleCommerce\Tags;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order as OrderAPI;
-use DoubleThreeDigital\SimpleCommerce\Orders\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Order as OrderAPI;
+use DuncanMcClean\SimpleCommerce\Orders\Order;
 
 class CustomerTags extends SubTag
 {

--- a/src/Tags/GatewayTags.php
+++ b/src/Tags/GatewayTags.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tags;
+namespace DuncanMcClean\SimpleCommerce\Tags;
 
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 
 class GatewayTags extends SubTag
 {

--- a/src/Tags/ShippingTags.php
+++ b/src/Tags/ShippingTags.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tags;
+namespace DuncanMcClean\SimpleCommerce\Tags;
 
-use DoubleThreeDigital\SimpleCommerce\Currency;
-use DoubleThreeDigital\SimpleCommerce\Facades\Shipping;
-use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Currency;
+use DuncanMcClean\SimpleCommerce\Facades\Shipping;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Statamic\Facades\Site;
 
 class ShippingTags extends SubTag

--- a/src/Tags/SimpleCommerceTag.php
+++ b/src/Tags/SimpleCommerceTag.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tags;
+namespace DuncanMcClean\SimpleCommerce\Tags;
 
-use DoubleThreeDigital\SimpleCommerce\Countries;
-use DoubleThreeDigital\SimpleCommerce\Currencies;
-use DoubleThreeDigital\SimpleCommerce\Regions;
+use DuncanMcClean\SimpleCommerce\Countries;
+use DuncanMcClean\SimpleCommerce\Currencies;
+use DuncanMcClean\SimpleCommerce\Regions;
 use Statamic\Tags\TagNotFoundException;
 use Statamic\Tags\Tags;
 

--- a/src/Tags/SubTag.php
+++ b/src/Tags/SubTag.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tags;
+namespace DuncanMcClean\SimpleCommerce\Tags;
 
 use Statamic\Tags\Tags;
 

--- a/src/Tags/TotalIncludingTax.php
+++ b/src/Tags/TotalIncludingTax.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tags;
+namespace DuncanMcClean\SimpleCommerce\Tags;
 
-use DoubleThreeDigital\SimpleCommerce\Currency;
+use DuncanMcClean\SimpleCommerce\Currency;
 use Statamic\Facades\Site;
 use Statamic\Tags\Tags;
 

--- a/src/Tax/BasicTaxEngine.php
+++ b/src/Tax/BasicTaxEngine.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax;
+namespace DuncanMcClean\SimpleCommerce\Tax;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
-use DoubleThreeDigital\SimpleCommerce\Contracts\TaxEngine;
-use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\ShippingMethod;
+use DuncanMcClean\SimpleCommerce\Contracts\TaxEngine;
+use DuncanMcClean\SimpleCommerce\Orders\LineItem;
 use Illuminate\Support\Facades\Config;
 
 class BasicTaxEngine implements TaxEngine

--- a/src/Tax/Standard/Stache/TaxCategory/TaxCategoryQueryBuilder.php
+++ b/src/Tax/Standard/Stache/TaxCategory/TaxCategoryQueryBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard\Stache\TaxCategory;
+namespace DuncanMcClean\SimpleCommerce\Tax\Standard\Stache\TaxCategory;
 
 use Statamic\Data\DataCollection;
 use Statamic\Stache\Query\Builder;

--- a/src/Tax/Standard/Stache/TaxCategory/TaxCategoryRepository.php
+++ b/src/Tax/Standard/Stache/TaxCategory/TaxCategoryRepository.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard\Stache\TaxCategory;
+namespace DuncanMcClean\SimpleCommerce\Tax\Standard\Stache\TaxCategory;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\TaxCategoryRepository as Contract;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
-use DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Contracts\TaxCategoryRepository as Contract;
+use DuncanMcClean\SimpleCommerce\Facades\TaxRate;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\TaxCategory;
 use Statamic\Data\DataCollection;
 use Statamic\Stache\Stache;
 

--- a/src/Tax/Standard/Stache/TaxCategory/TaxCategoryStore.php
+++ b/src/Tax/Standard/Stache/TaxCategory/TaxCategoryStore.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard\Stache\TaxCategory;
+namespace DuncanMcClean\SimpleCommerce\Tax\Standard\Stache\TaxCategory;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory;
 use Statamic\Facades\YAML;
 use Statamic\Stache\Stores\BasicStore;
 

--- a/src/Tax/Standard/Stache/TaxRate/TaxRateQueryBuilder.php
+++ b/src/Tax/Standard/Stache/TaxRate/TaxRateQueryBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard\Stache\TaxRate;
+namespace DuncanMcClean\SimpleCommerce\Tax\Standard\Stache\TaxRate;
 
 use Statamic\Data\DataCollection;
 use Statamic\Stache\Query\Builder;

--- a/src/Tax/Standard/Stache/TaxRate/TaxRateRepository.php
+++ b/src/Tax/Standard/Stache/TaxRate/TaxRateRepository.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard\Stache\TaxRate;
+namespace DuncanMcClean\SimpleCommerce\Tax\Standard\Stache\TaxRate;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\TaxRateRepository as Contract;
-use DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxRate;
+use DuncanMcClean\SimpleCommerce\Contracts\TaxRateRepository as Contract;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\TaxRate;
 use Statamic\Data\DataCollection;
 use Statamic\Stache\Stache;
 

--- a/src/Tax/Standard/Stache/TaxRate/TaxRateStore.php
+++ b/src/Tax/Standard/Stache/TaxRate/TaxRateStore.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard\Stache\TaxRate;
+namespace DuncanMcClean\SimpleCommerce\Tax\Standard\Stache\TaxRate;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
+use DuncanMcClean\SimpleCommerce\Facades\TaxRate;
 use Statamic\Facades\YAML;
 use Statamic\Stache\Stores\BasicStore;
 

--- a/src/Tax/Standard/Stache/TaxZone/TaxZoneQueryBuilder.php
+++ b/src/Tax/Standard/Stache/TaxZone/TaxZoneQueryBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard\Stache\TaxZone;
+namespace DuncanMcClean\SimpleCommerce\Tax\Standard\Stache\TaxZone;
 
 use Statamic\Data\DataCollection;
 use Statamic\Stache\Query\Builder;

--- a/src/Tax/Standard/Stache/TaxZone/TaxZoneRepository.php
+++ b/src/Tax/Standard/Stache/TaxZone/TaxZoneRepository.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard\Stache\TaxZone;
+namespace DuncanMcClean\SimpleCommerce\Tax\Standard\Stache\TaxZone;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\TaxZoneRepository as Contract;
-use DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxZone;
+use DuncanMcClean\SimpleCommerce\Contracts\TaxZoneRepository as Contract;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\TaxZone;
 use Statamic\Data\DataCollection;
 use Statamic\Stache\Stache;
 

--- a/src/Tax/Standard/Stache/TaxZone/TaxZoneStore.php
+++ b/src/Tax/Standard/Stache/TaxZone/TaxZoneStore.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard\Stache\TaxZone;
+namespace DuncanMcClean\SimpleCommerce\Tax\Standard\Stache\TaxZone;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
 use Statamic\Facades\YAML;
 use Statamic\Stache\Stores\BasicStore;
 

--- a/src/Tax/Standard/TaxCategory.php
+++ b/src/Tax/Standard/TaxCategory.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard;
+namespace DuncanMcClean\SimpleCommerce\Tax\Standard;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory as TaxCategoryFacade;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory as TaxCategoryFacade;
+use DuncanMcClean\SimpleCommerce\Facades\TaxRate;
 use Statamic\Data\ContainsData;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Data\TracksQueriedColumns;

--- a/src/Tax/Standard/TaxEngine.php
+++ b/src/Tax/Standard/TaxEngine.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard;
+namespace DuncanMcClean\SimpleCommerce\Tax\Standard;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
-use DoubleThreeDigital\SimpleCommerce\Contracts\TaxEngine as Contract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\PreventCheckout;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
-use DoubleThreeDigital\SimpleCommerce\Orders\Address;
-use DoubleThreeDigital\SimpleCommerce\Orders\LineItem;
-use DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxRate as StandardTaxRate;
-use DoubleThreeDigital\SimpleCommerce\Tax\TaxCalculation;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\ShippingMethod;
+use DuncanMcClean\SimpleCommerce\Contracts\TaxEngine as Contract;
+use DuncanMcClean\SimpleCommerce\Exceptions\PreventCheckout;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Facades\TaxRate;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\Orders\Address;
+use DuncanMcClean\SimpleCommerce\Orders\LineItem;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\TaxRate as StandardTaxRate;
+use DuncanMcClean\SimpleCommerce\Tax\TaxCalculation;
 use Illuminate\Support\Facades\Config;
 
 class TaxEngine implements Contract
@@ -48,7 +48,7 @@ class TaxEngine implements Contract
     {
         $product = $lineItem->product();
 
-        /** @var \DoubleThreeDigital\SimpleCommerce\Orders\Address */
+        /** @var \DuncanMcClean\SimpleCommerce\Orders\Address */
         $address = config('simple-commerce.tax_engine_config.address') === 'billing'
             ? $order->billingAddress()
             : $order->shippingAddress();
@@ -119,7 +119,7 @@ class TaxEngine implements Contract
 
     protected function decideOnShippingRate(Order $order, ShippingMethod $shippingMethod): ?StandardTaxRate
     {
-        /** @var \DoubleThreeDigital\SimpleCommerce\Orders\Address */
+        /** @var \DuncanMcClean\SimpleCommerce\Orders\Address */
         $address = config('simple-commerce.tax_engine_config.address') === 'billing'
             ? $order->billingAddress()
             : $order->shippingAddress();

--- a/src/Tax/Standard/TaxRate.php
+++ b/src/Tax/Standard/TaxRate.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard;
+namespace DuncanMcClean\SimpleCommerce\Tax\Standard;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory as TaxCategoryFacade;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate as TaxRateFacade;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory as TaxCategoryFacade;
+use DuncanMcClean\SimpleCommerce\Facades\TaxRate as TaxRateFacade;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
 use Statamic\Data\ContainsData;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Data\TracksQueriedColumns;

--- a/src/Tax/Standard/TaxZone.php
+++ b/src/Tax/Standard/TaxZone.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax\Standard;
+namespace DuncanMcClean\SimpleCommerce\Tax\Standard;
 
-use DoubleThreeDigital\SimpleCommerce\Countries;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone as TaxZoneFacade;
-use DoubleThreeDigital\SimpleCommerce\Regions;
+use DuncanMcClean\SimpleCommerce\Countries;
+use DuncanMcClean\SimpleCommerce\Facades\TaxRate;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone as TaxZoneFacade;
+use DuncanMcClean\SimpleCommerce\Regions;
 use Statamic\Data\ContainsData;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Data\TracksQueriedColumns;

--- a/src/Tax/TaxCalculation.php
+++ b/src/Tax/TaxCalculation.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tax;
+namespace DuncanMcClean\SimpleCommerce\Tax;
 
 class TaxCalculation
 {

--- a/src/Telemetry.php
+++ b/src/Telemetry.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce;
+namespace DuncanMcClean\SimpleCommerce;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;

--- a/src/UpdateScripts/v6_0/MigrateProductType.php
+++ b/src/UpdateScripts/v6_0/MigrateProductType.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0;
+namespace DuncanMcClean\SimpleCommerce\UpdateScripts\v6_0;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Products\ProductVariant;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Products\ProductVariant;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Statamic\Facades\Collection;
 use Statamic\Fields\Blueprint;
 use Statamic\UpdateScripts\UpdateScript;

--- a/src/UpdateScripts/v6_0/PublishMigrations.php
+++ b/src/UpdateScripts/v6_0/PublishMigrations.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0;
+namespace DuncanMcClean\SimpleCommerce\UpdateScripts\v6_0;
 
 use Illuminate\Support\Facades\File;
 use Statamic\UpdateScripts\UpdateScript;

--- a/src/UpdateScripts/v6_0/ReplaceOldVendorName.php
+++ b/src/UpdateScripts/v6_0/ReplaceOldVendorName.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DuncanMcClean\SimpleCommerce\UpdateScripts\v6_0;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\File;
+use Statamic\UpdateScripts\UpdateScript;
+
+class ReplaceOldVendorName extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('6.0.0');
+    }
+
+    public function update()
+    {
+        $configFileContents = File::get(config_path('simple-commerce.php'));
+
+        $configFileContents = Str::of($configFileContents)
+            ->replace("DoubleThreeDigital", "DuncanMcClean")
+            ->toString();
+
+        File::put(config_path('simple-commerce.php'), $configFileContents);
+    }
+}

--- a/src/UpdateScripts/v6_0/ReplaceOldVendorName.php
+++ b/src/UpdateScripts/v6_0/ReplaceOldVendorName.php
@@ -2,8 +2,8 @@
 
 namespace DuncanMcClean\SimpleCommerce\UpdateScripts\v6_0;
 
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use Statamic\UpdateScripts\UpdateScript;
 
 class ReplaceOldVendorName extends UpdateScript
@@ -18,7 +18,7 @@ class ReplaceOldVendorName extends UpdateScript
         $configFileContents = File::get(config_path('simple-commerce.php'));
 
         $configFileContents = Str::of($configFileContents)
-            ->replace("DoubleThreeDigital", "DuncanMcClean")
+            ->replace('DoubleThreeDigital', 'DuncanMcClean')
             ->toString();
 
         File::put(config_path('simple-commerce.php'), $configFileContents);

--- a/src/UpdateScripts/v6_0/UpdateClassReferences.php
+++ b/src/UpdateScripts/v6_0/UpdateClassReferences.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0;
+namespace DuncanMcClean\SimpleCommerce\UpdateScripts\v6_0;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -33,7 +33,7 @@ class UpdateClassReferences extends UpdateScript
 
                     // Adjust the class name before new'ing it up since the namespace has changed.
                     if (Str::startsWith($class, 'DoubleThreeDigital')) {
-                        // $class = str_replace('DoubleThreeDigital', 'DuncanMcClean', $class);
+                        $class = str_replace('DoubleThreeDigital', 'DuncanMcClean', $class);
                     }
 
                     $handle = $class::handle();
@@ -56,7 +56,7 @@ class UpdateClassReferences extends UpdateScript
 
                     // Adjust the class name before new'ing it up since the namespace has changed.
                     if (Str::startsWith($class, 'DoubleThreeDigital')) {
-                        // $class = str_replace('DoubleThreeDigital', 'DuncanMcClean', $class);
+                        $class = str_replace('DoubleThreeDigital', 'DuncanMcClean', $class);
                     }
 
                     $handle = $class::handle();

--- a/src/UpdateScripts/v6_0/UpdateCouponExpiryDate.php
+++ b/src/UpdateScripts/v6_0/UpdateCouponExpiryDate.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0;
+namespace DuncanMcClean\SimpleCommerce\UpdateScripts\v6_0;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
 use Illuminate\Support\Carbon;
 use Statamic\UpdateScripts\UpdateScript;
 

--- a/src/Widgets/LowStockProducts.php
+++ b/src/Widgets/LowStockProducts.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Widgets;
+namespace DuncanMcClean\SimpleCommerce\Widgets;
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Statamic\Widgets\Widget;
 
 class LowStockProducts extends Widget

--- a/src/Widgets/OrdersChart.php
+++ b/src/Widgets/OrdersChart.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Widgets;
+namespace DuncanMcClean\SimpleCommerce\Widgets;
 
 use Carbon\CarbonPeriod;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Support\Runway;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Support\Runway;
 use Illuminate\Support\Carbon;
 use Statamic\Widgets\Widget;
 

--- a/src/Widgets/RecentOrders.php
+++ b/src/Widgets/RecentOrders.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Widgets;
+namespace DuncanMcClean\SimpleCommerce\Widgets;
 
-use DoubleThreeDigital\SimpleCommerce\Currency;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\StatusLogEvent;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Support\Runway;
+use DuncanMcClean\SimpleCommerce\Currency;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Orders\StatusLogEvent;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Support\Runway;
 use Statamic\Facades\Site;
 use Statamic\Widgets\Widget;
 

--- a/src/Widgets/TopCustomers.php
+++ b/src/Widgets/TopCustomers.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Widgets;
+namespace DuncanMcClean\SimpleCommerce\Widgets;
 
-use DoubleThreeDigital\SimpleCommerce\Customers\EloquentCustomerRepository;
-use DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository;
-use DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Support\Runway;
+use DuncanMcClean\SimpleCommerce\Customers\EloquentCustomerRepository;
+use DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository;
+use DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Support\Runway;
 use Illuminate\Database\SQLiteConnection;
 use Statamic\Widgets\Widget;
 

--- a/tests/Actions/DeleteTest.php
+++ b/tests/Actions/DeleteTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Actions\Delete;
-use DoubleThreeDigital\SimpleCommerce\Coupons\CouponType;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Actions\Delete;
+use DuncanMcClean\SimpleCommerce\Coupons\CouponType;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
 use Statamic\Facades\Entry;
 
 beforeEach(function () {

--- a/tests/Actions/RefundActionTest.php
+++ b/tests/Actions/RefundActionTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Actions\RefundAction;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\DummyGateway;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Actions\RefundAction;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Gateways\Builtin\DummyGateway;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Stache;

--- a/tests/Actions/UpdateOrderStatusTest.php
+++ b/tests/Actions/UpdateOrderStatusTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Actions\UpdateOrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Actions\UpdateOrderStatus;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
 use Illuminate\Support\Carbon;
 use Spatie\TestTime\TestTime;
 use Statamic\Facades\Collection;

--- a/tests/ComputedValuesTest.php
+++ b/tests/ComputedValuesTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Support\Carbon;
 
-uses(DoubleThreeDigital\SimpleCommerce\Tests\TestCase::class);
+uses(DuncanMcClean\SimpleCommerce\Tests\TestCase::class);
 uses(SetupCollections::class);
 
 test('product returns with raw price value', function () {

--- a/tests/Console/Commands/MakeCommandsTest.php
+++ b/tests/Console/Commands/MakeCommandsTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Console\Commands;
+namespace DuncanMcClean\SimpleCommerce\Tests\Console\Commands;
 
-use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
+use DuncanMcClean\SimpleCommerce\Tests\TestCase;
 use Illuminate\Filesystem\Filesystem;
 
 class MakeCommandsTest extends TestCase

--- a/tests/Coupons/CouponTest.php
+++ b/tests/Coupons/CouponTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Coupons\Coupon as CouponsCoupon;
-use DoubleThreeDigital\SimpleCommerce\Coupons\CouponType;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Coupons\Coupon as CouponsCoupon;
+use DuncanMcClean\SimpleCommerce\Coupons\CouponType;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
 use Statamic\Facades\Stache;
 
 test('can create', function () {

--- a/tests/Customers/EloquentCustomerRepositoryTest.php
+++ b/tests/Customers/EloquentCustomerRepositoryTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Customer as CustomerContract;
-use DoubleThreeDigital\SimpleCommerce\Customers\CustomerModel;
-use DoubleThreeDigital\SimpleCommerce\Customers\EloquentQueryBuilder;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\UseDatabaseContentDrivers;
+use DuncanMcClean\SimpleCommerce\Contracts\Customer as CustomerContract;
+use DuncanMcClean\SimpleCommerce\Customers\CustomerModel;
+use DuncanMcClean\SimpleCommerce\Customers\EloquentQueryBuilder;
+use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\UseDatabaseContentDrivers;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);

--- a/tests/Customers/EntryCustomerRepositoryTest.php
+++ b/tests/Customers/EntryCustomerRepositoryTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Customer as CustomerContract;
-use DoubleThreeDigital\SimpleCommerce\Customers\Customer as CustomersCustomer;
-use DoubleThreeDigital\SimpleCommerce\Customers\EntryQueryBuilder;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Contracts\Customer as CustomerContract;
+use DuncanMcClean\SimpleCommerce\Customers\Customer as CustomersCustomer;
+use DuncanMcClean\SimpleCommerce\Customers\EntryQueryBuilder;
+use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Stache;

--- a/tests/Customers/UserCustomerRepositoryTest.php
+++ b/tests/Customers/UserCustomerRepositoryTest.php
@@ -1,12 +1,12 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Customer as CustomerContract;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as ContractsOrder;
-use DoubleThreeDigital\SimpleCommerce\Customers\StacheUserQueryBuilder;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\Invader;
+use DuncanMcClean\SimpleCommerce\Contracts\Customer as CustomerContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as ContractsOrder;
+use DuncanMcClean\SimpleCommerce\Customers\StacheUserQueryBuilder;
+use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\Invader;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use Statamic\Auth\User as StatamicAuthUser;
@@ -16,8 +16,8 @@ use Statamic\Statamic;
 
 beforeEach(function () {
     Statamic::repository(
-        \DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository::class,
-        \DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository::class
+        \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
+        \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class
     );
 
     File::deleteDirectory(__DIR__.'/../__fixtures__/users');
@@ -27,8 +27,8 @@ beforeEach(function () {
 
 afterEach(function () {
     Statamic::repository(
-        \DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository::class,
-        \DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository::class
+        \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
+        \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class
     );
 });
 

--- a/tests/Data/HasDataTest.php
+++ b/tests/Data/HasDataTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Tests\Data\TraitAccess;
+use DuncanMcClean\SimpleCommerce\Tests\Data\TraitAccess;
 
 beforeEach(function () {
     $this->trait = new TraitAccess();

--- a/tests/Data/TraitAccess.php
+++ b/tests/Data/TraitAccess.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Data;
+namespace DuncanMcClean\SimpleCommerce\Tests\Data;
 
-use DoubleThreeDigital\SimpleCommerce\Data\HasData;
+use DuncanMcClean\SimpleCommerce\Data\HasData;
 
 // We're using this `TraitAccess` class instead of simply 'using' the class
 // as some of the trait's method name's conflict with those of Testbench's Test Case.

--- a/tests/Fieldtypes/CountryFieldtypeTest.php
+++ b/tests/Fieldtypes/CountryFieldtypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Fieldtypes\CountryFieldtype;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\Invader;
+use DuncanMcClean\SimpleCommerce\Fieldtypes\CountryFieldtype;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\Invader;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Statamic\CP\Column;

--- a/tests/Fieldtypes/CouponFieldtypeTest.php
+++ b/tests/Fieldtypes/CouponFieldtypeTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Fieldtypes\CouponFieldtype;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\Invader;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Fieldtypes\CouponFieldtype;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\Invader;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Statamic\CP\Column;

--- a/tests/Fieldtypes/GatewayFieldtypeTest.php
+++ b/tests/Fieldtypes/GatewayFieldtypeTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Fieldtypes\GatewayFieldtype;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\DummyGateway;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Fieldtypes\GatewayFieldtype;
+use DuncanMcClean\SimpleCommerce\Gateways\Builtin\DummyGateway;
 use Illuminate\Support\Facades\Auth;
 use Statamic\Facades\User;
 use Statamic\Fields\Field;

--- a/tests/Fieldtypes/Helpers/MoneyFieldtypeWithMockedField.php
+++ b/tests/Fieldtypes/Helpers/MoneyFieldtypeWithMockedField.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fieldtypes\Helpers;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fieldtypes\Helpers;
 
-use DoubleThreeDigital\SimpleCommerce\Fieldtypes\MoneyFieldtype;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Fieldtypes\MoneyFieldtype;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Statamic\Facades\Collection;
 use Statamic\Fields\Field;
 

--- a/tests/Fieldtypes/MoneyFieldtypeTest.php
+++ b/tests/Fieldtypes/MoneyFieldtypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Fieldtypes\MoneyFieldtype;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fieldtypes\Helpers\MoneyFieldtypeWithMockedField;
+use DuncanMcClean\SimpleCommerce\Fieldtypes\MoneyFieldtype;
+use DuncanMcClean\SimpleCommerce\Tests\Fieldtypes\Helpers\MoneyFieldtypeWithMockedField;
 use Statamic\Fields\Field;
 
 test('can preload currency with no field', function () {

--- a/tests/Fieldtypes/ProductVariantFieldtypeTest.php
+++ b/tests/Fieldtypes/ProductVariantFieldtypeTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Fieldtypes\ProductVariantFieldtype;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Fieldtypes\ProductVariantFieldtype;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 
 uses(SetupCollections::class);
 

--- a/tests/Fieldtypes/ProductVariantsFieldtypeTest.php
+++ b/tests/Fieldtypes/ProductVariantsFieldtypeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Fieldtypes\ProductVariantsFieldtype;
+use DuncanMcClean\SimpleCommerce\Fieldtypes\ProductVariantsFieldtype;
 use Statamic\Fields\Field;
 
 it('can preload', function () {

--- a/tests/Fieldtypes/RegionFieldtypeTest.php
+++ b/tests/Fieldtypes/RegionFieldtypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Fieldtypes\RegionFieldtype;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\Invader;
+use DuncanMcClean\SimpleCommerce\Fieldtypes\RegionFieldtype;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\Invader;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Statamic\CP\Column;

--- a/tests/Fieldtypes/ShippingMethodFieldtypeTest.php
+++ b/tests/Fieldtypes/ShippingMethodFieldtypeTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Fieldtypes\ShippingMethodFieldtype;
-use DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\Invader;
+use DuncanMcClean\SimpleCommerce\Fieldtypes\ShippingMethodFieldtype;
+use DuncanMcClean\SimpleCommerce\Shipping\FreeShipping;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\Invader;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Statamic\CP\Column;

--- a/tests/Fieldtypes/Variables/LineItemTaxTest.php
+++ b/tests/Fieldtypes/Variables/LineItemTaxTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Fieldtypes\Variables\LineItemTax;
+use DuncanMcClean\SimpleCommerce\Fieldtypes\Variables\LineItemTax;
 
 test('can augment line item tax', function () {
     $value = [

--- a/tests/Gateways/Builtin/BaseGatewayTest.php
+++ b/tests/Gateways/Builtin/BaseGatewayTest.php
@@ -1,12 +1,12 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Events\PaymentStatusUpdated;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Gateways\FakeOffsiteGateway;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Gateways\FakeOnsiteGateway;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Events\PaymentStatusUpdated;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways\FakeOffsiteGateway;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways\FakeOnsiteGateway;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Support\Facades\Event;
 
 uses(SetupCollections::class);

--- a/tests/Gateways/Builtin/DummyGatewayTest.php
+++ b/tests/Gateways/Builtin/DummyGatewayTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\DummyGateway;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Gateways\Builtin\DummyGateway;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Notification;
 use Spatie\TestTime\TestTime;

--- a/tests/Gateways/Builtin/MollieGatewayTest.php
+++ b/tests/Gateways/Builtin/MollieGatewayTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\MollieGateway;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\Invader;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Gateways\Builtin\MollieGateway;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\Invader;
 use Illuminate\Http\Request;
 use Statamic\Facades\Collection;
 

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -1,15 +1,15 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as ContractsOrder;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayHasNotImplementedMethod;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\StripeGateway;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\RefreshContent;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as ContractsOrder;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayHasNotImplementedMethod;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Gateways\Builtin\StripeGateway;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\RefreshContent;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Stripe\Customer as StripeCustomer;

--- a/tests/Helpers/Invader.php
+++ b/tests/Helpers/Invader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Helpers;
+namespace DuncanMcClean\SimpleCommerce\Tests\Helpers;
 
 use ReflectionClass;
 

--- a/tests/Helpers/RefreshContent.php
+++ b/tests/Helpers/RefreshContent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Helpers;
+namespace DuncanMcClean\SimpleCommerce\Tests\Helpers;
 
 use Illuminate\Support\Facades\File;
 

--- a/tests/Helpers/RunsUpdateScripts.php
+++ b/tests/Helpers/RunsUpdateScripts.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Helpers;
+namespace DuncanMcClean\SimpleCommerce\Tests\Helpers;
 
 trait RunsUpdateScripts
 {
@@ -10,7 +10,7 @@ trait RunsUpdateScripts
      * @param  string  $fqcn
      * @param  string  $package
      */
-    protected function runUpdateScript($fqcn, $package = 'doublethreedigital/simple-commerce')
+    protected function runUpdateScript($fqcn, $package = 'duncanmcclean/simple-commerce')
     {
         $script = new $fqcn($package);
 

--- a/tests/Helpers/SetupCollections.php
+++ b/tests/Helpers/SetupCollections.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Helpers;
+namespace DuncanMcClean\SimpleCommerce\Tests\Helpers;
 
 use Statamic\Facades\Collection;
 

--- a/tests/Helpers/StaticCartDriver.php
+++ b/tests/Helpers/StaticCartDriver.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Helpers;
+namespace DuncanMcClean\SimpleCommerce\Tests\Helpers;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\CartDriver;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\CartDriver;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
 
 class StaticCartDriver implements CartDriver
 {

--- a/tests/Helpers/UseDatabaseContentDrivers.php
+++ b/tests/Helpers/UseDatabaseContentDrivers.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Helpers;
+namespace DuncanMcClean\SimpleCommerce\Tests\Helpers;
 
 use Illuminate\Support\Facades\File;
 
@@ -25,22 +25,22 @@ trait UseDatabaseContentDrivers
         $this->runLaravelMigrations();
 
         $this->app['config']->set('simple-commerce.content.customers', [
-            'repository' => \DoubleThreeDigital\SimpleCommerce\Customers\EloquentCustomerRepository::class,
-            'model' => \DoubleThreeDigital\SimpleCommerce\Customers\CustomerModel::class,
+            'repository' => \DuncanMcClean\SimpleCommerce\Customers\EloquentCustomerRepository::class,
+            'model' => \DuncanMcClean\SimpleCommerce\Customers\CustomerModel::class,
         ]);
 
         $this->app['config']->set('simple-commerce.content.orders', [
-            'repository' => \DoubleThreeDigital\SimpleCommerce\Orders\EloquentOrderRepository::class,
-            'model' => \DoubleThreeDigital\SimpleCommerce\Orders\OrderModel::class,
+            'repository' => \DuncanMcClean\SimpleCommerce\Orders\EloquentOrderRepository::class,
+            'model' => \DuncanMcClean\SimpleCommerce\Orders\OrderModel::class,
         ]);
 
         $this->app->bind(
-            \DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository::class,
+            \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
             $this->app['config']->get('simple-commerce.content.customers.repository')
         );
 
         $this->app->bind(
-            \DoubleThreeDigital\SimpleCommerce\Contracts\OrderRepository::class,
+            \DuncanMcClean\SimpleCommerce\Contracts\OrderRepository::class,
             $this->app['config']->get('simple-commerce.content.orders.repository')
         );
     }

--- a/tests/Http/Controllers/CP/CouponControllerTest.php
+++ b/tests/Http/Controllers/CP/CouponControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
 
 test('can get index', function () {
     $this

--- a/tests/Http/Controllers/CP/ResendNotificationsControllerTest.php
+++ b/tests/Http/Controllers/CP/ResendNotificationsControllerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderPaid;
-use DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderShipped;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderPaid;
+use DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderShipped;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Notification;
 use Statamic\Facades\User;
@@ -18,7 +18,7 @@ it('can resend notifications for order statuses', function () {
 
     Config::set('simple-commerce.notifications', [
         'order_dispatched' => [
-            \DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderShipped::class => ['to' => 'customer'],
+            \DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderShipped::class => ['to' => 'customer'],
         ],
     ]);
 
@@ -40,7 +40,7 @@ it('can resend notifications for payment statuses', function () {
 
     Config::set('simple-commerce.notifications', [
         'order_paid' => [
-            \DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderPaid::class => ['to' => 'customer'],
+            \DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderPaid::class => ['to' => 'customer'],
         ],
     ]);
 

--- a/tests/Http/Controllers/CP/TaxCategoryControllerTest.php
+++ b/tests/Http/Controllers/CP/TaxCategoryControllerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Facades\TaxRate;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
 use Illuminate\Support\Facades\File;
 
 beforeEach(function () {

--- a/tests/Http/Controllers/CP/TaxRateControllerTest.php
+++ b/tests/Http/Controllers/CP/TaxRateControllerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Facades\TaxRate;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
 use Illuminate\Support\Facades\File;
 
 beforeEach(function () {

--- a/tests/Http/Controllers/CP/TaxZoneControllerTest.php
+++ b/tests/Http/Controllers/CP/TaxZoneControllerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Facades\TaxRate;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
 use Illuminate\Support\Facades\File;
 
 beforeEach(function () {

--- a/tests/Http/Controllers/CartControllerTest.php
+++ b/tests/Http/Controllers/CartControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Http\Requests\CartUpdateFormRequest;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Http\Requests\CartUpdateWithNoRulesFormRequest;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\RefreshContent;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Http\Requests\CartUpdateFormRequest;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Http\Requests\CartUpdateWithNoRulesFormRequest;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\RefreshContent;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Support\Facades\Config;
 use Statamic\Facades\Stache;
 use Statamic\Facades\User;

--- a/tests/Http/Controllers/CartItemControllerTest.php
+++ b/tests/Http/Controllers/CartItemControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CustomerNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Http\Requests\CartItemStoreFormRequest;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Http\Requests\CartItemUpdateFormRequest;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\RefreshContent;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Exceptions\CustomerNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Http\Requests\CartItemStoreFormRequest;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Http\Requests\CartItemUpdateFormRequest;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\RefreshContent;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Support\Facades\Config;
 use Statamic\Facades\Stache;
 use Statamic\Facades\User;

--- a/tests/Http/Controllers/CheckoutControllerTest.php
+++ b/tests/Http/Controllers/CheckoutControllerTest.php
@@ -1,26 +1,26 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Events\OrderStatusUpdated;
-use DoubleThreeDigital\SimpleCommerce\Events\PaymentStatusUpdated;
-use DoubleThreeDigital\SimpleCommerce\Events\PostCheckout;
-use DoubleThreeDigital\SimpleCommerce\Events\PreCheckout;
-use DoubleThreeDigital\SimpleCommerce\Events\StockRunningLow;
-use DoubleThreeDigital\SimpleCommerce\Events\StockRunOut;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Gateways\Builtin\DummyGateway;
-use DoubleThreeDigital\SimpleCommerce\Notifications\BackOfficeOrderPaid;
-use DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderPaid;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Gateways\TestCheckoutErrorGateway;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Gateways\TestValidationGateway;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Http\Requests\CheckoutFormRequest;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\RefreshContent;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Events\OrderStatusUpdated;
+use DuncanMcClean\SimpleCommerce\Events\PaymentStatusUpdated;
+use DuncanMcClean\SimpleCommerce\Events\PostCheckout;
+use DuncanMcClean\SimpleCommerce\Events\PreCheckout;
+use DuncanMcClean\SimpleCommerce\Events\StockRunningLow;
+use DuncanMcClean\SimpleCommerce\Events\StockRunOut;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Gateways\Builtin\DummyGateway;
+use DuncanMcClean\SimpleCommerce\Notifications\BackOfficeOrderPaid;
+use DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderPaid;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways\TestCheckoutErrorGateway;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways\TestValidationGateway;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Http\Requests\CheckoutFormRequest;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\RefreshContent;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
@@ -2222,10 +2222,10 @@ test('can post checkout and ensure user is redirected', function () {
 
 test('can post checkout and ensure order paid notifications are sent', function () {
     config(['simple-commerce.notifications.order_paid' => [
-        \DoubleThreeDigital\SimpleCommerce\Notifications\CustomerOrderPaid::class => [
+        \DuncanMcClean\SimpleCommerce\Notifications\CustomerOrderPaid::class => [
             'to' => 'customer',
         ],
-        \DoubleThreeDigital\SimpleCommerce\Notifications\BackOfficeOrderPaid::class => [
+        \DuncanMcClean\SimpleCommerce\Notifications\BackOfficeOrderPaid::class => [
             'to' => 'duncan@example.com',
         ],
     ]]);

--- a/tests/Http/Controllers/CouponControllerTest.php
+++ b/tests/Http/Controllers/CouponControllerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Events\CouponRedeemed;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Events\CouponRedeemed;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Statamic\Facades\Stache;

--- a/tests/Http/Controllers/CustomerControllerTest.php
+++ b/tests/Http/Controllers/CustomerControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Http\Requests\CustomerUpdateFormRequest;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Http\Requests\CustomerUpdateFormRequest;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Support\Facades\Config;
 use Statamic\Facades\Entry;
 

--- a/tests/Http/Controllers/DigitalProducts/VerificationControllerEloquentTest.php
+++ b/tests/Http/Controllers/DigitalProducts/VerificationControllerEloquentTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\LicenseKey;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\UseDatabaseContentDrivers;
+use DuncanMcClean\SimpleCommerce\Facades\LicenseKey;
+use DuncanMcClean\SimpleCommerce\Orders\OrderModel;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\UseDatabaseContentDrivers;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Statamic\Facades\Collection;
 

--- a/tests/Http/Controllers/DigitalProducts/VerificationControllerEntriesTest.php
+++ b/tests/Http/Controllers/DigitalProducts/VerificationControllerEntriesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\LicenseKey;
+use DuncanMcClean\SimpleCommerce\Facades\LicenseKey;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 

--- a/tests/Listeners/EnforceEntryBlueprintFieldsTest.php
+++ b/tests/Listeners/EnforceEntryBlueprintFieldsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Listeners\EnforceEntryBlueprintFields;
+use DuncanMcClean\SimpleCommerce\Listeners\EnforceEntryBlueprintFields;
 use Statamic\Events\EntryBlueprintFound;
 use Statamic\Facades\Blueprint;
 

--- a/tests/Listeners/EnforceUserBlueprintFieldsTest.php
+++ b/tests/Listeners/EnforceUserBlueprintFieldsTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository;
-use DoubleThreeDigital\SimpleCommerce\Listeners\EnforceUserBlueprintFields;
+use DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository;
+use DuncanMcClean\SimpleCommerce\Listeners\EnforceUserBlueprintFields;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Statamic\Events\UserBlueprintFound;
@@ -18,8 +18,8 @@ test('fields can be added to user blueprint', function () {
     ]);
 
     Statamic::repository(
-        \DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository::class,
-        \DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository::class
+        \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
+        \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class
     );
 
     File::deleteDirectory(__DIR__.'/../__fixtures__/users');
@@ -35,8 +35,8 @@ test('fields can be added to user blueprint', function () {
     $this->assertTrue($handle->hasField('orders'));
 
     Statamic::repository(
-        \DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository::class,
-        \DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository::class
+        \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
+        \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class
     );
 });
 

--- a/tests/Listeners/SendConfiguredNotificationsTest.php
+++ b/tests/Listeners/SendConfiguredNotificationsTest.php
@@ -1,19 +1,19 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Events\OrderStatusUpdated;
-use DoubleThreeDigital\SimpleCommerce\Events\PaymentStatusUpdated;
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Listeners\SendConfiguredNotifications;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events\AnotherRandomEvent;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events\AnotherRandomEventNotification;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events\OrderDispatchedNotification;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events\OrderPlacedNotification;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events\PaymentRefundedNotification;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events\SomeRandomEvent;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events\SomeRandomEventNotification;
+use DuncanMcClean\SimpleCommerce\Events\OrderStatusUpdated;
+use DuncanMcClean\SimpleCommerce\Events\PaymentStatusUpdated;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Listeners\SendConfiguredNotifications;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events\AnotherRandomEvent;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events\AnotherRandomEventNotification;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events\OrderDispatchedNotification;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events\OrderPlacedNotification;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events\PaymentRefundedNotification;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events\SomeRandomEvent;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events\SomeRandomEventNotification;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Notification as NotificationFacade;
 

--- a/tests/Modifiers/CurrencyTest.php
+++ b/tests/Modifiers/CurrencyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Modifiers\Currency as CurrencyModifier;
+use DuncanMcClean\SimpleCommerce\Modifiers\Currency as CurrencyModifier;
 
 beforeEach(function () {
     $this->modifier = new CurrencyModifier;

--- a/tests/Orders/AddressTest.php
+++ b/tests/Orders/AddressTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Countries;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Regions;
+use DuncanMcClean\SimpleCommerce\Countries;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Regions;
 
 test('can get address as array', function () {
     $order = Order::make()

--- a/tests/Orders/Calculator/CalculateGrandTotalTest.php
+++ b/tests/Orders/Calculator/CalculateGrandTotalTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\Calculator\CalculateGrandTotal;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\Calculator\CalculateGrandTotal;
 use Illuminate\Support\Facades\Pipeline;
 
 uses()->group('calculator');

--- a/tests/Orders/Calculator/CalculateItemsTotalTest.php
+++ b/tests/Orders/Calculator/CalculateItemsTotalTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\Calculator\CalculateItemsTotal;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\Calculator\CalculateItemsTotal;
 use Illuminate\Support\Facades\Pipeline;
 
 uses()->group('calculator');

--- a/tests/Orders/Calculator/CalculatorTest.php
+++ b/tests/Orders/Calculator/CalculatorTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\Calculator\Calculator;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\Calculator\Calculator;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Support\Facades\Config;
 
 use function PHPUnit\Framework\assertTrue;

--- a/tests/Orders/Calculator/CouponCalculatorTest.php
+++ b/tests/Orders/Calculator/CouponCalculatorTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\Calculator\CouponCalculator;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\Calculator\CouponCalculator;
 use Illuminate\Support\Facades\Pipeline;
 
 uses()->group('calculator');

--- a/tests/Orders/Calculator/LineItemCalculatorTest.php
+++ b/tests/Orders/Calculator/LineItemCalculatorTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\Calculator\LineItemCalculator;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\Calculator\LineItemCalculator;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Support\Facades\Pipeline;
 
 uses()->group('calculator');

--- a/tests/Orders/Calculator/LineItemTaxCalculatorTest.php
+++ b/tests/Orders/Calculator/LineItemTaxCalculatorTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\Calculator\LineItemTaxCalculator;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\Calculator\LineItemTaxCalculator;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Pipeline;
 

--- a/tests/Orders/Calculator/ResetTotalsTest.php
+++ b/tests/Orders/Calculator/ResetTotalsTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\Calculator\ResetTotals;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\Calculator\ResetTotals;
 use Illuminate\Support\Facades\Pipeline;
 
 uses()->group('calculator');

--- a/tests/Orders/Calculator/ShippingCalculatorTest.php
+++ b/tests/Orders/Calculator/ShippingCalculatorTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\Calculator\ShippingCalculator;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods\Postage;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\Calculator\ShippingCalculator;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\ShippingMethods\Postage;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Pipeline;
 use Statamic\Facades\Site;

--- a/tests/Orders/Calculator/ShippingTaxCalculatorTest.php
+++ b/tests/Orders/Calculator/ShippingTaxCalculatorTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\Calculator\ShippingTaxCalculator;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods\Postage;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\Calculator\ShippingTaxCalculator;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\ShippingMethods\Postage;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Pipeline;
 use Statamic\Facades\Site;

--- a/tests/Orders/Checkout/HandleDigitalProductsTest.php
+++ b/tests/Orders/Checkout/HandleDigitalProductsTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Customer;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Notifications\DigitalDownloadsNotification;
-use DoubleThreeDigital\SimpleCommerce\Orders\Checkout\HandleDigitalProducts;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Notifications\DigitalDownloadsNotification;
+use DuncanMcClean\SimpleCommerce\Orders\Checkout\HandleDigitalProducts;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\Config;

--- a/tests/Orders/Checkout/UpdateProductStockTest.php
+++ b/tests/Orders/Checkout/UpdateProductStockTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Events\StockRunningLow;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\Checkout\UpdateProductStock;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Events\StockRunningLow;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\Checkout\UpdateProductStock;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;

--- a/tests/Orders/Checkout/ValidateProductStockTest.php
+++ b/tests/Orders/Checkout/ValidateProductStockTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Exceptions\CheckoutProductHasNoStockException;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\Checkout\ValidateProductStock;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Exceptions\CheckoutProductHasNoStockException;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\Checkout\ValidateProductStock;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Pipeline\Pipeline;
 
 uses(SetupCollections::class);

--- a/tests/Orders/EloquentOrderRepositoryTest.php
+++ b/tests/Orders/EloquentOrderRepositoryTest.php
@@ -1,16 +1,16 @@
 <?php
 
 use Carbon\Carbon;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\EloquentQueryBuilder;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderModel;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\UseDatabaseContentDrivers;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Exceptions\OrderNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\EloquentQueryBuilder;
+use DuncanMcClean\SimpleCommerce\Orders\OrderModel;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\UseDatabaseContentDrivers;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(SetupCollections::class);

--- a/tests/Orders/EntryOrderRepositoryTest.php
+++ b/tests/Orders/EntryOrderRepositoryTest.php
@@ -1,16 +1,16 @@
 <?php
 
 use Carbon\Carbon;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\OrderNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryOrderRepository;
-use DoubleThreeDigital\SimpleCommerce\Orders\EntryQueryBuilder;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\Invader;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\RefreshContent;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Exceptions\OrderNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\EntryOrderRepository;
+use DuncanMcClean\SimpleCommerce\Orders\EntryQueryBuilder;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\Invader;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\RefreshContent;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Spatie\TestTime\TestTime;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;

--- a/tests/Orders/LineItemsTest.php
+++ b/tests/Orders/LineItemsTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,10 +1,10 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\RefreshContent;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
-use DoubleThreeDigital\SimpleCommerce\Tests\TestCase;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\RefreshContent;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Session;
@@ -129,12 +129,12 @@ function fakeCart($cart = null)
 function setupUserCustomerRepository(): void
 {
     Config::set('simple-commerce.content.customers', [
-        'repository' => \DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository::class,
+        'repository' => \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class,
     ]);
 
     Statamic::repository(
-        \DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository::class,
-        \DoubleThreeDigital\SimpleCommerce\Customers\UserCustomerRepository::class
+        \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
+        \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class
     );
 
     File::deleteDirectory(__DIR__.'/../__fixtures__/users');
@@ -144,12 +144,12 @@ function setupUserCustomerRepository(): void
 function tearDownUserCustomerRepository(): void
 {
     Config::set('simple-commerce.content.customers', [
-        'repository' => \DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository::class,
+        'repository' => \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class,
         'collection' => 'customers',
     ]);
 
     Statamic::repository(
-        \DoubleThreeDigital\SimpleCommerce\Contracts\CustomerRepository::class,
-        \DoubleThreeDigital\SimpleCommerce\Customers\EntryCustomerRepository::class
+        \DuncanMcClean\SimpleCommerce\Contracts\CustomerRepository::class,
+        \DuncanMcClean\SimpleCommerce\Customers\EntryCustomerRepository::class
     );
 }

--- a/tests/Products/DigitalProducts/LicenseKeyRepositoryTest.php
+++ b/tests/Products/DigitalProducts/LicenseKeyRepositoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Products\DigitalProducts\LicenseKeyRepository;
+use DuncanMcClean\SimpleCommerce\Products\DigitalProducts\LicenseKeyRepository;
 
 $repository = app(LicenseKeyRepository::class);
 

--- a/tests/Products/EntryProductRepositoryTest.php
+++ b/tests/Products/EntryProductRepositoryTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Product as ProductContract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\ProductNotFound;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Products\EntryQueryBuilder;
+use DuncanMcClean\SimpleCommerce\Contracts\Product as ProductContract;
+use DuncanMcClean\SimpleCommerce\Exceptions\ProductNotFound;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Products\EntryQueryBuilder;
 
 it('can get all products', function () {
     Product::make()->id('one')->price(1500)->save();

--- a/tests/Rules/CountryExistsTest.php
+++ b/tests/Rules/CountryExistsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Rules\CountryExists;
+use DuncanMcClean\SimpleCommerce\Rules\CountryExists;
 use Illuminate\Support\Facades\Validator;
 
 it('passes for matching iso code', function () {

--- a/tests/Rules/ProductExistsTest.php
+++ b/tests/Rules/ProductExistsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Rules\ProductExists;
+use DuncanMcClean\SimpleCommerce\Rules\ProductExists;
 use Illuminate\Support\Facades\Validator;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Currency;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
-use DoubleThreeDigital\SimpleCommerce\Tags\CartTags;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Currency;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Facades\TaxRate;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\Tags\CartTags;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Session;
 use Statamic\Facades\Antlers;

--- a/tests/Tags/CheckoutTagTest.php
+++ b/tests/Tags/CheckoutTagTest.php
@@ -1,15 +1,15 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Tags\CheckoutTags;
-use DoubleThreeDigital\SimpleCommerce\Tags\GatewayTags;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Gateways\TestOffsiteGateway;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Gateways\TestOnsiteGateway;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Tags\CheckoutTags;
+use DuncanMcClean\SimpleCommerce\Tags\GatewayTags;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways\TestOffsiteGateway;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways\TestOnsiteGateway;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Support\Facades\Session;
 use Statamic\Facades\Antlers;

--- a/tests/Tags/Helpers/SimpleCommerceTag.php
+++ b/tests/Tags/Helpers/SimpleCommerceTag.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Tags\Helpers;
+namespace DuncanMcClean\SimpleCommerce\Tests\Tags\Helpers;
 
-use DoubleThreeDigital\SimpleCommerce\Tags\SimpleCommerceTag as Tag;
+use DuncanMcClean\SimpleCommerce\Tags\SimpleCommerceTag as Tag;
 
 class SimpleCommerceTag extends Tag
 {

--- a/tests/Tags/Helpers/TestTag.php
+++ b/tests/Tags/Helpers/TestTag.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Tags\Helpers;
+namespace DuncanMcClean\SimpleCommerce\Tests\Tags\Helpers;
 
-use DoubleThreeDigital\SimpleCommerce\Tags\SubTag;
+use DuncanMcClean\SimpleCommerce\Tags\SubTag;
 
 class TestTag extends SubTag
 {

--- a/tests/Tags/ShippingTagsTest.php
+++ b/tests/Tags/ShippingTagsTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Tags\ShippingTags;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods\DPD;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods\RoyalMail;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods\StorePickup;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\StaticCartDriver;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Tags\ShippingTags;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\ShippingMethods\DPD;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\ShippingMethods\RoyalMail;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\ShippingMethods\StorePickup;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\StaticCartDriver;
 use Statamic\Facades\Antlers;
 
 uses(SetupCollections::class);

--- a/tests/Tags/SimpleCommerceTagTest.php
+++ b/tests/Tags/SimpleCommerceTagTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Countries;
-use DoubleThreeDigital\SimpleCommerce\Currencies;
-use DoubleThreeDigital\SimpleCommerce\Regions;
-use DoubleThreeDigital\SimpleCommerce\Tests\Tags\Helpers\SimpleCommerceTag;
+use DuncanMcClean\SimpleCommerce\Countries;
+use DuncanMcClean\SimpleCommerce\Currencies;
+use DuncanMcClean\SimpleCommerce\Regions;
+use DuncanMcClean\SimpleCommerce\Tests\Tags\Helpers\SimpleCommerceTag;
 
 beforeEach(function () {
     SimpleCommerceTag::register();

--- a/tests/Tax/BasicTaxEngineTest.php
+++ b/tests/Tax/BasicTaxEngineTest.php
@@ -1,12 +1,12 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\OrderStatus;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Tax\BasicTaxEngine;
-use DoubleThreeDigital\SimpleCommerce\Tax\TaxCalculation;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods\DummyShippingMethod;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Tax\BasicTaxEngine;
+use DuncanMcClean\SimpleCommerce\Tax\TaxCalculation;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\ShippingMethods\DummyShippingMethod;
 use Illuminate\Support\Facades\Config;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Site;

--- a/tests/Tax/StandardTaxEngineTest.php
+++ b/tests/Tax/StandardTaxEngineTest.php
@@ -1,15 +1,15 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Exceptions\PreventCheckout;
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxCategory;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxRate;
-use DoubleThreeDigital\SimpleCommerce\Facades\TaxZone;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxEngine as StandardTaxEngine;
-use DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods\DummyShippingMethod;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Exceptions\PreventCheckout;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Facades\TaxCategory;
+use DuncanMcClean\SimpleCommerce\Facades\TaxRate;
+use DuncanMcClean\SimpleCommerce\Facades\TaxZone;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\TaxEngine as StandardTaxEngine;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\ShippingMethods\DummyShippingMethod;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Statamic\Facades\Site;

--- a/tests/TelemetryTest.php
+++ b/tests/TelemetryTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\Facades\Order;
-use DoubleThreeDigital\SimpleCommerce\Facades\Product;
-use DoubleThreeDigital\SimpleCommerce\Orders\PaymentStatus;
-use DoubleThreeDigital\SimpleCommerce\Telemetry;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\RefreshContent;
-use DoubleThreeDigital\SimpleCommerce\Tests\Helpers\SetupCollections;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Facades\Product;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\Telemetry;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\RefreshContent;
+use DuncanMcClean\SimpleCommerce\Tests\Helpers\SetupCollections;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
@@ -15,7 +15,7 @@ use function PHPUnit\Framework\assertFileDoesNotExist;
 use function PHPUnit\Framework\assertNotNull;
 use function PHPUnit\Framework\assertNotSame;
 
-uses(DoubleThreeDigital\SimpleCommerce\Tests\TestCase::class);
+uses(DuncanMcClean\SimpleCommerce\Tests\TestCase::class);
 uses(SetupCollections::class);
 uses(RefreshContent::class);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -122,6 +122,7 @@ abstract class TestCase extends OrchestraTestCase
             Blueprint::setDirectory(__DIR__.'/../resources/blueprints');
 
             AssetContainer::make('assets')->disk('test')->save();
+            AssetContainer::make('test')->disk('test')->save();
         });
 
         $this->ensureContentDirectoriesExist();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests;
+namespace DuncanMcClean\SimpleCommerce\Tests;
 
-use DoubleThreeDigital\SimpleCommerce\Orders\Cart\Drivers\SessionDriver;
-use DoubleThreeDigital\SimpleCommerce\ServiceProvider;
-use DoubleThreeDigital\SimpleCommerce\SimpleCommerce;
-use DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxEngine as StandardTaxEngine;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\SessionDriver;
+use DuncanMcClean\SimpleCommerce\ServiceProvider;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Tax\Standard\TaxEngine as StandardTaxEngine;
 use Facades\Statamic\Version;
 use Illuminate\Encryption\Encrypter;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
@@ -56,9 +56,9 @@ abstract class TestCase extends OrchestraTestCase
         parent::getEnvironmentSetUp($app);
 
         $app->make(Manifest::class)->manifest = [
-            'doublethreedigital/simple-commerce' => [
-                'id' => 'doublethreedigital/simple-commerce',
-                'namespace' => 'DoubleThreeDigital\\SimpleCommerce',
+            'duncanmcclean/simple-commerce' => [
+                'id' => 'duncanmcclean/simple-commerce',
+                'namespace' => 'DuncanMcClean\\SimpleCommerce',
             ],
         ];
     }
@@ -180,11 +180,11 @@ abstract class TestCase extends OrchestraTestCase
 
     protected function useBasicTaxEngine()
     {
-        SimpleCommerce::setTaxEngine(\DoubleThreeDigital\SimpleCommerce\Tax\BasicTaxEngine::class);
+        SimpleCommerce::setTaxEngine(\DuncanMcClean\SimpleCommerce\Tax\BasicTaxEngine::class);
     }
 
     protected function useStandardTaxEngine()
     {
-        SimpleCommerce::setTaxEngine(\DoubleThreeDigital\SimpleCommerce\Tax\Standard\TaxEngine::class);
+        SimpleCommerce::setTaxEngine(\DuncanMcClean\SimpleCommerce\Tax\Standard\TaxEngine::class);
     }
 }

--- a/tests/UpdateScripts/MigrateProductTypeTest.php
+++ b/tests/UpdateScripts/MigrateProductTypeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0\MigrateProductType;
+use DuncanMcClean\SimpleCommerce\UpdateScripts\v6_0\MigrateProductType;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -17,7 +17,7 @@ it('updates product_type field for physical product', function () {
 
     $productEntry->save();
 
-    (new MigrateProductType('doublethreedigital/simple-commerce', '6.0.0'))->update();
+    (new MigrateProductType('duncanmcclean/simple-commerce', '6.0.0'))->update();
 
     $productEntry->fresh();
 
@@ -32,7 +32,7 @@ it('updates product_type field for digital product', function () {
 
     $productEntry->save();
 
-    (new MigrateProductType('doublethreedigital/simple-commerce', '6.0.0'))->update();
+    (new MigrateProductType('duncanmcclean/simple-commerce', '6.0.0'))->update();
 
     $productEntry->fresh();
 
@@ -57,7 +57,7 @@ it('updates product_type field for digital product with variants', function () {
 
     $productEntry->save();
 
-    (new MigrateProductType('doublethreedigital/simple-commerce', '6.0.0'))->update();
+    (new MigrateProductType('duncanmcclean/simple-commerce', '6.0.0'))->update();
 
     $productEntry->fresh();
 
@@ -75,7 +75,7 @@ it('adds product type field and removes old digital product fields from product 
         ],
     ])->save();
 
-    (new MigrateProductType('doublethreedigital/simple-commerce', '6.0.0'))->update();
+    (new MigrateProductType('duncanmcclean/simple-commerce', '6.0.0'))->update();
 
     $blueprint = $collection->entryBlueprints()->where('handle', 'test')->first();
 
@@ -104,7 +104,7 @@ it('adds product type field and removes old digital product fields from variant 
         ],
     ])->save();
 
-    (new MigrateProductType('doublethreedigital/simple-commerce', '6.0.0'))->update();
+    (new MigrateProductType('duncanmcclean/simple-commerce', '6.0.0'))->update();
 
     $blueprint = $collection->entryBlueprints()->where('handle', 'test')->first();
 

--- a/tests/UpdateScripts/ReplaceOldVendorNameTest.php
+++ b/tests/UpdateScripts/ReplaceOldVendorNameTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use DuncanMcClean\SimpleCommerce\UpdateScripts\v6_0\ReplaceOldVendorName;
+use Illuminate\Support\Facades\File;
+
+it('updates product_type field for physical product', function () {
+    // Obviously, the contents aren't real PHP but all we need to test is that
+    // the string replacement works as expected.
+    File::shouldReceive('get')
+        ->with(config_path('simple-commerce.php'))
+        ->andReturn("\DoubleThreeDigital\SimpleCommerce\Shipping\FreeShipping::class // 'tax_engine' => \DoubleThreeDigital\SimpleCommerce\Tax\BasicTaxEngine::class");
+
+    File::shouldReceive('put')->with(
+        config_path('simple-commerce.php'),
+        "\DuncanMcClean\SimpleCommerce\Shipping\FreeShipping::class // 'tax_engine' => \DuncanMcClean\SimpleCommerce\Tax\BasicTaxEngine::class"
+    );
+
+    (new ReplaceOldVendorName('duncanmcclean/simple-commerce', '6.0.0'))->update();
+});

--- a/tests/UpdateScripts/UpdateClassReferencesTest.php
+++ b/tests/UpdateScripts/UpdateClassReferencesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0\UpdateClassReferences;
+use DuncanMcClean\SimpleCommerce\UpdateScripts\v6_0\UpdateClassReferences;
 use Statamic\Facades\Entry;
 
 it('updates reference to gateway class', function () {
@@ -11,7 +11,7 @@ it('updates reference to gateway class', function () {
 
     $orderEntry->save();
 
-    (new UpdateClassReferences('doublethreedigital/simple-commerce', '6.0.0'))->update();
+    (new UpdateClassReferences('duncanmcclean/simple-commerce', '6.0.0'))->update();
 
     $orderEntry->fresh();
 
@@ -30,7 +30,7 @@ it('updates reference to shipping method class', function () {
 
     $orderEntry->save();
 
-    (new UpdateClassReferences('doublethreedigital/simple-commerce', '6.0.0'))->update();
+    (new UpdateClassReferences('duncanmcclean/simple-commerce', '6.0.0'))->update();
 
     $orderEntry->fresh();
 

--- a/tests/UpdateScripts/UpdateCouponExpiryDateTest.php
+++ b/tests/UpdateScripts/UpdateCouponExpiryDateTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use Carbon\Carbon;
-use DoubleThreeDigital\SimpleCommerce\Facades\Coupon;
-use DoubleThreeDigital\SimpleCommerce\UpdateScripts\v6_0\UpdateCouponExpiryDate;
+use DuncanMcClean\SimpleCommerce\Facades\Coupon;
+use DuncanMcClean\SimpleCommerce\UpdateScripts\v6_0\UpdateCouponExpiryDate;
 use Spatie\TestTime\TestTime;
 
 it('sets the expiry date for a disabled coupon', function () {
@@ -18,7 +18,7 @@ it('sets the expiry date for a disabled coupon', function () {
 
     $coupon->save();
 
-    (new UpdateCouponExpiryDate('doublethreedigital/simple-commerce', '6.0.0'))->update();
+    (new UpdateCouponExpiryDate('duncanmcclean/simple-commerce', '6.0.0'))->update();
 
     $coupon->fresh();
 
@@ -38,7 +38,7 @@ it('does not set the expiry date for an enabled coupon', function () {
 
     $coupon->save();
 
-    (new UpdateCouponExpiryDate('doublethreedigital/simple-commerce', '6.0.0'))->update();
+    (new UpdateCouponExpiryDate('duncanmcclean/simple-commerce', '6.0.0'))->update();
 
     $coupon->fresh();
 
@@ -58,7 +58,7 @@ it('does not set the expiry date for an already expired coupon', function () {
 
     $coupon->save();
 
-    (new UpdateCouponExpiryDate('doublethreedigital/simple-commerce', '6.0.0'))->update();
+    (new UpdateCouponExpiryDate('duncanmcclean/simple-commerce', '6.0.0'))->update();
 
     $coupon->fresh();
 

--- a/tests/__fixtures__/app/Events/AnotherRandomEvent.php
+++ b/tests/__fixtures__/app/Events/AnotherRandomEvent.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
 
 class AnotherRandomEvent
 {

--- a/tests/__fixtures__/app/Events/AnotherRandomEventNotification.php
+++ b/tests/__fixtures__/app/Events/AnotherRandomEventNotification.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 

--- a/tests/__fixtures__/app/Events/OrderDispatchedNotification.php
+++ b/tests/__fixtures__/app/Events/OrderDispatchedNotification.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 

--- a/tests/__fixtures__/app/Events/OrderPlacedNotification.php
+++ b/tests/__fixtures__/app/Events/OrderPlacedNotification.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 

--- a/tests/__fixtures__/app/Events/PaymentRefundedNotification.php
+++ b/tests/__fixtures__/app/Events/PaymentRefundedNotification.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 

--- a/tests/__fixtures__/app/Events/SomeRandomEvent.php
+++ b/tests/__fixtures__/app/Events/SomeRandomEvent.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
 
 class SomeRandomEvent
 {

--- a/tests/__fixtures__/app/Events/SomeRandomEventNotification.php
+++ b/tests/__fixtures__/app/Events/SomeRandomEventNotification.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Events;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Events;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 

--- a/tests/__fixtures__/app/Gateways/FakeOffsiteGateway.php
+++ b/tests/__fixtures__/app/Gateways/FakeOffsiteGateway.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Gateways;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as ContractsOrder;
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as ContractsOrder;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
 use Illuminate\Http\Request;
 
 class FakeOffsiteGateway extends BaseGateway

--- a/tests/__fixtures__/app/Gateways/FakeOnsiteGateway.php
+++ b/tests/__fixtures__/app/Gateways/FakeOnsiteGateway.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Gateways;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as ContractsOrder;
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as ContractsOrder;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
 use Illuminate\Http\Request;
 
 class FakeOnsiteGateway extends BaseGateway

--- a/tests/__fixtures__/app/Gateways/TestCheckoutErrorGateway.php
+++ b/tests/__fixtures__/app/Gateways/TestCheckoutErrorGateway.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Gateways;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
-use DoubleThreeDigital\SimpleCommerce\Exceptions\GatewayCheckoutFailed;
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Gateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayCheckoutFailed;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
 use Illuminate\Http\Request;
 
 class TestCheckoutErrorGateway extends BaseGateway implements Gateway

--- a/tests/__fixtures__/app/Gateways/TestOffsiteGateway.php
+++ b/tests/__fixtures__/app/Gateways/TestOffsiteGateway.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Gateways;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Gateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
 use Illuminate\Http\Request;
 
 class TestOffsiteGateway extends BaseGateway implements Gateway

--- a/tests/__fixtures__/app/Gateways/TestOnsiteGateway.php
+++ b/tests/__fixtures__/app/Gateways/TestOnsiteGateway.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Gateways;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Gateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
 use Illuminate\Http\Request;
 
 class TestOnsiteGateway extends BaseGateway implements Gateway

--- a/tests/__fixtures__/app/Gateways/TestValidationGateway.php
+++ b/tests/__fixtures__/app/Gateways/TestValidationGateway.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Gateways;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Gateway;
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
-use DoubleThreeDigital\SimpleCommerce\Gateways\BaseGateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Gateway;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
 use Illuminate\Http\Request;
 
 class TestValidationGateway extends BaseGateway implements Gateway

--- a/tests/__fixtures__/app/Http/Requests/CartItemStoreFormRequest.php
+++ b/tests/__fixtures__/app/Http/Requests/CartItemStoreFormRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Http\Requests;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/tests/__fixtures__/app/Http/Requests/CartItemUpdateFormRequest.php
+++ b/tests/__fixtures__/app/Http/Requests/CartItemUpdateFormRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Http\Requests;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/tests/__fixtures__/app/Http/Requests/CartUpdateFormRequest.php
+++ b/tests/__fixtures__/app/Http/Requests/CartUpdateFormRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Http\Requests;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/tests/__fixtures__/app/Http/Requests/CartUpdateWithNoRulesFormRequest.php
+++ b/tests/__fixtures__/app/Http/Requests/CartUpdateWithNoRulesFormRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Http\Requests;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/tests/__fixtures__/app/Http/Requests/CheckoutFormRequest.php
+++ b/tests/__fixtures__/app/Http/Requests/CheckoutFormRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Http\Requests;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/tests/__fixtures__/app/Http/Requests/CustomerUpdateFormRequest.php
+++ b/tests/__fixtures__/app/Http/Requests/CustomerUpdateFormRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\Http\Requests;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/tests/__fixtures__/app/ShippingMethods/DPD.php
+++ b/tests/__fixtures__/app/ShippingMethods/DPD.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\ShippingMethods;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
-use DoubleThreeDigital\SimpleCommerce\Orders\Address;
-use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\ShippingMethod;
+use DuncanMcClean\SimpleCommerce\Orders\Address;
+use DuncanMcClean\SimpleCommerce\Shipping\BaseShippingMethod;
 
 class DPD extends BaseShippingMethod implements ShippingMethod
 {

--- a/tests/__fixtures__/app/ShippingMethods/DummyShippingMethod.php
+++ b/tests/__fixtures__/app/ShippingMethods/DummyShippingMethod.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\ShippingMethods;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
-use DoubleThreeDigital\SimpleCommerce\Orders\Address;
-use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\ShippingMethod;
+use DuncanMcClean\SimpleCommerce\Orders\Address;
+use DuncanMcClean\SimpleCommerce\Shipping\BaseShippingMethod;
 
 class DummyShippingMethod extends BaseShippingMethod implements ShippingMethod
 {

--- a/tests/__fixtures__/app/ShippingMethods/Postage.php
+++ b/tests/__fixtures__/app/ShippingMethods/Postage.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\ShippingMethods;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order as OrderContract;
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
-use DoubleThreeDigital\SimpleCommerce\Orders\Address;
-use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
+use DuncanMcClean\SimpleCommerce\Contracts\Order as OrderContract;
+use DuncanMcClean\SimpleCommerce\Contracts\ShippingMethod;
+use DuncanMcClean\SimpleCommerce\Orders\Address;
+use DuncanMcClean\SimpleCommerce\Shipping\BaseShippingMethod;
 
 class Postage extends BaseShippingMethod implements ShippingMethod
 {

--- a/tests/__fixtures__/app/ShippingMethods/RoyalMail.php
+++ b/tests/__fixtures__/app/ShippingMethods/RoyalMail.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\ShippingMethods;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
-use DoubleThreeDigital\SimpleCommerce\Orders\Address;
-use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\ShippingMethod;
+use DuncanMcClean\SimpleCommerce\Orders\Address;
+use DuncanMcClean\SimpleCommerce\Shipping\BaseShippingMethod;
 
 class RoyalMail extends BaseShippingMethod implements ShippingMethod
 {

--- a/tests/__fixtures__/app/ShippingMethods/StorePickup.php
+++ b/tests/__fixtures__/app/ShippingMethods/StorePickup.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\SimpleCommerce\Tests\Fixtures\ShippingMethods;
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\ShippingMethods;
 
-use DoubleThreeDigital\SimpleCommerce\Contracts\Order;
-use DoubleThreeDigital\SimpleCommerce\Contracts\ShippingMethod;
-use DoubleThreeDigital\SimpleCommerce\Orders\Address;
-use DoubleThreeDigital\SimpleCommerce\Shipping\BaseShippingMethod;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Contracts\ShippingMethod;
+use DuncanMcClean\SimpleCommerce\Orders\Address;
+use DuncanMcClean\SimpleCommerce\Shipping\BaseShippingMethod;
 
 class StorePickup extends BaseShippingMethod implements ShippingMethod
 {


### PR DESCRIPTION
This pull request changes the package namespace from `DoubleThreeDigital` to `DuncanMcClean`.

Double Three Digital is the name of my company but I've moved all of my other addons over to my name because people know & trust my name, rather than Double Three, which people don't know.

I've made this change on all my other addons but I'm only just doing it now since it's require a breaking change and it was too tight for me to do it for v5. 

## Breaking Changes

Obviously, changing the package's namespace means code **will** need updating in sites running Simple Commerce.

There is an update script which *should* replace references to `DoubleThreeDigital` to `DuncanMcClean` in a site's `simple-commerce` config file.

However, any custom code developers have which touches Simple Commerce will need to be updated. 