### PR TITLE
[6.x] Fix shipping method fieldtype

### DIFF
--- a/src/Fieldtypes/ShippingMethodFieldtype.php
+++ b/src/Fieldtypes/ShippingMethodFieldtype.php
@@ -60,7 +60,7 @@ class ShippingMethodFieldtype extends Relationship
         $site = Site::selected();
 
         $shippingMethod = SimpleCommerce::shippingMethods($site->handle())
-            ->where('class', $value)
+            ->where('handle', $value)
             ->first();
 
         if (! $shippingMethod) {
@@ -83,7 +83,7 @@ class ShippingMethodFieldtype extends Relationship
             $site = Site::selected();
 
             $shippingMethod = SimpleCommerce::shippingMethods($site->handle())
-                ->where('class', $item)
+                ->where('handle', $item)
                 ->first();
 
             if (! $shippingMethod) {

--- a/tests/Fieldtypes/ShippingMethodFieldtypeTest.php
+++ b/tests/Fieldtypes/ShippingMethodFieldtypeTest.php
@@ -40,7 +40,7 @@ test('can get columns', function () {
 });
 
 test('can return as item array', function () {
-    $toItemArray = $this->fieldtype->toItemArray(FreeShipping::class);
+    $toItemArray = $this->fieldtype->toItemArray(FreeShipping::handle());
 
     expect($toItemArray)->toBeArray();
 
@@ -51,7 +51,7 @@ test('can return as item array', function () {
 });
 
 test('can preprocess index', function () {
-    $preProcessIndex = $this->fieldtype->preProcessIndex(FreeShipping::class);
+    $preProcessIndex = $this->fieldtype->preProcessIndex(FreeShipping::handle());
 
     expect($preProcessIndex)->toBeString();
     expect('Free Shipping')->toBe($preProcessIndex);


### PR DESCRIPTION
This pull request fixes an issue where the Shipping Method fieldtype wasn't returning any shipping methods, due to the fact it was querying the `class` on shipping methods instead of the handles.

Partially fixes #1026.