### PR TITLE
[7.x] Prevent fields on users from being wiped

### DIFF
--- a/src/Customers/UserCustomerRepository.php
+++ b/src/Customers/UserCustomerRepository.php
@@ -99,7 +99,10 @@ class UserCustomerRepository implements RepositoryContract
             $ignoredKeys = array_merge($ignoredKeys, $user->model()->getAppends());
         }
 
-        $user->data(Arr::except($customer->data()->all(), $ignoredKeys));
+        $user->data(array_merge(
+            $user->data()->all(),
+            Arr::except($customer->data()->all(), $ignoredKeys)
+        ));
 
         $user->save();
 


### PR DESCRIPTION
This pull request fixes an issue where fields on User Customers were being wiped out, due to Simple Commerce overriding the user's data, rather than merging into what's already there.

We used to `->merge()` the user data, but that was changed in #1087, since the `->merge()` method doesn't exist on the Statamic Eloquent User implementation.

Fixes #1122.