### PR TITLE
[7.x] Gracefully return false in `$order->redeemCoupon()`

### DIFF
--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -284,7 +284,7 @@ class Order implements Contract
     {
         $coupon = Coupon::findByCode($code);
 
-        if ($coupon->isValid($this)) {
+        if ($coupon?->isValid($this)) {
             $this->coupon($coupon);
             $this->save();
 


### PR DESCRIPTION
If no coupon exists, gracefully return false in `$order->redeemCoupon()`. Use case is for when user creates a more custom coupon flow using Livewire or similar, so they don't have to try/catch when coupon cannot be found ❤️