### PR TITLE
[7.x] Fix error when querying customers stored as database users

### DIFF
--- a/src/Customers/EloquentUserQueryBuilder.php
+++ b/src/Customers/EloquentUserQueryBuilder.php
@@ -4,11 +4,14 @@ namespace DuncanMcClean\SimpleCommerce\Customers;
 
 use DuncanMcClean\SimpleCommerce\Facades\Customer;
 use Statamic\Auth\Eloquent\UserQueryBuilder;
+use Statamic\Facades\User;
 
 class EloquentUserQueryBuilder extends UserQueryBuilder
 {
     protected function transform($items, $columns = ['*'])
     {
-        return $items->map(fn ($item) => Customer::fromModel($item));
+        return $items
+            ->map(fn ($item) => User::make()->model($item))
+            ->map(fn ($item) => Customer::fromUser($item));
     }
 }


### PR DESCRIPTION
This pull request fixes an error when querying customers when they're stored as database users. 

Essentially, the raw items that come back from the query builder are `User` models instead of Statamic user instances as expected. This PR fixes it by mapping the models to Statamic `User` instances before then mapping to Simple Commerce `Customer` objects.

Fixes #1082.