### PR TITLE
[7.x] Fix `{{ sc:customer:order }}` tag

### DIFF
--- a/src/Tags/CustomerTags.php
+++ b/src/Tags/CustomerTags.php
@@ -40,6 +40,6 @@ class CustomerTags extends SubTag
 
     public function order()
     {
-        return OrderAPI::find($this->params->get('id'));
+        return OrderAPI::find($this->params->get('id'))->toAugmentedArray();
     }
 }


### PR DESCRIPTION
This pull request fixes the `{{ sc:customer:order }}` tag. It was returning an `Order` object which was causing an error in Antlers since it doesn't know how to handle it.

Instead, we're now returning an augmented array which Antlers *will* be able to handle.

Closes #1081.