### PR TITLE
[7.x] Supports Laravel 12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php: [8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*]
+        laravel: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,8 @@
         "statamic-rad-pack/runway": "^7.13 || ^8.0",
         "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0",
         "phpunit/phpunit": "^10.5.35 || ^11.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0",
+        "pestphp/pest": "^2.2 || ^3.0",
+        "pestphp/pest-plugin-laravel": "^2.0 || ^3.0",
         "spatie/ray": "^1.17",
         "spatie/test-time": "^1.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -61,5 +61,5 @@
             "pestphp/pest-plugin": true
         }
     },
-    "minimum-stability": "alpha"
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "require-dev": {
         "statamic-rad-pack/runway": "^7.13 || ^8.0",
         "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0",
-        "phpunit/phpunit": "^10.5.35",
+        "phpunit/phpunit": "^10.5.35 || ^11.0",
         "pestphp/pest": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0",
         "spatie/ray": "^1.17",

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,8 @@
         "statamic-rad-pack/runway": "^7.13 || ^8.0",
         "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0",
         "phpunit/phpunit": "^10.5.35",
-        "pestphp/pest": "^2.2",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "pestphp/pest": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.0",
         "spatie/ray": "^1.17",
         "spatie/test-time": "^1.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": "^8.2",
         "ext-intl": "*",
-        "laravel/framework": "^10.34 || ^11.0.3",
+        "laravel/framework": "^10.34 || ^11.0.3 || ^12.0",
         "mollie/mollie-api-php": "^2.30.0",
         "moneyphp/money": "^4.0",
         "paypal/paypal-checkout-sdk": "^1.0",
@@ -43,7 +43,7 @@
     },
     "require-dev": {
         "statamic-rad-pack/runway": "^7.13 || ^8.0",
-        "orchestra/testbench": "^8.28 || ^9.6.1",
+        "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0",
         "phpunit/phpunit": "^10.5.35",
         "pestphp/pest": "^2.2",
         "pestphp/pest-plugin-laravel": "^2.0",


### PR DESCRIPTION
This pull request adds Laravel 12 support to `duncanmcclean/simple-commerce`.

Depends on:

* [x] https://github.com/statamic/cms/pull/11433
* [x] https://github.com/Stillat/proteus/pull/34
* [x] https://github.com/statamic-rad-pack/runway/pull/664