### PR TITLE
[6.x] Fix "Recursion detected" error with cart endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ package-lock.json
 .idea
 .antlers.json
 composer.lock
+.phpunit.cache
 
 tests/__fixtures__/users/*.yaml
 

--- a/src/Http/Controllers/BaseActionController.php
+++ b/src/Http/Controllers/BaseActionController.php
@@ -10,16 +10,6 @@ class BaseActionController extends Controller
 {
     protected function withSuccess(Request $request, array $data = [])
     {
-        // The cart is only useful in a JSON response, so we'll remove it from
-        // the $data array before we pass it to the view.
-        if (Arr::has($data, 'cart')) {
-            // dd($data['cart']);
-            // unset($data['cart']['customer']);
-            // unset($data['cart']['customer_id']);
-
-            // dd($data['cart']['customer']);
-        }
-
         if ($request->wantsJson()) {
             $data = array_merge($data, [
                 'status' => 'success',

--- a/src/Http/Controllers/BaseActionController.php
+++ b/src/Http/Controllers/BaseActionController.php
@@ -10,6 +10,16 @@ class BaseActionController extends Controller
 {
     protected function withSuccess(Request $request, array $data = [])
     {
+        // The cart is only useful in a JSON response, so we'll remove it from
+        // the $data array before we pass it to the view.
+        if (Arr::has($data, 'cart')) {
+            // dd($data['cart']);
+            // unset($data['cart']['customer']);
+            // unset($data['cart']['customer_id']);
+
+            // dd($data['cart']['customer']);
+        }
+
         if ($request->wantsJson()) {
             $data = array_merge($data, [
                 'status' => 'success',

--- a/src/Http/Controllers/CartController.php
+++ b/src/Http/Controllers/CartController.php
@@ -22,7 +22,7 @@ class CartController extends BaseActionController
         }
 
         return [
-            'cart' => $this->getCart()
+            'data' => $this->getCart()
                 ->toAugmentedCollection()
                 ->withRelations(['customer', 'customer_id'])
                 ->withShallowNesting()

--- a/src/Http/Controllers/CartController.php
+++ b/src/Http/Controllers/CartController.php
@@ -22,8 +22,9 @@ class CartController extends BaseActionController
         }
 
         return [
-            'data' => $this->getCart()
+            'cart' => $this->getCart()
                 ->toAugmentedCollection()
+                ->withRelations(['customer', 'customer_id'])
                 ->withShallowNesting()
                 ->toArray(),
         ];
@@ -58,7 +59,11 @@ class CartController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Cart Updated'),
-            'cart' => $cart->toAugmentedArray(),
+            'cart' => $this->getCart()
+                ->toAugmentedCollection()
+                ->withRelations(['customer', 'customer_id'])
+                ->withShallowNesting()
+                ->toArray(),
         ]);
     }
 
@@ -72,7 +77,6 @@ class CartController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Cart Deleted'),
-            'cart' => null,
         ]);
     }
 

--- a/src/Http/Controllers/CartController.php
+++ b/src/Http/Controllers/CartController.php
@@ -59,7 +59,7 @@ class CartController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Cart Updated'),
-            'cart' => $this->getCart()
+            'cart' => $cart
                 ->toAugmentedCollection()
                 ->withRelations(['customer', 'customer_id'])
                 ->withShallowNesting()

--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -119,7 +119,7 @@ class CartItemController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Added to Cart'),
-            'cart' => $this->getCart()
+            'cart' => $cart
                 ->toAugmentedCollection()
                 ->withRelations(['customer', 'customer_id'])
                 ->withShallowNesting()
@@ -167,7 +167,7 @@ class CartItemController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Line Item Updated'),
-            'cart' => $this->getCart()
+            'cart' => $cart
                 ->toAugmentedCollection()
                 ->withRelations(['customer', 'customer_id'])
                 ->withShallowNesting()
@@ -183,7 +183,7 @@ class CartItemController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Item Removed from Cart'),
-            'cart' => $this->getCart()
+            'cart' => $cart
                 ->toAugmentedCollection()
                 ->withRelations(['customer', 'customer_id'])
                 ->withShallowNesting()

--- a/src/Http/Controllers/CartItemController.php
+++ b/src/Http/Controllers/CartItemController.php
@@ -119,7 +119,11 @@ class CartItemController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Added to Cart'),
-            'cart' => $cart->fresh()->toAugmentedArray(),
+            'cart' => $this->getCart()
+                ->toAugmentedCollection()
+                ->withRelations(['customer', 'customer_id'])
+                ->withShallowNesting()
+                ->toArray(),
         ]);
     }
 
@@ -163,7 +167,11 @@ class CartItemController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Line Item Updated'),
-            'cart' => $cart->toAugmentedArray(),
+            'cart' => $this->getCart()
+                ->toAugmentedCollection()
+                ->withRelations(['customer', 'customer_id'])
+                ->withShallowNesting()
+                ->toArray(),
         ]);
     }
 
@@ -175,7 +183,11 @@ class CartItemController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Item Removed from Cart'),
-            'cart' => $cart->toAugmentedArray(),
+            'cart' => $this->getCart()
+                ->toAugmentedCollection()
+                ->withRelations(['customer', 'customer_id'])
+                ->withShallowNesting()
+                ->toArray(),
         ]);
     }
 

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -52,7 +52,11 @@ class CheckoutController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Checkout Complete!'),
-            'cart' => $this->order->toAugmentedArray(),
+            'cart' => $this->getCart()
+                ->toAugmentedCollection()
+                ->withRelations(['customer', 'customer_id'])
+                ->withShallowNesting()
+                ->toArray(),
             'is_checkout_request' => true,
         ]);
     }

--- a/src/Http/Controllers/CheckoutController.php
+++ b/src/Http/Controllers/CheckoutController.php
@@ -52,7 +52,7 @@ class CheckoutController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Checkout Complete!'),
-            'cart' => $this->getCart()
+            'cart' => $this->order
                 ->toAugmentedCollection()
                 ->withRelations(['customer', 'customer_id'])
                 ->withShallowNesting()

--- a/src/Http/Controllers/CouponController.php
+++ b/src/Http/Controllers/CouponController.php
@@ -25,7 +25,7 @@ class CouponController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Coupon added to cart'),
-            'cart' => $this->getCart()
+            'cart' => $cart
                 ->toAugmentedCollection()
                 ->withRelations(['customer', 'customer_id'])
                 ->withShallowNesting()
@@ -45,7 +45,7 @@ class CouponController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Coupon removed from cart'),
-            'cart' => $this->getCart()
+            'cart' => $cart
                 ->toAugmentedCollection()
                 ->withRelations(['customer', 'customer_id'])
                 ->withShallowNesting()

--- a/src/Http/Controllers/CouponController.php
+++ b/src/Http/Controllers/CouponController.php
@@ -25,7 +25,11 @@ class CouponController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Coupon added to cart'),
-            'cart' => $this->getCart()->toAugmentedArray(),
+            'cart' => $this->getCart()
+                ->toAugmentedCollection()
+                ->withRelations(['customer', 'customer_id'])
+                ->withShallowNesting()
+                ->toArray(),
         ]);
     }
 
@@ -41,7 +45,11 @@ class CouponController extends BaseActionController
 
         return $this->withSuccess($request, [
             'message' => __('Coupon removed from cart'),
-            'cart' => $this->getCart()->toAugmentedArray(),
+            'cart' => $this->getCart()
+                ->toAugmentedCollection()
+                ->withRelations(['customer', 'customer_id'])
+                ->withShallowNesting()
+                ->toArray(),
         ]);
     }
 }

--- a/tests/Http/Controllers/CartControllerTest.php
+++ b/tests/Http/Controllers/CartControllerTest.php
@@ -674,7 +674,6 @@ test('can destroy cart and request json response', function () {
     $response->assertJsonStructure([
         'status',
         'message',
-        'cart',
     ]);
 
     $cart = $cart->fresh();


### PR DESCRIPTION
This pull request fixes an issue where a "Recursion detected" error would occur when using the Database Driver & when expecting a JSON response from the server.

This PR fixes it by shallowly augmenting nested fields, like the customer field. Otherwise, Statamic would go round in circles looking at an order, its customer, its customer's orders, the customer of all the customer's orders, etc.

Fixes #1024.