### PR TITLE
[6.x] Fix "Order Date" for database orders

### DIFF
--- a/src/Orders/OrderModel.php
+++ b/src/Orders/OrderModel.php
@@ -49,8 +49,8 @@ class OrderModel extends Model
         return Attribute::make(
             get: function () {
                 return $this->statusLog
-                    ->where('status', OrderStatus::Placed)
-                    ->map->date()
+                    ->where('status', OrderStatus::Placed->value)
+                    ->pluck('timestamp')
                     ->last();
             },
         );


### PR DESCRIPTION
This pull request fixes an issue where the "Order Date" field wasn't returning anything for database orders, which was probably caused by the changes in #983.

Related: https://github.com/duncanmcclean/simple-commerce/discussions/1046