### PR TITLE
[7.x] Fix variants not showing

### DIFF
--- a/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
@@ -29,7 +29,7 @@
                             :key="field.handle"
                             :config="field"
                             :value="variant[field.handle]"
-                            :meta="meta[field.handle]"
+                            :meta="meta.variant_fields[field.handle]"
                             :errors="errors(field.handle)"
                             class="p-3 w-1/2"
                             @input="updated(variantIndex, field.handle, $event)"


### PR DESCRIPTION
This pull request fixes an issue where product variants wouldn't show in the Product Variants fieldtype.

After some digging, I found that [this line](https://github.com/statamic/cms/blob/8efcedcee2f29f36c895e50d4ee48438c4e6f352/resources/js/components/publish/FieldMeta.vue#L40) made an AJAX request to the backend, which subsequently overwrote the `value` being passed to Statamic's Tags fieldtype, used for displaying the variants.

This was happening due to no `meta` being provided to the fieldtype.

Fixes  #1117.