### PR TITLE
[7.x] Delete `some-other-collection` blueprint

### DIFF
--- a/resources/blueprints/collections/some-other-collection/some-other-collection.yaml
+++ b/resources/blueprints/collections/some-other-collection/some-other-collection.yaml
@@ -1,3 +1,0 @@
-tabs:
-  main:
-    fields: {  }


### PR DESCRIPTION
When you install Simple Commerce, it was copying the default blueprints out of `resources/blueprints`. 

However, it looks like there was an extra blueprint for a collection which doesn't exist, `some-other-collection`. I probably never meant to commit it, so this pull request deletes it.