### PR TITLE
[6.x] Fix querying `data` in Eloquent Query Builders

### DIFF
--- a/src/Customers/EloquentQueryBuilder.php
+++ b/src/Customers/EloquentQueryBuilder.php
@@ -3,6 +3,8 @@
 namespace DuncanMcClean\SimpleCommerce\Customers;
 
 use DuncanMcClean\SimpleCommerce\Facades\Customer;
+use Illuminate\Support\Facades\Schema;
+use Statamic\Facades\Blink;
 use Statamic\Query\EloquentQueryBuilder as QueryEloquentQueryBuilder;
 
 class EloquentQueryBuilder extends QueryEloquentQueryBuilder
@@ -18,6 +20,23 @@ class EloquentQueryBuilder extends QueryEloquentQueryBuilder
             return $this->builder->getModel()->getKeyName();
         }
 
+        if (! $this->columnExists($column)) {
+            $column = "data->{$column}";
+        }
+
         return $column;
+    }
+
+    protected function columnExists(string $column): bool
+    {
+        $databaseColumns = Blink::once("DatabaseColumns_{$this->builder->getModel()->getTable()}", function () {
+            $columns = Schema::getConnection()
+                ->getDoctrineSchemaManager()
+                ->listTableColumns($this->builder->getModel()->getTable());
+
+            return collect($columns)->map->getName()->values();
+        });
+
+        return $databaseColumns->contains($column);
     }
 }

--- a/src/Orders/EloquentQueryBuilder.php
+++ b/src/Orders/EloquentQueryBuilder.php
@@ -26,15 +26,7 @@ class EloquentQueryBuilder extends QueryEloquentQueryBuilder
             return 'customer_id';
         }
 
-        $databaseColumns = Blink::once("DatabaseColumns_{$this->builder->getModel()->getTable()}", function () {
-            $columns = Schema::getConnection()
-                ->getDoctrineSchemaManager()
-                ->listTableColumns($this->builder->getModel()->getTable());
-
-            return collect($columns)->map->getName()->values();
-        });
-
-        if (! $databaseColumns->contains($column)) {
+        if (! $this->columnExists($column)) {
             $column = "data->{$column}";
         }
 
@@ -80,5 +72,18 @@ class EloquentQueryBuilder extends QueryEloquentQueryBuilder
                 ->where('status', $status->value)
                 ->whereDate('timestamp', $date->format('Y-m-d'));
         });
+    }
+
+    protected function columnExists(string $column): bool
+    {
+        $databaseColumns = Blink::once("DatabaseColumns_{$this->builder->getModel()->getTable()}", function () {
+            $columns = Schema::getConnection()
+                ->getDoctrineSchemaManager()
+                ->listTableColumns($this->builder->getModel()->getTable());
+
+            return collect($columns)->map->getName()->values();
+        });
+
+        return $databaseColumns->contains($column);
     }
 }

--- a/src/Orders/EloquentQueryBuilder.php
+++ b/src/Orders/EloquentQueryBuilder.php
@@ -4,7 +4,9 @@ namespace DuncanMcClean\SimpleCommerce\Orders;
 
 use Carbon\Carbon;
 use DuncanMcClean\SimpleCommerce\Facades\Order;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Statamic\Facades\Blink;
 use Statamic\Query\EloquentQueryBuilder as QueryEloquentQueryBuilder;
 
 class EloquentQueryBuilder extends QueryEloquentQueryBuilder
@@ -22,6 +24,18 @@ class EloquentQueryBuilder extends QueryEloquentQueryBuilder
 
         if ($column === 'customer') {
             return 'customer_id';
+        }
+
+        $databaseColumns = Blink::once("DatabaseColumns_{$this->builder->getModel()->getTable()}", function () {
+            $columns = Schema::getConnection()
+                ->getDoctrineSchemaManager()
+                ->listTableColumns($this->builder->getModel()->getTable());
+
+            return collect($columns)->map->getName()->values();
+        });
+
+        if (! $databaseColumns->contains($column)) {
+            $column = "data->{$column}";
         }
 
         return $column;

