### PR TITLE
[6.x] Fix searching database orders

### DIFF
--- a/src/Orders/OrderModel.php
+++ b/src/Orders/OrderModel.php
@@ -60,8 +60,8 @@ class OrderModel extends Model
     {
         return $query
             ->where('order_number', 'like', "%$searchQuery%")
-            ->orWhere('grand_total', 'like', "%" . str_replace('.', '', $searchQuery) . "%")
-            ->orWhere('items_total', 'like', "%" . str_replace('.', '', $searchQuery) . "%")
+            ->orWhere('grand_total', 'like', '%'.str_replace('.', '', $searchQuery).'%')
+            ->orWhere('items_total', 'like', '%'.str_replace('.', '', $searchQuery).'%')
             ->when($this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], EloquentCustomerRepository::class), function ($query) use ($searchQuery) {
                 $query->orWhereHas('customer', function ($query) use ($searchQuery) {
                     $query->where('name', 'like', "%$searchQuery%")


### PR DESCRIPTION
This pull request fixes an issue when attempting to search orders when storing orders in the database.

Essentially, Runway was trying to search through all fields on the order blueprint. However, in our case, not all of those fields actually have associated database columns, so it was erroring out.

This PR fixes that by manually defining the [`runwaySearch` scope](https://runway.duncanmcclean.com/control-panel#content-scoping-search-results) to override how orders are searched. Search on orders now only searches through the order number, grand total, items total and customer name/email.

Fixes #1045.