### PR TITLE
[6.x] Fix error from the Status Log fieldtype when using Database Orders

### DIFF
--- a/src/Fieldtypes/StatusLogFieldtype.php
+++ b/src/Fieldtypes/StatusLogFieldtype.php
@@ -57,9 +57,15 @@ class StatusLogFieldtype extends Fieldtype
         }
 
         return collect($value)->map(function (array $statusLogEvent) {
+            // When orders are stored in the database, the timestamp is cast to a Carbon instance.
+            // However, to pass it into the StatusLogEvent class, we need to convert it back to a timestamp.
+            $timestamp = $statusLogEvent['timestamp'] instanceof Carbon
+                ? $statusLogEvent['timestamp']->timestamp
+                : $statusLogEvent['timestamp'];
+
             return new StatusLogEvent(
                 $statusLogEvent['status'],
-                $statusLogEvent['timestamp'],
+                $timestamp,
                 $statusLogEvent['data'] ?? []
             );
         });


### PR DESCRIPTION
This pull request fixes an issue with the Status Log fieldtype when using storing orders in the database, where the `$statusLogEvent['timestamp']` would be cast to a `Carbon` instance but the `StatusLogEvent` class requires a timestamp.

This PR fixes that by checking if the timestamp is a `Carbon` instance and converting its value so it passes the expected value.