### PR TITLE
[6.x] When a tax zone has no region, but the address does, ensure the tax zone can still be found

### DIFF
--- a/src/Tax/Standard/TaxEngine.php
+++ b/src/Tax/Standard/TaxEngine.php
@@ -79,6 +79,10 @@ class TaxEngine implements Contract
 
             if ($address->region()) {
                 $taxZoneQuery = $taxZoneQuery->filter(function ($taxZone) use ($address) {
+                    if (! $taxZone->region()) {
+                        return true;
+                    }
+
                     return $taxZone->region() === $address->region();
                 });
             }
@@ -150,6 +154,10 @@ class TaxEngine implements Contract
 
             if ($address->region()) {
                 $taxZoneQuery = $taxZoneQuery->filter(function ($taxZone) use ($address) {
+                    if (! $taxZone->region()) {
+                        return true;
+                    }
+
                     return $taxZone->region() === $address->region();
                 });
             }


### PR DESCRIPTION
This pull request fixes an issue when an address had a region set, but the available tax zones didn't have a region set only a country, causing no tax zone to be found.

