### PR TITLE
[7.x] Fix error when saving user customer data

### DIFF
--- a/src/Customers/UserCustomerRepository.php
+++ b/src/Customers/UserCustomerRepository.php
@@ -99,7 +99,7 @@ class UserCustomerRepository implements RepositoryContract
             $ignoredKeys = array_merge($ignoredKeys, $user->model()->getAppends());
         }
 
-        $user->merge(Arr::except($customer->data()->all(), $ignoredKeys));
+        $user->data(Arr::except($customer->data()->all(), $ignoredKeys));
 
         $user->save();
 


### PR DESCRIPTION
This pull request fixes an error that'd occur when saving customer data, where customers were stored as users in the database.

I believe it was happening due to the fact Statamic would merge in our customer data with the existing user data, which was causing the `roles` and `groups` fields to attempt to save as their own columns.

Closes #1083.