### PR TITLE
[7.x] Include order when dispatching `CouponRedeemed` event

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -48,6 +48,7 @@ This event is fired when a customer adds a coupon to their cart/order.
 public function handle(CouponRedeemed $event)
 {
 	$event->coupon;
+	$event->order;
 }
 ```
 

--- a/src/Events/CouponRedeemed.php
+++ b/src/Events/CouponRedeemed.php
@@ -3,6 +3,7 @@
 namespace DuncanMcClean\SimpleCommerce\Events;
 
 use DuncanMcClean\SimpleCommerce\Contracts\Coupon;
+use DuncanMcClean\SimpleCommerce\Contracts\Order;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 
@@ -11,7 +12,9 @@ class CouponRedeemed
     use Dispatchable;
     use InteractsWithSockets;
 
-    public function __construct(public Coupon $coupon)
-    {
+    public function __construct(
+        public Coupon $coupon,
+        public Order $order
+    ) {
     }
 }

--- a/src/Events/CouponRedeemed.php
+++ b/src/Events/CouponRedeemed.php
@@ -12,9 +12,7 @@ class CouponRedeemed
     use Dispatchable;
     use InteractsWithSockets;
 
-    public function __construct(
-        public Coupon $coupon,
-        public Order $order
-    ) {
+    public function __construct(public Coupon $coupon, public Order $order)
+    {
     }
 }

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -288,7 +288,7 @@ class Order implements Contract
             $this->coupon($coupon);
             $this->save();
 
-            event(new CouponRedeemed($coupon));
+            event(new CouponRedeemed($coupon, $this));
 
             return true;
         }

--- a/tests/Http/Controllers/CouponControllerTest.php
+++ b/tests/Http/Controllers/CouponControllerTest.php
@@ -96,23 +96,6 @@ test('emits order in CouponRedeemed event', function () {
     });
 });
 
-test('Order is required in CouponRedeemed event', function () {
-    expect(function () {
-        $coupon = Coupon::make()
-            ->code('hof-price')
-            ->value(50)
-            ->type('percentage')
-            ->data([
-                'description' => 'Half Price',
-                'redeemed' => 0,
-                'minimum_cart_value' => null,
-            ]);
-
-        new CouponRedeemed($coupon);
-    })
-        ->toThrow(\ArgumentCountError::class);
-});
-
 test('can store coupon and request json response', function () {
     Event::fake();
 

--- a/tests/Http/Controllers/CouponControllerTest.php
+++ b/tests/Http/Controllers/CouponControllerTest.php
@@ -54,45 +54,9 @@ test('can store coupon', function () {
     expect($coupon->id())->toBe($cart->coupon()->id());
     $this->assertNotSame($cart->couponTotal(), 0);
 
-    Event::assertDispatched(CouponRedeemed::class);
-});
-
-test('emits order in CouponRedeemed event', function () {
-    Event::fake();
-
-    [$product, $cart] = buildCartWithProducts();
-
-    $coupon = Coupon::make()
-        ->code('hof-price')
-        ->value(50)
-        ->type('percentage')
-        ->data([
-            'description' => 'Half Price',
-            'redeemed' => 0,
-            'minimum_cart_value' => null,
-        ]);
-
-    $coupon->save();
-    $coupon->fresh();
-
-    $data = [
-        'code' => 'hof-price',
-    ];
-
-    $response = $this
-        ->from('/cart')
-        ->withSession(['simple-commerce-cart' => $cart->id])
-        ->post(route('statamic.simple-commerce.coupon.store'), $data);
-
-    $response->assertRedirect('/cart');
-
-    $cart = $cart->fresh();
-
-    expect($coupon->id())->toBe($cart->coupon()->id());
-    $this->assertNotSame($cart->couponTotal(), 0);
-
     Event::assertDispatched(function (CouponRedeemed $event) use ($cart) {
-        return $event->order->id() === $cart->id();
+        return $event->coupon->id() === $cart->coupon()->id()
+            && $event->order->id() === $cart->id();
     });
 });
 


### PR DESCRIPTION
On my shop, we have an affiliate program. We primarily use coupon codes to track which orders are assigned to which affiliate users. I created a listener for this (on the `CouponRedeemed` event), only to find that it didn't include the order on which the coupon was redeemed.

This PR fixes that. I added a test to ensure that it works, and AFAIK it should be backwards compatible with base simple-commerce, however any custom packages that emit `CouponRedeemed` **will break**. This could however be made more compatible by making `$order` default to null, and then waiting until the v8 release to make it non-optional- I leave that to you to decide.