### PR TITLE
[6.x] Fix error when redirecting back from off-site gateways

### DIFF
--- a/src/Http/Controllers/GatewayCallbackController.php
+++ b/src/Http/Controllers/GatewayCallbackController.php
@@ -35,7 +35,7 @@ class GatewayCallbackController extends BaseActionController
         }
 
         try {
-            $callbackSuccess = Gateway::use($gateway['class'])->callback($request);
+            $callbackSuccess = Gateway::use($gateway['handle'])->callback($request);
         } catch (GatewayCallbackMethodDoesNotExist $e) {
             $callbackSuccess = $order->paymentStatus() === PaymentStatus::Paid;
         }

--- a/tests/Http/Controllers/GatewayCallbackControllerTest.php
+++ b/tests/Http/Controllers/GatewayCallbackControllerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayDoesNotExist;
+use DuncanMcClean\SimpleCommerce\Facades\Order;
+use DuncanMcClean\SimpleCommerce\Orders\OrderStatus;
+use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways\CallbackTestGateway;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\withoutExceptionHandling;
+use function Pest\Laravel\withSession;
+
+it('handles a successful callback response from the gateway', function () {
+    CallbackTestGateway::$expectedCallbackResult = true;
+    SimpleCommerce::registerGateway(CallbackTestGateway::class, []);
+
+    $order = Order::make()->id('abc')->save();
+    $order->save();
+
+    withSession(['simple-commerce-cart' => 'abc'])
+        ->get('/!/simple-commerce/gateways/callback_test/callback?_redirect=/order-complete')
+        ->assertSessionMissing('simple-commerce-cart')
+        ->assertSessionHas('simple-commerce.checkout.success')
+        ->assertRedirect('/order-complete');
+
+    expect($order->fresh()->status())->toBe(OrderStatus::Placed);
+
+    CallbackTestGateway::$expectedCallbackResult = null;
+});
+
+it('handles an unsuccessful callback response from the gateway', function () {
+    CallbackTestGateway::$expectedCallbackResult = false;
+    SimpleCommerce::registerGateway(CallbackTestGateway::class, []);
+
+    $order = Order::make()->id('abc')->save();
+    $order->save();
+
+    withSession(['simple-commerce-cart' => 'abc'])
+        ->get('/!/simple-commerce/gateways/callback_test/callback?_error_redirect=/payment-failed')
+        ->assertSessionHas('simple-commerce-cart')
+        ->assertSessionMissing('simple-commerce.checkout.success')
+        ->assertRedirect('/payment-failed');
+
+    expect($order->fresh()->status())->toBe(OrderStatus::Cart);
+
+    CallbackTestGateway::$expectedCallbackResult = null;
+});
+
+it('handles a successful payment status check when gateway does not implement callback method', function () {
+    CallbackTestGateway::$expectedCallbackResult = 'throw';
+    SimpleCommerce::registerGateway(CallbackTestGateway::class, []);
+
+    $order = Order::make()->id('abc')->paymentStatus(PaymentStatus::Paid)->save();
+    $order->save();
+
+    withSession(['simple-commerce-cart' => 'abc'])
+        ->get('/!/simple-commerce/gateways/callback_test/callback?_redirect=/order-complete')
+        ->assertSessionMissing('simple-commerce-cart')
+        ->assertSessionHas('simple-commerce.checkout.success')
+        ->assertRedirect('/order-complete');
+
+    expect($order->fresh()->status())->toBe(OrderStatus::Placed);
+
+    CallbackTestGateway::$expectedCallbackResult = null;
+});
+
+it('handles an unsuccessful payment status check when gateway does not implement callback method', function () {
+    CallbackTestGateway::$expectedCallbackResult = 'throw';
+    SimpleCommerce::registerGateway(CallbackTestGateway::class, []);
+
+    $order = Order::make()->id('abc')->paymentStatus(PaymentStatus::Unpaid)->save();
+    $order->save();
+
+    withSession(['simple-commerce-cart' => 'abc'])
+        ->get('/!/simple-commerce/gateways/callback_test/callback?_error_redirect=/payment-failed')
+        ->assertSessionHas('simple-commerce-cart')
+        ->assertSessionMissing('simple-commerce.checkout.success')
+        ->assertRedirect('/payment-failed')
+        ->assertSessionHasErrors();
+
+    expect($order->fresh()->status())->toBe(OrderStatus::Cart);
+
+    CallbackTestGateway::$expectedCallbackResult = null;
+});
+
+it('gets the order ID from the request', function () {
+    CallbackTestGateway::$expectedCallbackResult = true;
+    SimpleCommerce::registerGateway(CallbackTestGateway::class, []);
+
+    $order = Order::make()->id('abc')->save();
+    $order->save();
+
+    get('/!/simple-commerce/gateways/callback_test/callback?_order_id=abc&_redirect=/order-complete')
+        ->assertSessionMissing('simple-commerce-cart')
+        ->assertSessionHas('simple-commerce.checkout.success')
+        ->assertRedirect('/order-complete');
+
+    expect($order->fresh()->status())->toBe(OrderStatus::Placed);
+
+    CallbackTestGateway::$expectedCallbackResult = null;
+});
+
+it('throws an exception when the provided gateway does not exist', function () {
+    $order = Order::make()->id('abc')->save();
+    $order->save();
+
+    expect(function () {
+        withoutExceptionHandling()
+            ->withSession(['simple-commerce-cart' => 'abc'])
+            ->get('/!/simple-commerce/gateways/some_gateway_that_does_not_exist/callback');
+    })->toThrow(GatewayDoesNotExist::class);
+
+    expect($order->fresh()->status())->toBe(OrderStatus::Cart);
+});

--- a/tests/__fixtures__/app/Gateways/CallbackTestGateway.php
+++ b/tests/__fixtures__/app/Gateways/CallbackTestGateway.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace DuncanMcClean\SimpleCommerce\Tests\Fixtures\Gateways;
+
+use DuncanMcClean\SimpleCommerce\Contracts\Order as ContractsOrder;
+use DuncanMcClean\SimpleCommerce\Exceptions\GatewayCallbackMethodDoesNotExist;
+use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
+use Illuminate\Http\Request;
+
+class CallbackTestGateway extends BaseGateway
+{
+    public static $expectedCallbackResult = null;
+
+    public static function handle()
+    {
+        return 'callback_test';
+    }
+
+    public function isOffsiteGateway(): bool
+    {
+        return true;
+    }
+
+    public function prepare(Request $request, ContractsOrder $order): array
+    {
+        return [];
+    }
+
+    public function refund(ContractsOrder $order): ?array
+    {
+        return [];
+    }
+
+    public function callback(Request $request): bool
+    {
+        if (static::$expectedCallbackResult === 'throw') {
+            throw new GatewayCallbackMethodDoesNotExist('callback');
+        }
+
+        return static::$expectedCallbackResult;
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue where we were referencing the gateway by its FCQN, rather than it's handle. This was causing the "gateway callback" to fail (the URL where off-site gateways redirect the user back to after payment).

This PR also adds a few tests to cover the gateway callback functionality since I noticed it didn't already have a test.

Fixes #1010.