### PR TITLE
[7.x] Add config option to set cookie expiry for carts

### DIFF
--- a/src/Orders/Cart/Drivers/CookieDriver.php
+++ b/src/Orders/Cart/Drivers/CookieDriver.php
@@ -52,7 +52,9 @@ class CookieDriver implements CartDriver
         $cart->set('site', $this->guessSiteFromRequest()->handle());
         $cart->save();
 
-        Cookie::queue($this->getKey(), $cart->id);
+        // Cookie expiry: Defaults to 0, which means the cookie will expire at the end of the session.
+        $cookieExpiration = Config::get('simple-commerce.cart.expiration', 0);
+        Cookie::queue($this->getKey(), $cart->id, $cookieExpiration);
 
         // Because the cookie won't be set until the end of the request,
         // we need to set it somewhere for the remainder of the request.

--- a/src/Orders/Cart/Drivers/CookieDriver.php
+++ b/src/Orders/Cart/Drivers/CookieDriver.php
@@ -52,9 +52,11 @@ class CookieDriver implements CartDriver
         $cart->set('site', $this->guessSiteFromRequest()->handle());
         $cart->save();
 
-        // Cookie expiry: Defaults to 0, which means the cookie will expire at the end of the session.
-        $cookieExpiration = Config::get('simple-commerce.cart.expiration', 0);
-        Cookie::queue($this->getKey(), $cart->id, $cookieExpiration);
+        Cookie::queue(
+            $this->getKey(),
+            $cart->id,
+            Config::get('simple-commerce.cart.expiration', 0)
+        );
 
         // Because the cookie won't be set until the end of the request,
         // we need to set it somewhere for the remainder of the request.


### PR DESCRIPTION
Tested it with the following and it forgets the cookie after 1 minute of creating 👍 
``` 
    'cart' => [
        'expiration' => 1
    ]
```

Not sure where to add this in the documentation, since the other `simple-commerce.cart` keys are also not explained on a specific docs page (only in a upgrade guide). 