### PR TITLE
[7.x] Fix broken Assets fields in Product Variant options

### DIFF
--- a/src/Fieldtypes/ProductVariantsFieldtype.php
+++ b/src/Fieldtypes/ProductVariantsFieldtype.php
@@ -35,7 +35,14 @@ class ProductVariantsFieldtype extends Fieldtype
                 'variant' => resolve(Textarea::class)->preload(),
                 'price' => resolve(MoneyFieldtype::class)->preload(),
             ],
-            $this->optionFields()->meta()->all(),
+            collect($this->optionFields()->meta()->all())->mapWithKeys(function ($value, $handle) {
+                // Fix the assets fieldtype (for now!)
+                if (isset($value['data']) && collect($value['data'])->count() === 0) {
+                    $value['data'] = null;
+                }
+
+                return [$handle => $value];
+            })->all(),
         );
     }
 


### PR DESCRIPTION
This pull request fixes an issue where Asset fields in variant options weren't showing as expected after a refresh. 

While I was fixing another issue in 8cc6c07, I removed a temporary fix added in 676199f for the Assets fieldtype.

I've added the Product Variants fieldtype to the "to refactor list" for v8.

Fixes #1187.