### PR TITLE
[7.x] Prevent calling `preload` when augmenting product variants

### DIFF
--- a/src/Fieldtypes/ProductVariantsFieldtype.php
+++ b/src/Fieldtypes/ProductVariantsFieldtype.php
@@ -117,8 +117,16 @@ class ProductVariantsFieldtype extends Fieldtype
         }
 
         return [
-            'variants' => $this->processInsideFields(isset($value['variants']) ? $value['variants'] : [], $this->preload()['variant_fields'], 'augment'),
-            'options' => $this->processInsideFields(isset($value['options']) ? $value['options'] : [], $this->preload()['option_fields'], 'augment'),
+            'variants' => $this->processInsideFields(
+                fieldValues: Arr::get($value, 'variants', []),
+                fields: $this->variantFields()->toPublishArray(),
+                method: 'augment'
+            ),
+            'options' => $this->processInsideFields(
+                fieldValues: Arr::get($value, 'options', []),
+                fields: $this->optionFields()->toPublishArray(),
+                method: 'augment'
+            ),
         ];
     }
 


### PR DESCRIPTION
This pull request prevents the `preload` method from being called when augmenting Product Variants, since it was causing issues with certain fieldtypes because the `preload` method is usually called in the Control Panel, with logged in users.

Fixes #1076.