### PR TITLE
[7.x] Add tax input step for floating tax rates

### DIFF
--- a/resources/views/cp/tax-rates/create.blade.php
+++ b/resources/views/cp/tax-rates/create.blade.php
@@ -33,7 +33,7 @@
                     <label class="block mb-1">{{ __('Rate') }} <i class="required">*</i></label>
 
                     <div class="input-group">
-                        <input type="number" name="rate" class="input-text" value="{{ old('rate') }}">
+                        <input type="number" step="0.1" name="rate" class="input-text" value="{{ old('rate') }}">
                         <div class="input-group-append">%</div>
                     </div>
 

--- a/resources/views/cp/tax-rates/edit.blade.php
+++ b/resources/views/cp/tax-rates/edit.blade.php
@@ -33,7 +33,7 @@
                     <label class="block mb-1">{{ __('Rate') }} <i class="required">*</i></label>
 
                     <div class="input-group">
-                        <input type="number" name="rate" class="input-text" value="{{ $taxRate->rate() }}">
+                        <input type="number" step="0.1" name="rate" class="input-text" value="{{ $taxRate->rate() }}">
                         <div class="input-group-append">%</div>
                     </div>
 


### PR DESCRIPTION
This PR adds the possibility to input floating tax rates.

Without it, form validation was expecting intergers and thus blocking submission.

(see discussion https://github.com/duncanmcclean/simple-commerce/discussions/1108)