### PR TITLE
[6.x] Fixes for database orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v6.0.2 (2024-02-11)
+
+### What's fixed
+* Fixed errors in some of the update scripts
+* Fixed some issues with the default blueprints
+
+### What's improved
+* Refreshed the upgrade guide
+* Tidied up some of the comments in the config file
+
+
+
 ## v6.0.1 (2024-02-11)
 
 ### What's fixed

--- a/src/Console/Commands/SwitchToDatabase.php
+++ b/src/Console/Commands/SwitchToDatabase.php
@@ -80,12 +80,12 @@ class SwitchToDatabase extends Command
 
         File::ensureDirectoryExists(resource_path('blueprints/vendor/runway'));
 
-        if (! File::exists(resource_path('blueprints/vendor/runway/customer.yaml'))) {
-            File::copy($this->stubsPath.'/runway_customer_blueprint.yaml', resource_path('blueprints/vendor/runway/customer.yaml'));
+        if (! File::exists(resource_path('blueprints/vendor/runway/customers.yaml'))) {
+            File::copy($this->stubsPath.'/runway_customer_blueprint.yaml', resource_path('blueprints/vendor/runway/customers.yaml'));
         }
 
-        if (! File::exists(resource_path('blueprints/vendor/runway/order.yaml'))) {
-            File::copy($this->stubsPath.'/runway_order_blueprint.yaml', resource_path('blueprints/vendor/runway/order.yaml'));
+        if (! File::exists(resource_path('blueprints/vendor/runway/orders.yaml'))) {
+            File::copy($this->stubsPath.'/runway_order_blueprint.yaml', resource_path('blueprints/vendor/runway/orders.yaml'));
         }
 
         return $this;

--- a/src/Fieldtypes/GatewayFieldtype.php
+++ b/src/Fieldtypes/GatewayFieldtype.php
@@ -57,7 +57,7 @@ class GatewayFieldtype extends Fieldtype
             $orderModel = SimpleCommerce::orderDriver()['model'];
 
             $actionUrl = cp_route('runway.actions.run', [
-                'resourceHandle' => Runway::orderModel()->handle(),
+                'resource' => Runway::orderModel()->handle(),
             ]);
         }
 

--- a/src/Orders/OrderModel.php
+++ b/src/Orders/OrderModel.php
@@ -45,7 +45,7 @@ class OrderModel extends Model
     {
         return Attribute::make(
             get: function () {
-                return $this->statusLog()
+                return $this->statusLog
                     ->where('status', OrderStatus::Placed)
                     ->map->date()
                     ->last();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -325,7 +325,7 @@ class ServiceProvider extends AddonServiceProvider
 
                 $nav->create(__('Orders'))
                     ->section(__('Simple Commerce'))
-                    ->route('runway.index', ['resourceHandle' => $orderResource->handle()])
+                    ->route('runway.index', ['resource' => $orderResource->handle()])
                     ->can('view', $orderResource)
                     ->icon(SimpleCommerce::svg('shop'));
             }
@@ -354,7 +354,7 @@ class ServiceProvider extends AddonServiceProvider
 
                 $nav->create(__('Customers'))
                     ->section(__('Simple Commerce'))
-                    ->route('runway.index', ['resourceHandle' => $customerResource->handle()])
+                    ->route('runway.index', ['resource' => $customerResource->handle()])
                     ->can('view', $customerResource)
                     ->icon('user');
             }

--- a/src/Widgets/OrdersChart.php
+++ b/src/Widgets/OrdersChart.php
@@ -21,7 +21,7 @@ class OrdersChart extends Widget
         if ((new self)->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EntryOrderRepository::class)) {
             $indexUrl = cp_route('collections.show', SimpleCommerce::orderDriver()['collection']);
         } elseif ((new self)->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EloquentOrderRepository::class)) {
-            $indexUrl = cp_route('runway.index', ['resourceHandle' => Runway::orderModel()->handle()]);
+            $indexUrl = cp_route('runway.index', ['resource' => Runway::orderModel()->handle()]);
         }
 
         $timePeriod = CarbonPeriod::create(Carbon::now()->subDays(30)->format('Y-m-d'), Carbon::now()->format('Y-m-d'));

--- a/src/Widgets/RecentOrders.php
+++ b/src/Widgets/RecentOrders.php
@@ -51,7 +51,7 @@ class RecentOrders extends Widget
         }
 
         if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EloquentOrderRepository::class)) {
-            return cp_route('runway.index', ['resourceHandle' => Runway::orderModel()->handle()]);
+            return cp_route('runway.index', ['resource' => Runway::orderModel()->handle()]);
         }
     }
 
@@ -63,7 +63,7 @@ class RecentOrders extends Widget
 
         if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EloquentOrderRepository::class)) {
             return cp_route('runway.edit', [
-                'resourceHandle' => Runway::orderModel()->handle(),
+                'resource' => Runway::orderModel()->handle(),
                 'record' => $order->resource()->{$order->getRouteKeyName()},
             ]);
         }

--- a/src/Widgets/RecentOrders.php
+++ b/src/Widgets/RecentOrders.php
@@ -31,8 +31,8 @@ class RecentOrders extends Widget
                     'edit_url' => $this->getEditUrl($order),
                     'date' => $order->statusLog()
                         ->filter(fn (StatusLogEvent $statusLogEvent) => $statusLogEvent->status->is(PaymentStatus::Paid))
