### PR TITLE
[7.x] Fix variable being output in email template

### DIFF
--- a/resources/views/emails/backoffice_order_paid.blade.php
+++ b/resources/views/emails/backoffice_order_paid.blade.php
@@ -1,4 +1,6 @@
-{{ $taxIncludedInPrices = config('simple-commerce.tax_engine_config.included_in_prices') }}
+@php
+    $taxIncludedInPrices = config('simple-commerce.tax_engine_config.included_in_prices')
+@endphp
 
 @component('mail::message')
 # {{ __('New Order') }}

--- a/resources/views/emails/customer_order_paid.blade.php
+++ b/resources/views/emails/customer_order_paid.blade.php
@@ -1,4 +1,6 @@
-{{ $taxIncludedInPrices = config('simple-commerce.tax_engine_config.included_in_prices') }}
+@php
+    $taxIncludedInPrices = config('simple-commerce.tax_engine_config.included_in_prices')
+@endphp
 
 @component('mail::message')
 # {{ __('Order Confirmation') }}

--- a/resources/views/emails/customer_order_shipped.blade.php
+++ b/resources/views/emails/customer_order_shipped.blade.php
@@ -1,4 +1,6 @@
-{{ $taxIncludedInPrices = config('simple-commerce.tax_engine_config.included_in_prices') }}
+@php
+    $taxIncludedInPrices = config('simple-commerce.tax_engine_config.included_in_prices')
+@endphp
 
 @component('mail::message')
 # {{ __('Order Shipped') }}


### PR DESCRIPTION
This variable assignment in Blade is also output to the template (as "1" at the top of the email). Use the @php directive to silently assign the "tax included" variable.