### PR TITLE
Add Shipment tracking information to orders

### DIFF
--- a/config/simple-commerce.php
+++ b/config/simple-commerce.php
@@ -176,4 +176,19 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Shipment Tracking Providers
+    |--------------------------------------------------------------------------
+    |
+    | This is where you can configure the providers which that update the status
+    | of tracked packges.
+    */
+
+    'shipment_tracking_providers' => [
+        /*
+        'ups' => \DuncanMcClean\SimpleCommerce\Shipping\Tracking\UpsShipmentTracking::class
+        'fedex' => \DuncanMcClean\SimpleCommerce\Shipping\Tracking\FedExShipmentTracking::class
+        */
+    ],
 ];

--- a/src/Contracts/ShipmentTrackingProvider.php
+++ b/src/Contracts/ShipmentTrackingProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace DuncanMcClean\SimpleCommerce\Contracts;
+
+use DuncanMcClean\SimpleCommerce\Shipping\Tracking\TrackingNumberStatus;
+use Illuminate\Support\Collection;
+
+/**
+ * Likely a wrapper around an API class, this class is responsible for querying
+ * The shipping provider and updating tracking information.
+ */
+interface ShipmentTrackingProvider {
+  /**
+   * The human readable name of the provider
+   * e.g. FedEx, DHL, etc.
+   */
+  public function name(): string;
+
+  /**
+   * The machine readable name of the provider that will be stored in config
+   * files, entries, and models.
+
+   * e.g. fedex, dhl, etc.
+   */
+  public function slug(): string;
+
+  /**
+   * A glide compatible image containing the logo of the company.
+   * TODO: We should define recommended size(s) for this.
+   */
+  public function logo(): Asset;
+
+  /**
+   * (OPTIONAL)
+   * A list of countries to which this provider will ship packages.
+   */
+  public function countries(): Collection;
+
+  /**
+   * Given a Tracking number, converts the number's status string into an enum.
+   *
+   * @throws \InvalidArgumentException if the $number's status is unrecognizable.
+   */
+  public function mapStatus(string $status): TrackingNumberStatus;
+}

--- a/src/Contracts/ShipmentTrackingRepository.php
+++ b/src/Contracts/ShipmentTrackingRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace DuncanMcClean\SimpleCommerce\Contracts;
+
+use Statamic\Data\DataCollection;
+
+interface ShipmentTrackingRepository
+{
+    public function all(): DataCollection;
+    public function find(string $slug): ShipmentTrackingProvider;
+}

--- a/src/Contracts/TrackingNumber.php
+++ b/src/Contracts/TrackingNumber.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace DuncanMcClean\SimpleCommerce\Contracts;
+
+use \Carbon\Carbon;
+use DuncanMcClean\SimpleCommerce\Shipping\Tracking\TrackingNumberStatus;
+
+interface TrackingNumber {
+  /**
+   * The 'id' of the tracking number, used to query the status.
+   */
+  public function trackingNumber(): string;
+
+  /**
+   * The service that is used to update the tracking number information.
+   * The 'slug' of the shipper should be stored, and then retrieved using the 
+   * `ShipmentTracking` Facade. 
+   *
+   * @throws if Provider is not insta
+   */
+  public function shippingProvider(): ShipmentTrackingProvider;
+
+  /**
+   * The datetime when the tracking nummber was created. Could be called
+   * "shippedAt", but that could be misleading as tracking numbers are created
+   * before the package is actually shipped.
+   */
+  public function createdAt(): Carbon;
+
+  /**
+   * The current status of the package in generic terms.
+   * This should be saved in the shipping provider's native format,
+   * and then converted into a common format by passing saved status to the
+   * shipping provider's `mapStatus` method.
+   */
+  public function status(): TrackingNumberStatus;
+
+  /**
+   * (OPTIONAL)
+   * The datetime when the status was most recently updated. Useful if you want
+   * to check for jobs on a cron, or be notified if info goes stale for too long.
+   */
+  public function statusUpdatedAt(): Carbon;
+}
+

--- a/src/Exceptions/ShipmentTrackingProviderNotFound.php
+++ b/src/Exceptions/ShipmentTrackingProviderNotFound.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DuncanMcClean\SimpleCommerce\Exceptions;
+
+use Exception;
+
+class ShipmentTrackingProviderNotFound extends Exception
+{
+    public function __construct(
+        string $providerSlug,
+        int $code = 0,
+        Exception $previous = null
+    )
+    {
+        $message = "No ShipmentTrackingProvider could be found with the given slug '{$providerSlug}'";
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Facades/ShipmentTracking.php
+++ b/src/Facades/ShipmentTracking.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace DuncanMcClean\SimpleCommerce\Facades;
+
+use DuncanMcClean\SimpleCommerce\Contracts\ShipmentTrackingRepository;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @see \DuncanMcClean\SimpleCommerce\Contracts\CouponRepository
+ */
+class ShipmentTracking extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return ShipmentTrackingRepository::class;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -245,6 +245,16 @@ class ServiceProvider extends AddonServiceProvider
             });
         }
 
