### PR TITLE
[6.x] Refactor code expecting NotFound exceptions to be thrown

### DIFF
--- a/src/Customers/Customer.php
+++ b/src/Customers/Customer.php
@@ -4,7 +4,6 @@ namespace DuncanMcClean\SimpleCommerce\Customers;
 
 use DuncanMcClean\SimpleCommerce\Contracts\Customer as Contract;
 use DuncanMcClean\SimpleCommerce\Data\HasData;
-use DuncanMcClean\SimpleCommerce\Exceptions\OrderNotFound;
 use DuncanMcClean\SimpleCommerce\Facades\Customer as CustomerFacade;
 use DuncanMcClean\SimpleCommerce\Facades\Order;
 use DuncanMcClean\SimpleCommerce\Http\Resources\BaseResource;
@@ -82,11 +81,7 @@ class Customer implements Contract
         $orders = $this->get('orders', []);
 
         return collect($orders)->map(function ($orderId) {
-            try {
-                return Order::find($orderId);
-            } catch (OrderNotFound $e) {
-                return null;
-            }
+            return Order::find($orderId);
         })->filter()->values();
     }
 

--- a/src/Orders/Cart/Drivers/CookieDriver.php
+++ b/src/Orders/Cart/Drivers/CookieDriver.php
@@ -31,7 +31,7 @@ class CookieDriver implements CartDriver
         }
 
         try {
-            return OrderAPI::find($this->getCartKey());
+            return OrderAPI::findOrFail($this->getCartKey());
         } catch (OrderNotFound $e) {
             return $this->makeCart();
         }

--- a/src/Orders/Cart/Drivers/SessionDriver.php
+++ b/src/Orders/Cart/Drivers/SessionDriver.php
@@ -25,7 +25,7 @@ class SessionDriver implements CartDriver
         }
 
         try {
-            return OrderAPI::find($this->getCartKey());
+            return OrderAPI::findOrFail($this->getCartKey());
         } catch (OrderNotFound $e) {
             return $this->makeCart();
         }

--- a/src/Orders/LineItem.php
+++ b/src/Orders/LineItem.php
@@ -3,7 +3,6 @@
 namespace DuncanMcClean\SimpleCommerce\Orders;
 
 use DuncanMcClean\SimpleCommerce\Contracts\Product;
-use DuncanMcClean\SimpleCommerce\Exceptions\ProductNotFound;
 use DuncanMcClean\SimpleCommerce\Facades\Product as ProductFacade;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
@@ -46,11 +45,7 @@ class LineItem
                     return $product;
                 }
 
-                try {
-                    return ProductFacade::find($product);
-                } catch (ProductNotFound $e) {
-                    return null;
-                }
+                return ProductFacade::find($product);
             })
             ->args(func_get_args());
     }


### PR DESCRIPTION
This pull request slightly refactors some code which expects the repository `find` method to throw `...NotFound` exceptions.

However, after #990, they'll return `null` instead and exceptions will only be thrown when using the specific `findOrFail` method.

Fixes #1005.