--- a/tests/Customers/EloquentCustomerRepositoryTest.php
+++ b/tests/Customers/EloquentCustomerRepositoryTest.php
@@ -61,6 +61,12 @@ it('can query customers', function () {
     $query = Customer::query()->where('email', 'cj@whitehouse.gov');
     expect($query->count())->toBe(1);
     expect($query->get()[0])->toBeInstanceOf(CustomerContract::class);
+
+    $query = Customer::query()->where('role', 'Press Secretary');
+    expect($query->count())->toBe(1);
+    expect($query->get()[0])
+        ->toBeInstanceOf(CustomerContract::class)
+        ->and($query->get()[0]->email())->toBe('cj@whitehouse.gov');
 });
 
 it('can find customer by id', function () {

--- a/tests/Customers/EntryCustomerRepositoryTest.php
+++ b/tests/Customers/EntryCustomerRepositoryTest.php
@@ -29,7 +29,7 @@ it('can get all customers', function () {
 });
 
 it('can query customers', function () {
-    Customer::make()->email('cj.cregg@whitehouse.gov')->save();
+    Customer::make()->email('cj.cregg@whitehouse.gov')->set('role', 'Press Secretary')->save();
     Customer::make()->email('leo.mcgary@whitehouse.gov')->save();
     Customer::make()->email('sam.seaborne@whitehouse.gov')->save();
 
@@ -40,6 +40,12 @@ it('can query customers', function () {
     $query = Customer::query()->where('email', 'cj.cregg@whitehouse.gov');
     expect($query->count())->toBe(1);
     expect($query->get()[0])->toBeInstanceOf(CustomerContract::class);
+
+    $query = Customer::query()->where('role', 'Press Secretary');
+    expect($query->count())->toBe(1);
+    expect($query->get()[0])
+        ->toBeInstanceOf(CustomerContract::class)
+        ->and($query->get()[0]->email())->toBe('cj.cregg@whitehouse.gov');
 });
 
 it('can find customer by id', function () {

--- a/tests/Customers/UserCustomerRepositoryTest.php
+++ b/tests/Customers/UserCustomerRepositoryTest.php
@@ -46,7 +46,7 @@ test('can get all customers', function () {
 });
 
 test('can query customers', function () {
-    User::make()->email('james@example.com')->save();
+    User::make()->email('james@example.com')->set('role', 'Press Secretary')->save();
     User::make()->email('ben@example.com')->save();
 
     $query = Customer::query();
@@ -56,6 +56,12 @@ test('can query customers', function () {
     $query = Customer::query()->where('email', 'james@example.com');
     expect($query->count())->toBe(1);
     expect($query->get()[0])->toBeInstanceOf(CustomerContract::class);
+
+    $query = Customer::query()->where('role', 'Press Secretary');
+    expect($query->count())->toBe(1);
+    expect($query->get()[0])
+        ->toBeInstanceOf(CustomerContract::class)
+        ->and($query->get()[0]->email())->toBe('james@example.com');
 });
 
 test('can find customer by id', function () {

--- a/tests/Orders/EloquentOrderRepositoryTest.php
+++ b/tests/Orders/EloquentOrderRepositoryTest.php
@@ -72,7 +72,7 @@ it('can query orders', function () {
         'items' => [
             ['product' => $productOne->id(), 'quantity' => 1, 'total' => 1000],
         ],
-        'data' => ['foo' => 'bar'],
+        'data' => ['foo' => 'bar', 'hello' => 'world'],
     ]);
 
     $orderModelA->statusLog()->create(['status' => 'cart', 'timestamp' => Carbon::parse('2024-01-27 15:00:00')->timestamp, 'data' => []]);
@@ -85,7 +85,7 @@ it('can query orders', function () {
         'items' => [
             ['product' => $productTwo->id(), 'quantity' => 1, 'total' => 1000],
         ],
-        'data' => ['boo' => 'foo'],
+        'data' => ['boo' => 'foo', 'hello' => 'universe'],
     ]);
 
     $orderModelB->statusLog()->create(['status' => 'placed', 'timestamp' => Carbon::parse('2024-01-27 15:00:00')->timestamp, 'data' => []]);
@@ -99,7 +99,7 @@ it('can query orders', function () {
             ['product' => $productOne->id(), 'quantity' => 1, 'total' => 1000],
             ['product' => $productTwo->id(), 'quantity' => 1, 'total' => 1000],
         ],
-        'data' => ['baz' => 'fax'],
+        'data' => ['baz' => 'fax', 'hello' => 'world'],
     ]);
 
     $orderModelC->statusLog()->create(['status' => 'placed', 'timestamp' => Carbon::parse('2024-01-27 15:00:00')->timestamp, 'data' => []]);
@@ -129,6 +129,16 @@ it('can query orders', function () {
     expect($query->get()[0])
         ->toBeInstanceOf(OrderContract::class)
         ->and($query->get()[0]->orderNumber())->toBe(1003);
+    expect($query->get()[1])
+        ->toBeInstanceOf(OrderContract::class)
+        ->and($query->get()[1]->orderNumber())->toBe(1004);
+
+    // Ensure we can query by data
+    $query = Order::query()->where('hello', 'world');
+    expect($query->count())->toBe(2);
+    expect($query->get()[0])
+        ->toBeInstanceOf(OrderContract::class)
+        ->and($query->get()[0]->orderNumber())->toBe(1002);
     expect($query->get()[1])
         ->toBeInstanceOf(OrderContract::class)
         ->and($query->get()[1]->orderNumber())->toBe(1004);

--- a/tests/Orders/EntryOrderRepositoryTest.php
+++ b/tests/Orders/EntryOrderRepositoryTest.php
@@ -42,6 +42,7 @@ it('can query orders', function () {
         ->set('status_log', [
             ['status' => 'cart', 'timestamp' => Carbon::parse('2024-01-27 15:00:00')->timestamp, 'data' => []],
         ])
+        ->set('hello', 'world')
         ->save();
 
     Order::make()
@@ -52,6 +53,7 @@ it('can query orders', function () {
             ['status' => 'placed', 'timestamp' => Carbon::parse('2024-01-27 15:00:00')->timestamp, 'data' => []],
             ['status' => 'paid', 'timestamp' => Carbon::parse('2024-01-27 17:55:00')->timestamp, 'data' => []],
         ])
+        ->set('hello', 'universe')
         ->save();
 
     Order::make()
@@ -63,6 +65,7 @@ it('can query orders', function () {
             ['status' => 'paid', 'timestamp' => Carbon::parse('2024-01-27 15:20:00')->timestamp, 'data' => []],
             ['status' => 'dispatched', 'timestamp' => Carbon::parse('2024-01-29 12:12:12')->timestamp, 'data' => []],
         ])
+        ->set('hello', 'world')
         ->save();
 
     // Ensure all 3 orders are returned when we're not doing any filtering.
@@ -88,6 +91,16 @@ it('can query orders', function () {
     expect($query->get()[0])
         ->toBeInstanceOf(OrderContract::class)
         ->and($query->get()[0]->id())->toBe('two');
+    expect($query->get()[1])
+        ->toBeInstanceOf(OrderContract::class)
+        ->and($query->get()[1]->id())->toBe('three');
+
+    // Ensure we can query by data
+    $query = Order::query()->where('hello', 'world');
+    expect($query->count())->toBe(2);
+    expect($query->get()[0])
+        ->toBeInstanceOf(OrderContract::class)
+        ->and($query->get()[0]->id())->toBe('one');
     expect($query->get()[1])
         ->toBeInstanceOf(OrderContract::class)
         ->and($query->get()[1]->id())->toBe('three');


### PR DESCRIPTION
This pull request fixes an issue where queries like `Order::query()->where('hello', 'world')->get()` would error when using Database Orders.

This was happening since the query builders were querying as if `hello` was a *real* column. However, we store a lot of things inside the `data` JSON column.

This PR fixes that for both the order & customer query builders to ensure if a column doesn't exist matching the provided column name, it'll instead query against the `data` column.

Fixes #1002.