### PR TITLE
[7.x] Remove coupon & reset total when coupon is no longer valid

### DIFF
--- a/src/Orders/Calculator/CouponCalculator.php
+++ b/src/Orders/Calculator/CouponCalculator.php
@@ -15,6 +15,9 @@ class CouponCalculator
 
             // Double check coupon is still valid
             if (! $coupon->isValid($order)) {
+                $order->coupon(null);
+                $order->couponTotal(0);
+
                 return $next($order);
             }
 

--- a/tests/Orders/Calculator/CouponCalculatorTest.php
+++ b/tests/Orders/Calculator/CouponCalculatorTest.php
@@ -37,10 +37,11 @@ it('skips calculating coupon total if coupon is not valid', function () {
 
     $order = Order::make()->lineItems([
         ['id' => '123', 'product' => $product->id, 'quantity' => 2, 'total' => 10000],
-    ])->itemsTotal(10000)->coupon($coupon->id)->save();
+    ])->itemsTotal(10000)->couponTotal(5000)->coupon($coupon->id)->save();
 
     $order = Pipeline::send($order)->through([CouponCalculator::class])->thenReturn();
 
+    expect($order->coupon())->toBeNull();
     expect($order->couponTotal())->toBe(0);
 });
 


### PR DESCRIPTION
This pull request _hopefully_ fixes an issue where a coupon would remain attached to the cart, even after it's no longer valid.

Related: #1194