### PR TITLE
[7.x] Mollie: Remove tr_ prefix from ID lookup

### DIFF
--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -157,7 +157,7 @@ class MollieGateway extends BaseGateway implements Gateway
     {
         return OrderFacade::query()
             ->where('mollie->id', $request->get('id'))
-            ->orWhere('gateway', 'like', "%tr_{$request->get('id')}%")
+            ->orWhere('gateway', 'like', "%{$request->get('id')}%")
             ->first();
     }
 }


### PR DESCRIPTION
Had the same error again (#1136), found out that the newly added orWhere is prefixed with `tr_`, while `$request->get('id')` is already containing `tr_`. That is removed with this PR. Then it should work properly :) 

I tested this using tinker and that is able to find the order. Couldn't test it 100% with Mollie webhook since they don't have the ability to trigger sending a failed webhook again.
```php
DuncanMcClean\SimpleCommerce\Facades\Order::query()->where('mollie->id', 'tr_XXXX')->orWhere('gateway', 'like', "%tr_XXXX%”)->first();
```