### PR TITLE
[7.x] Update php-api.md typo in it

### DIFF
--- a/docs/php-api.md
+++ b/docs/php-api.md
@@ -35,7 +35,7 @@ $product->variant('Red_Large');
 $product->productVariants([
     'variants' => [
         ['name' => 'Colours', 'values' => ['Red', 'Green', 'Blue']],
-        ['name' => 'Size', 'value' => ['Small', 'Medium']],
+        ['name' => 'Size', 'values' => ['Small', 'Medium']],
     ],
     'options' => [
         ['key' => 'Red_Small', 'variant' => 'Red Small', 'price' => 2500],


### PR DESCRIPTION
Typo when setting the variants. Was value but should be values.