### PR TITLE
[6.x] Fix error with default shipping methods

### DIFF
--- a/src/Orders/Calculator/ShippingCalculator.php
+++ b/src/Orders/Calculator/ShippingCalculator.php
@@ -20,7 +20,7 @@ class ShippingCalculator
 
         $order->shippingTotal(
             Shipping::site(Site::current()->handle())
-                ->use($shippingMethod ?? $defaultShippingMethod::handle())
+                ->use($shippingMethod ?? $defaultShippingMethod)
                 ->calculateCost($order)
         );
 

--- a/tests/Orders/Calculator/ShippingCalculatorTest.php
+++ b/tests/Orders/Calculator/ShippingCalculatorTest.php
@@ -29,7 +29,7 @@ it('does not calculate shipping total without default shipping method or shippin
 
 it('calculates shipping total using default shipping method', function () {
     SimpleCommerce::registerShippingMethod(Site::current()->handle(), Postage::class);
-    Config::set('simple-commerce.sites.'.Site::current()->handle().'.shipping.default_method', Postage::class);
+    Config::set('simple-commerce.sites.'.Site::current()->handle().'.shipping.default_method', 'postage');
 
     $product = Product::make()->price(1000);
     $product->save();


### PR DESCRIPTION
This pull request fixes an issue when using the `default_method` setting to define the default shipping method for new orders.

Fixes #1019.