### PR TITLE
[7.x] Mollie: Check for the payment ID under the `gateway` key too

### DIFF
--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -157,6 +157,7 @@ class MollieGateway extends BaseGateway implements Gateway
     {
         return OrderFacade::query()
             ->where('mollie->id', $request->get('id'))
+            ->orWhere('gateway', 'like', "%tr_{$request->get('id')}%")
             ->first();
     }
 }


### PR DESCRIPTION
This pull request attempts to fix an issue where an `OrderNotFound` exception is being thrown when the Mollie webhook looks up an order which has already been marked as paid.

When the checkout process has been completed, we remove the `mollie` key from the order data, in place of the `gateway` key and the data underneath it. 

This PR *hopefully* fixes this issue by also checking the `gateway` data.

Fixes #1136.