### PR TITLE
[7.x] Fix variant options not being added correctly

### DIFF
--- a/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariants/ProductVariantsFieldtype.vue
@@ -219,9 +219,9 @@ export default {
                     }
 
                     return {
+                        ...existingData,
                         key: key,
                         variant: variantName,
-                        ...existingData,
                     }
                 })
 


### PR DESCRIPTION
This pull request fixes an issue where variant options weren't being added correctly after adding new variants to a product.

This was likely caused by changes in 8cc6c07.

Fixes #1185.