### PR TITLE
[6.x] Remove customer from order when logged out

### DIFF
--- a/src/Listeners/RemoveCustomerFromOrder.php
+++ b/src/Listeners/RemoveCustomerFromOrder.php
@@ -2,12 +2,9 @@
 
 namespace DuncanMcClean\SimpleCommerce\Listeners;
 
-use DuncanMcClean\SimpleCommerce\Contracts\Order;
 use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
 use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Auth\Events\Logout;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
 
 class RemoveCustomerFromOrder
 {

--- a/src/Listeners/RemoveCustomerFromOrder.php
+++ b/src/Listeners/RemoveCustomerFromOrder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DuncanMcClean\SimpleCommerce\Listeners;
+
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
+use DuncanMcClean\SimpleCommerce\Orders\Cart\Drivers\CartDriver;
+use DuncanMcClean\SimpleCommerce\SimpleCommerce;
+use Illuminate\Auth\Events\Logout;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class RemoveCustomerFromOrder
+{
+    use CartDriver;
+
+    public function handle(Logout $event)
+    {
+        if (! $this->isOrExtendsClass(SimpleCommerce::customerDriver()['repository'], \DuncanMcClean\SimpleCommerce\Customers\UserCustomerRepository::class)) {
+            return;
+        }
+
+        if ($this->hasCart()) {
+            $this->getCart()->customer(null)->save();
+        }
+    }
+
+    protected function isOrExtendsClass(string $class, string $classToCheckAgainst): bool
+    {
+        return is_subclass_of($class, $classToCheckAgainst)
+            || $class === $classToCheckAgainst;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -90,6 +90,9 @@ class ServiceProvider extends AddonServiceProvider
         Events\DigitalDownloadReady::class => [
             Listeners\SendConfiguredNotifications::class,
         ],
+        \Illuminate\Auth\Events\Logout::class => [
+            Listeners\RemoveCustomerFromOrder::class,
+        ],
     ];
 
     protected $modifiers = [


### PR DESCRIPTION
This pull request pairs up with the changes introduced in #961, removing the authenticated user as the customer on their cart when they logout.

Related: #1058