### PR TITLE
[6.x] Fix error with `{{ sc:cart:raw_tax_total_split }}` tag

### DIFF
--- a/src/Tags/CartTags.php
+++ b/src/Tags/CartTags.php
@@ -160,16 +160,16 @@ class CartTags extends SubTag
 
     public function rawTaxTotalSplit(): Collection
     {
-        return collect($this->items())
-            ->groupBy(function ($item) {
-                return $item['tax']['rate'];
-            })
-            ->map(function ($group, $groupRate) {
+        if (! $this->hasCart()) {
+            return collect();
+        }
+
+        return $this->getCart()->lineItems()
+            ->groupBy(fn ($lineItem) => $lineItem->tax()['rate'])
+            ->map(function ($group, $rate) {
                 return [
-                    'rate' => $groupRate,
-                    'amount' => $group->sum(function ($item) {
-                        return $item['tax']['amount'];
-                    }),
+                    'rate' => $rate,
+                    'amount' => $group->sum(fn ($lineItem) => $lineItem->tax()['amount']),
                 ];
             })
             ->values();

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -429,6 +429,12 @@ test('can get cart tax total split', function () {
     $taxReduced = $cartProduct3->tax()['amount'];
     $taxReducedFormatted = Currency::parse($taxReduced, Site::default());
 
+    // Expected tag output format = '19:1234|7:5678'
+    $renderedTag = (string) tag('{{ sc:cart:rawTaxTotalSplit }}{{ rate }}:{{ amount }}|{{ /sc:cart:rawTaxTotalSplit }}');
+
+    expect($renderedTag)->toContain($taxRateDefault->rate().':'.$taxDefault);
+    expect($renderedTag)->toContain($taxRateReduced->rate().':'.$taxReduced);
+
     // Expected tag output format = '7:£12.34|19:£56.78'
     $renderedTag = (string) tag('{{ sc:cart:taxTotalSplit }}{{ rate }}:{{ amount }}|{{ /sc:cart:taxTotalSplit }}');
 


### PR DESCRIPTION
This pull request fixes an error when using the `{{ sc:cart:raw_tax_total_split }}` tag. 

Previously, the `raw_tax_total_split` tag was getting the line items from the tag's `->items()` method which meant it was getting the line items post-augmentation.

This would then cause an issue when trying to sum the tax totals because the tax amounts would be augmented as strings (eg. £12.50) instead of integers.

This refactors that implementation so we're dealing with the `LineItem` methods, rather than augmented arrays.

Related: https://github.com/duncanmcclean/simple-commerce/issues/1035#issuecomment-2018270684