### PR TITLE
[7.x] Don't enable telemetry by default due to GDPR

### DIFF
--- a/config/simple-commerce.php
+++ b/config/simple-commerce.php
@@ -176,4 +176,16 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Telemetry
+    |--------------------------------------------------------------------------
+    |
+    | We collect information about your system and amount of orders this addon has processed.
+    | By default, this is opted-out but if you wish to help us improve the addon then feel free
+    | to change this to true.
+    |
+    */
+
+    'enable_telemetry' => false,
 ];


### PR DESCRIPTION
Due to GDPR regulations, data shouldn't be "phoning home" to a random API endpoint.