### PR TITLE
[6.x] Prevent passing the cart to the view

### DIFF
--- a/src/Http/Controllers/BaseActionController.php
+++ b/src/Http/Controllers/BaseActionController.php
@@ -3,6 +3,7 @@
 namespace DuncanMcClean\SimpleCommerce\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Statamic\Http\Controllers\Controller;
 
 class BaseActionController extends Controller
@@ -18,7 +19,13 @@ class BaseActionController extends Controller
             return response()->json($data);
         }
 
-        if (isset($data['is_checkout_request'])) {
+        // The cart is only useful in a JSON response, so we'll remove it from
+        // the $data array before we pass it to the view.
+        if (Arr::has($data, 'cart')) {
+            unset($data['cart']);
+        }
+
+        if (Arr::has($data, 'is_checkout_request')) {
             $request->session()->put('simple-commerce.checkout.success', [
                 'order_id' => $data['cart']['id'],
                 'expiry' => now()->addMinutes(30),

--- a/src/Http/Controllers/BaseActionController.php
+++ b/src/Http/Controllers/BaseActionController.php
@@ -19,18 +19,18 @@ class BaseActionController extends Controller
             return response()->json($data);
         }
 
-        // The cart is only useful in a JSON response, so we'll remove it from
-        // the $data array before we pass it to the view.
-        if (Arr::has($data, 'cart')) {
-            unset($data['cart']);
-        }
-
         if (Arr::has($data, 'is_checkout_request')) {
             $request->session()->put('simple-commerce.checkout.success', [
                 'order_id' => $data['cart']['id'],
                 'expiry' => now()->addMinutes(30),
                 'url' => $request->_redirect,
             ]);
+        }
+
+        // The cart is only useful in a JSON response, so we'll remove it from
+        // the $data array before we pass it to the view.
+        if (Arr::has($data, 'cart')) {
+            unset($data['cart']);
         }
 
         return $request->_redirect ?


### PR DESCRIPTION
This pull request prevents the `cart` variable from being passed from SC's controllers into the view. 

Normally, when using entries, there's no issue with this. However, when using database orders and Runway v6, some of the raw augmented data contains query builders, which contain PDO objects which can't be serialized, leading to an error (#1003).

The easiest way to fix this is to just prevent the `cart` variable from being passed into the view. I can't find anywhere we're actually using the passed down `cart` variable in the docs or the starter kit and can't think of a case where you'd want it over using the `{{ sc:cart }}` tag.

We *are* still returning the `cart` data from the action controllers though but just for JSON responses where it doesn't seem to be an issue (probably because they get serialized differently).

Fixes #1003.