+        $this->app->bind(
+            Contracts\ShipmentTrackingRepository::class,
+            Shipping\Tracking\ShipmentTrackingConfigRepository::class
+        );
+        $this
+            ->app
+            ->when(Contracts\ShipmentTrackingRepository::class)
+            ->needs('$providers')
+            ->giveConfig('simple-commerce.shipment_tracking_providers');
+
         $this->app->bind(Contracts\GatewayManager::class, Gateways\Manager::class);
         $this->app->bind(Contracts\ShippingManager::class, Shipping\Manager::class);
 

--- a/src/Shipping/Tracking/ShipmentTrackingConfigRepository.php
+++ b/src/Shipping/Tracking/ShipmentTrackingConfigRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace DuncanMcClean\SimpleCommerce\Shipping\Tracking;
+
+use DuncanMcClean\SimpleCommerce\Contracts\ShipmentTrackingProvider;
+use DuncanMcClean\SimpleCommerce\Contracts\ShipmentTrackingRepository;
+use DuncanMcClean\SimpleCommerce\Exceptions\ShipmentTrackingProviderNotFound;
+use Statamic\Data\DataCollection;
+
+class ShipmentTrackingConfigRepository implements ShipmentTrackingRepository {
+    protected DataCollection $providers;
+
+    public function __construct(array $providers) {
+        $this->providers = new DataCollection();
+
+        foreach ($providers as $slug => $providerClass) {
+            $provider = app($providerClass);
+            $realSlug = $slug ?: $provider->slug();
+
+            $this->providers->put($realSlug, $providerClass);
+        }
+    }
+
+    public function all(): DataCollection {
+        return $this->providers;
+    }
+
+    /**
+     * @throws DuncanMcClean\SimpleCommerce\Exceptions\ShipmentTrackingProviderNotFound;
+     */
+    public function find(string $slug): ShipmentTrackingProvider {
+        if ($provider = $this->providers->get($slug)) {
+            return $provider;
+        } else {
+            throw new ShipmentTrackingProviderNotFound($slug);
+        }
+    }  
+}

--- a/src/Shipping/Tracking/TrackingNumber.php
+++ b/src/Shipping/Tracking/TrackingNumber.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DuncanMcClean\SimpleCommerce\Shipping\Tracking;
+
+use Carbon\Carbon;
+use DuncanMcClean\SimpleCommerce\Contracts\ShipmentTrackingProvider;
+use DuncanMcClean\SimpleCommerce\Contracts\TrackingNumber as BaseTrackingNumber;
+use DuncanMcClean\SimpleCommerce\Facades;
+
+class TrackingNumber Implements BaseTrackingNumber {
+    public function __construct(
+        protected string $trackingNumber,
+        protected string $shippingProvider,
+        protected Carbon $createdAt,
+        protected string $status,
+        protected Carbon $statusUpdatedAt,
+    ) {}
+
+    public function trackingNumber(): string {
+        return $this->trackingNumber;
+    }
+
+    public function shippingProvider(): ShipmentTrackingProvider {
+        return Facades\ShipmentTracking::find($this->shippingProvider);
+    }
+
+    public function createdAt(): Carbon {
+        return $this->createdAt;
+    }
+
+    public function status(): TrackingNumberStatus {
+        return $this
+            ->shippingProvider()
+            ->mapStatus($this->status);
+    }
+
+    public function statusUpdatedAt(): Carbon {
+        return $this->statusUpdatedAt;
+    }
+}
+

--- a/src/Shipping/Tracking/TrackingNumberStatus.php
+++ b/src/Shipping/Tracking/TrackingNumberStatus.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace DuncanMcClean\SimpleCommerce\Shipping\Tracking;
+
+enum TrackingNumberStatus: string {
+    /**
+     * The TrackingNumber has been created, but the package has not yet been
+     * received.
+     */
+    case Created = 'created';
+
+    /**
+     * The package has been recieved by the shipping provider and is on route to
+     * its destination.
+     */
+    case Shipped = 'shipped';
+
+    /**
+     * The package has been delivered to its destination.
+     */
+    case Delivered = 'delivered';
+    
+    /**
+     * TODO: Should break this down into multiple statuses.
+     * 
+     * A catch all for all shipment errors. i.e. Lost package, damaged package, etc.
+     */
+    case Error = 'error';
+}


### PR DESCRIPTION
I think it's safe to say that for shops selling physical goods, the ability to
provide tracking information for shipped orders is a *must*.

That being said, it would be totally unreasonable to try and manage all the
possible shipping providers inside the main `simple-commerce` repo. However, I do
think it would make sense for `simple-commerce` to provide *well defined* interfaces
that would allow application or library creators to make their own.

