### PR TITLE
[6.x] Require `ext-intl` PHP extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     },
     "require": {
         "php": "^8.1",
+        "ext-intl": "*",
         "laravel/framework": "^10.0",
         "mollie/mollie-api-php": "^2.30.0",
         "moneyphp/money": "^4.0",


### PR DESCRIPTION
Came up in the Statamic Discord as somebody had issues outputting the price and [it is already stated as required in the docs](https://github.com/duncanmcclean/simple-commerce/blob/6.x/docs/installation.md?plain=1#L13). This way you can’t install the package without the PHP extension being present in your environment.