### PR TITLE
[7.x] Fix `{{ sc:cart:shipping_total_with_tax }}` tag when tax rate has "Price includes tax" enabled

### DIFF
--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -156,11 +156,7 @@ class Order implements Contract
         $shippingTotal = $this->shippingTotal();
         $shippingTax = $this->get('shipping_tax');
 
-        if (isset($shippingTax) && ! $shippingTax['price_includes_tax']) {
-            return $shippingTotal + $shippingTax['amount'];
-        }
-
-        return $shippingTotal;
+        return $shippingTotal + $shippingTax['amount'];
     }
 
     public function couponTotal($couponTotal = null)

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -271,10 +271,10 @@ test('can get cart shipping total', function () {
 });
 
 test('can get cart shipping total with tax when tax is included in the price', function () {
-    $cart = Order::make()->shippingTotal(2550)->merge([
+    $cart = Order::make()->shippingTotal(826)->merge([
         'shipping_tax' => [
-            'amount' => 400,
-            'rate' => 20,
+            'amount' => 174,
+            'rate' => 21,
             'price_includes_tax' => true,
         ],
     ]);
@@ -282,7 +282,7 @@ test('can get cart shipping total with tax when tax is included in the price', f
 
     fakeCart($cart);
 
-    expect((string) tag('{{ sc:cart:shippingTotalWithTax }}'))->toBe('£25.50');
+    expect((string) tag('{{ sc:cart:shippingTotalWithTax }}'))->toBe('£10.00');
 });
 
 test('can get cart shipping total with tax when tax is not included in the price', function () {


### PR DESCRIPTION
This pull request fixes an issue with the `{{ sc:cart:shipping_total_with_tax }}` tag when the shipping tax rate has the "Price includes tax" toggle enabled.

Previous to this fix, both `shipping_total` and `shipping_total_with_tax` were returning the shipping total amount excluding tax. 

This was happening because the raw `shipping_total` value has tax deducted from it in the `ShippingTaxCalculator`, and in the `shippingTotalWithTax` method we were presuming it would include tax when the price includes tax setting was enabled.

Related: #1065