### PR TITLE
[7.x] Throw a warning when Runway config file already exists

### DIFF
--- a/src/Console/Commands/SwitchToDatabase.php
+++ b/src/Console/Commands/SwitchToDatabase.php
@@ -37,10 +37,10 @@ class SwitchToDatabase extends Command
         }
 
         $this
-            ->copyMigrationStubs()
-            ->copyBlueprintStubs()
-            ->publishRunwayConfig()
-            ->switchRepositories();
+//            ->copyMigrationStubs()
+//            ->copyBlueprintStubs()
+            ->publishRunwayConfig();
+//            ->switchRepositories();
 
         $this->line('Next steps...');
         $this->components->bulletList([
@@ -88,9 +88,13 @@ class SwitchToDatabase extends Command
 
     protected function publishRunwayConfig(): self
     {
-        if (! File::exists(config_path('runway.php'))) {
-            File::copy($this->stubsPath.'/runway_config.php', config_path('runway.php'));
+        if (File::exists($path = config_path('runway.php'))) {
+            $this->components->warn("You already have Runway installed. Please copy the config from {$this->stubsPath}/runway_config.php into your existing config file.");
+
+            return $this;
         }
+
+        File::copy($this->stubsPath.'/runway_config.php', $path);
 
         $this->components->info('Published Runway config file successfully');
 

--- a/src/Console/Commands/SwitchToDatabase.php
+++ b/src/Console/Commands/SwitchToDatabase.php
@@ -37,10 +37,10 @@ class SwitchToDatabase extends Command
         }
 
         $this
-//            ->copyMigrationStubs()
-//            ->copyBlueprintStubs()
-            ->publishRunwayConfig();
-//            ->switchRepositories();
+            ->copyMigrationStubs()
+            ->copyBlueprintStubs()
+            ->publishRunwayConfig()
+            ->switchRepositories();
 
         $this->line('Next steps...');
         $this->components->bulletList([


### PR DESCRIPTION
This pull request adds a warning when Simple Commerce is unable to publish its stub for the `runway.php` config file, prompting you to copy the config manually.

Closes #1126.