### PR TITLE
[7.x] Runway 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "stripe/stripe-php": "^13.0"
     },
     "require-dev": {
-        "statamic-rad-pack/runway": "^7.13",
+        "statamic-rad-pack/runway": "^7.13 || ^8.0",
         "orchestra/testbench": "^8.28 || ^9.6.1",
         "phpunit/phpunit": "^10.5.35",
         "pestphp/pest": "^2.2",

--- a/src/Console/Commands/stubs/runway_config.php
+++ b/src/Console/Commands/stubs/runway_config.php
@@ -23,6 +23,7 @@ return [
             'handle' => 'orders',
             'hidden' => true,
             'read_only' => true,
+            'nested_field_prefixes' => ['data'],
         ],
     ],
 

--- a/src/Console/Commands/stubs/runway_order_blueprint.yaml
+++ b/src/Console/Commands/stubs/runway_order_blueprint.yaml
@@ -38,7 +38,7 @@ tabs:
               display: Coupon
               width: 50
               visibility: read_only
-          - handle: data->shipping_method
+          - handle: data_shipping_method
             field:
               display: "Shipping Method"
               type: shipping_method


### PR DESCRIPTION
This pull request updates the Runway stubs around nested fields so everything works with Runway 8.0.0 which was just released.

Replaces #1119.