Here is a [CRC](https://agilemodeling.com/artifacts/crcModel.htm) diagram of the basic interfaces I'm envisioning:

[Diagram](https://mermaid.live/edit#pako:eNqFU8GOmzAQ_RVrTu0KIgJpMFxT9bStqt2eKl9ce0KsgI1sk-1ulH9fB8IuJcrWp-HN8_O8GeYIwkiEEuI4ZtorX2NJHneqbVB78stysVe6IpuaO4eObB42TPdUcUa-Kl5Z3jBNwpHKovDKaHL_wPSA9aw3mR9d8wctOQ6589lr8-SIH5_RPWGeHssZZX5ac1Dymie5R68aJMJiCOU8317uEdeiUFsliPPcd-6mzpAmT9yRrpXvkqd_7d2q79qo5g3OMVd31RyrTWXmmGnRcn_ukjCd9lbhpHBh9AGtd3NrYWTekAo12gn26fP7zcHY1Yzm1P9Y_sYFlzg1bNGZ-hCEXaC257LH9juytabpfbuJ-BDOymCwZEDi-BJ8_CfcKGqicfeBBkTQoG24kmEbeiMM_A7DwKAMoeR2z4DpU-DxzpvHZy2g9LbDCIYeXpYByi2vXUBRKm_s92G9-i2LoOX6tzHNeDF8QnmEv1Cm2aLIs4TS9EuWJ-mSRvAM5XKdLtJitS5okeVpkSTrUwQvvUCyoDSjNKF5tlzlqyxNI7Cmq3aX90-vIKRDeQ) (since inline version isn't loading).

```mermaid
classDiagram
    direction LR

    class TrackingNumber {
        knows tracking number
        knows ShipmentTrackingProvider
        knows datetime created
        knows provider specific status
        knows datetime status was updated
    }

    class ShipmentTrackingProvider {
        knows name
        knows slug
        knows logo
        knows operating countries
        converts specific statuses to generic statuses()
        updates TrackingNumber statuses()
    }

    class ShipmentTrackingFacade {
        resolves shipping providers from slugs
    }


    TrackingNumber "1" -- "1" ShipmentTrackingProvider
    ShipmentTrackingFacade "1" -- "*" ShipmentTrackingProvider
```

I would start by adding a `trackingNumbers()` method to the `Order` interface,
that returns a collection of `TrackingNumber`s.

```php
<?php

namespace DuncanMcClean\SimpleCommerce\Contracts;

use \Carbon\Carbon;
use DuncanMcClean\SimpleCommerce\Shipping\Tracking\TrackingNumberStatus;

interface TrackingNumber {
  /**
   * The 'id' of the tracking number, used to query the status.
   */
  public function trackingNumber(): string;

  /**
   * The service that is used to update the tracking number information.
   * The 'slug' of the shipper should be stored, and then retrieved using the 
   * `ShipmentTracking` Facade. 
   *
   * @throws if Provider is not insta
   */
  public function shippingProvider(): ShipmentTrackingProvider;

  /**
   * The datetime when the tracking nummber was created. Could be called
   * "shippedAt", but that could be misleading as tracking numbers are created
   * before the package is actually shipped.
   */
  public function createdAt(): Carbon;

  /**
   * The current status of the package in generic terms.
   * This should be saved in the shipping provider's native format,
   * and then converted into a common format by passing saved status to the
   * shipping provider's `mapStatus` method.
   */
  public function status(): TrackingNumberStatus;

  /**
   * (OPTIONAL)
   * The datetime when the status was most recently updated. Useful if you want
   * to check for jobs on a cron, or be notified if info goes stale for too long.
   */
  public function statusUpdatedAt(): Carbon;
}
```

```php
<?php

namespace DuncanMcClean\SimpleCommerce\Contracts;

use DuncanMcClean\SimpleCommerce\Shipping\Tracking\TrackingNumberStatus;
use Illuminate\Support\Collection;

/**
 * Likely a wrapper around an API class, this class is responsible for querying
 * The shipping provider and updating tracking information.
 */
interface ShipmentTrackingProvider {
  /**
   * The human readable name of the provider
   * e.g. FedEx, DHL, etc.
   */
  public function name(): string;

  /**
   * The machine readable name of the provider that will be stored in config
   * files, entries, and models.

   * e.g. fedex, dhl, etc.
   */
  public function slug(): string;

  /**
   * A glide compatible image containing the logo of the company.
   * TODO: We should define recommended size(s) for this.
   */
  public function logo(): Asset;

  /**
   * (OPTIONAL)
   * A list of countries to which this provider will ship packages.
   */
  public function countries(): Collection;

  /**
   * Given a Tracking number, converts the number's status string into an enum.
   *
   * @throws \InvalidArgumentException if the $number's status is unrecognizable.
   */
  public function mapStatus(string $status): TrackingNumberStatus;
}
```
