### PR TITLE
[7.x] Fix Stripe Payment Intent not being saved to order gateway data

### DIFF
--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -185,8 +185,8 @@ class StripeGateway extends BaseGateway implements Gateway
         if ($method === 'handlePaymentIntentSucceeded') {
             $order = Order::find($data['metadata']['order_id']);
 
-            $order->gatewayData(data: ['id' => $data['id']]);
-            $order->save();
+            // $order->gatewayData(data: ['id' => $data['id']]);
+            // $order->save();
 
             $this->markOrderAsPaid($order);
 

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -185,8 +185,8 @@ class StripeGateway extends BaseGateway implements Gateway
         if ($method === 'handlePaymentIntentSucceeded') {
             $order = Order::find($data['metadata']['order_id']);
 
-            // $order->gatewayData(data: ['id' => $data['id']]);
-            // $order->save();
+            $order->gatewayData(data: ['id' => $data['id']]);
+            $order->save();
 
             $this->markOrderAsPaid($order);
 

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -185,6 +185,9 @@ class StripeGateway extends BaseGateway implements Gateway
         if ($method === 'handlePaymentIntentSucceeded') {
             $order = Order::find($data['metadata']['order_id']);
 
+            $order->gatewayData(data: ['id' => $data['id']]);
+            $order->save();
+
             $this->markOrderAsPaid($order);
 
             return new Response('Webhook handled', 200);

--- a/tests/Gateways/Builtin/StripeGatewayTest.php
+++ b/tests/Gateways/Builtin/StripeGatewayTest.php
@@ -424,6 +424,7 @@ test('can hit webhook with payment intent succeeded event', function () {
         'type' => 'payment_intent.succeeded',
         'data' => [
             'object' => [
+                'id' => $paymentIntent = 'pi_123456789122345',
                 'metadata' => [
                     'order_id' => $order->id(),
                 ],
@@ -439,6 +440,14 @@ test('can hit webhook with payment intent succeeded event', function () {
 
     expect(OrderStatus::Placed)->toBe($order->status());
     expect(PaymentStatus::Paid)->toBe($order->paymentStatus());
+
+    expect($order->gatewayData()->toArray())->toBe([
+        'use' => StripeGateway::handle(),
+        'data' => [
+            'id' => $paymentIntent,
+        ],
+        'refund' => null,
+    ]);
 });
 
 test('returns array from payment display', function () {


### PR DESCRIPTION
This pull request fixes an issue when using the Stripe Payment Gateway, where the payment intent wasn't being saved onto the order's gateway data.

This meant that refunds couldn't be issued from within Simple Commerce.

Fixes #1071.