-                        ->last()
-                        ->date()
+                        ->first()
+                        ?->date()
                         ->format(config('statamic.system.date_format')),
                 ];
             })
@@ -64,7 +64,7 @@ class RecentOrders extends Widget
         if ($this->isOrExtendsClass(SimpleCommerce::orderDriver()['repository'], EloquentOrderRepository::class)) {
             return cp_route('runway.edit', [
                 'resource' => Runway::orderModel()->handle(),
-                'record' => $order->resource()->{$order->getRouteKeyName()},
+                'model' => $order->resource()->{$order->resource()->getRouteKeyName()},
             ]);
         }
     }

--- a/src/Widgets/TopCustomers.php
+++ b/src/Widgets/TopCustomers.php
@@ -70,7 +70,7 @@ class TopCustomers extends Widget
         }
 
         if ((new self)->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], EloquentCustomerRepository::class)) {
-            return cp_route('runway.index', ['resourceHandle' => Runway::customerModel()->handle()]);
+            return cp_route('runway.index', ['resource' => Runway::customerModel()->handle()]);
         }
 
         if ((new self)->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], UserCustomerRepository::class)) {

--- a/tests/Orders/EloquentOrderRepositoryTest.php
+++ b/tests/Orders/EloquentOrderRepositoryTest.php
@@ -103,7 +103,7 @@ it('can query orders', function () {
     ]);
 
     $orderModelC->statusLog()->create(['status' => 'placed', 'timestamp' => Carbon::parse('2024-01-27 15:00:00')->timestamp, 'data' => []]);
-    $orderModelC->statusLog()->create(['status' => 'paid', 'timestamp' => Carbon::parse('2024-01-27 15:00:00')->timestamp, 'data' => []]);
+    $orderModelC->statusLog()->create(['status' => 'paid', 'timestamp' => Carbon::parse('2024-01-27 15:20:00')->timestamp, 'data' => []]);
     $orderModelC->statusLog()->create(['status' => 'dispatched', 'timestamp' => Carbon::parse('2024-01-29 12:12:12')->timestamp, 'data' => []]);
 
     // Ensure all 3 orders are returned when we're not doing any filtering.
@@ -135,6 +135,16 @@ it('can query orders', function () {
 
     // Query by status log timestamps
     $query = Order::query()->whereStatusLogDate(PaymentStatus::Paid, Carbon::parse('2024-01-27')); // b & c
+    expect($query->count())->toBe(2);
+    expect($query->get()[0])
+        ->toBeInstanceOf(OrderContract::class)
+        ->and($query->get()[0]->orderNumber())->toBe(1003);
+    expect($query->get()[1])
+        ->toBeInstanceOf(OrderContract::class)
+        ->and($query->get()[1]->orderNumber())->toBe(1004);
+
+    // Order orders by status log timestamps
+    $query = Order::query()->wherePaymentStatus(PaymentStatus::Paid)->orderBy('status_log->paid', 'desc');
     expect($query->count())->toBe(2);
     expect($query->get()[0])
         ->toBeInstanceOf(OrderContract::class)

--- a/tests/Orders/EntryOrderRepositoryTest.php
+++ b/tests/Orders/EntryOrderRepositoryTest.php
@@ -60,7 +60,7 @@ it('can query orders', function () {
         ->paymentStatus(PaymentStatus::Paid)
         ->set('status_log', [
             ['status' => 'placed', 'timestamp' => Carbon::parse('2024-01-27 15:00:00')->timestamp, 'data' => []],
-            ['status' => 'paid', 'timestamp' => Carbon::parse('2024-01-27 15:00:00')->timestamp, 'data' => []],
+            ['status' => 'paid', 'timestamp' => Carbon::parse('2024-01-27 15:20:00')->timestamp, 'data' => []],
             ['status' => 'dispatched', 'timestamp' => Carbon::parse('2024-01-29 12:12:12')->timestamp, 'data' => []],
         ])
         ->save();
@@ -94,6 +94,16 @@ it('can query orders', function () {
 
     // Query by status log timestamps
     $query = Order::query()->whereStatusLogDate(PaymentStatus::Paid, Carbon::parse('2024-01-27'));
+    expect($query->count())->toBe(2);
+    expect($query->get()[0])
+        ->toBeInstanceOf(OrderContract::class)
+        ->and($query->get()[0]->id())->toBe('two');
+    expect($query->get()[1])
+        ->toBeInstanceOf(OrderContract::class)
+        ->and($query->get()[1]->id())->toBe('three');
+
+    // Order orders by status log timestamps
+    $query = Order::query()->wherePaymentStatus(PaymentStatus::Paid)->orderBy('status_log->paid', 'desc');
     expect($query->count())->toBe(2);
     expect($query->get()[0])
         ->toBeInstanceOf(OrderContract::class)


### PR DESCRIPTION
This pull request aims to fix a few issues with Database Orders & v6:

* Fixed incorrect Runway route bindings
* Refactored the ordering behind the "Recent Orders" widget
* Fixes order & customer blueprints being published with the wrong filename
* Fixed query in `orderDate` attribute

Closes #980.