### PR TITLE
[7.x] Ensure status log timestamps are always in UTC

### DIFF
--- a/src/Orders/EloquentOrderRepository.php
+++ b/src/Orders/EloquentOrderRepository.php
@@ -109,7 +109,10 @@ class EloquentOrderRepository implements RepositoryContract
                     ->merge([
                         'status_log' => $model->statusLog()->get()->map(fn ($statusLog) => [
                             'status' => $statusLog->status,
-                            'timestamp' => $statusLog->timestamp->timestamp,
+                            'timestamp' => $statusLog->timestamp
+                                ->shiftTimezone('UTC')
+                                ->setTimezone('UTC')
+                                ->timestamp,
                             'data' => $statusLog->data ?? [],
                         ]),
                     ])
@@ -238,7 +241,10 @@ class EloquentOrderRepository implements RepositoryContract
             ->merge([
                 'status_log' => $model->statusLog()->get()->map(fn ($statusLog) => [
                     'status' => $statusLog->status,
-                    'timestamp' => $statusLog->timestamp->timestamp,
+                    'timestamp' => $statusLog->timestamp
+                        ->shiftTimezone('UTC')
+                        ->setTimezone('UTC')
+                        ->timestamp,
                     'data' => $statusLog->data ?? [],
                 ]),
             ]);

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -350,7 +350,7 @@ class Order implements Contract
     {
         $statusLog = $this->statusLog()->push(new StatusLogEvent(
             status: $status,
-            timestamp: Carbon::now()->timestamp,
+            timestamp: Carbon::now('UTC')->timestamp,
             data: $data,
         ));
 

--- a/src/Orders/StatusLogEvent.php
+++ b/src/Orders/StatusLogEvent.php
@@ -16,7 +16,9 @@ class StatusLogEvent implements Arrayable
 
     public function date(): Carbon
     {
-        return Carbon::parse($this->timestamp);
+        return Carbon::parse($this->timestamp)
+            ->shiftTimezone('UTC')
+            ->setTimezone('UTC');
     }
 
     public function toArray(): array


### PR DESCRIPTION
This pull request ensures that status log timestamps are always saved in UTC, rather than the application's set timezone.

Applications should *really* be using `UTC` as their `timezone` - [Laravel strongly encourages it on their docs](https://laravel.com/docs/11.x/eloquent-mutators#date-casting-and-timezones). However, that's not always the case, especially with Statamic sites at the moment due to some outstanding timezone issues.

Fixes #1113.