### PR TITLE
[6.x] Fix matching Mollie ID to Order

### DIFF
--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -153,7 +153,7 @@ class MollieGateway extends BaseGateway implements Gateway
     protected function getOrderFromWebhookRequest(Request $request): ?Order
     {
         return OrderFacade::query()
-            ->where('data->mollie->id', $request->get('id'))
+            ->where('mollie->id', $request->get('id'))
             ->first();
     }
 }


### PR DESCRIPTION
This pull request fixes an issue I spotted with the Mollie Gateway where it wasn't correctly matching the Mollie ID to the relevant Simple Commerce order in the webhook.

This was causing orders to not be marked as paid when they should have been.