### PR TITLE
[6.x] Fix infinite loop when querying orders

### DIFF
--- a/src/Orders/HasLineItems.php
+++ b/src/Orders/HasLineItems.php
@@ -53,8 +53,6 @@ trait HasLineItems
                     // If the line item's product has been deleted, remove
                     // it from the cart & return null.
                     if ($this->paymentStatus() !== PaymentStatus::Paid && ! $lineItem->product()) {
-                        $this->removeLineItem($item['id']);
-
                         return null;
                     }
 

--- a/src/UpdateScripts/v6_0/UpdateClassReferences.php
+++ b/src/UpdateScripts/v6_0/UpdateClassReferences.php
@@ -50,9 +50,17 @@ class UpdateClassReferences extends UpdateScript
     {
         Order::query()->whereNotNull('shipping_method')->chunk(100, function (Collection $orders) {
             $orders
-                ->filter(fn (OrderContract $order) => str_contains($order->get('shipping_method'), '\\'))
+                ->filter(function (OrderContract $order) {
+                    $shippingMethod = is_array($order->get('shipping_method'))
+                        ? Arr::first($order->get('shipping_method'))
+                        : $order->get('shipping_method');
+
+                    return str_contains($shippingMethod, '\\');
+                })
                 ->each(function (OrderContract $order) {
-                    $class = $order->get('shipping_method');
+                    $class = is_array($order->get('shipping_method'))
+                        ? Arr::first($order->get('shipping_method'))
+                        : $order->get('shipping_method');
 
                     // Adjust the class name before new'ing it up since the namespace has changed.
                     if (Str::startsWith($class, 'DoubleThreeDigital')) {


### PR DESCRIPTION
This pull request fixes an issue where you could end up in an infinite loop when querying orders.

This infinite loop was happening due to some code which handles filtering out deleted products from an order's line items, we should be fine to remove the `removeLineItems` method since we're still returning `null` (related #734). 

This PR also fixes an issue with the `UpdateClassReferences` upgrade script, where it couldn't handle cases where `shipping_method` was an array, instead of a string. 

Fixes #1043.