### PR TITLE
[7.x] Fix `use_shipping_address_for_billing` option when using Database Orders

### DIFF
--- a/src/Orders/EloquentOrderRepository.php
+++ b/src/Orders/EloquentOrderRepository.php
@@ -171,7 +171,7 @@ class EloquentOrderRepository implements RepositoryContract
         $model->billing_region = $order->get('billing_region');
         $model->billing_country = $order->get('billing_country');
 
-        $model->use_shipping_address_for_billing = $order->get('use_shipping_address_for_billing') == 'true';
+        $model->use_shipping_address_for_billing = $order->get('use_shipping_address_for_billing') && $order->get('use_shipping_address_for_billing') != 'off';
 
         // If anything in the order data has it's own column, save it
         // there, rather than in the data column.

--- a/src/Orders/EloquentOrderRepository.php
+++ b/src/Orders/EloquentOrderRepository.php
@@ -171,7 +171,7 @@ class EloquentOrderRepository implements RepositoryContract
         $model->billing_region = $order->get('billing_region');
         $model->billing_country = $order->get('billing_country');
 
-        $model->use_shipping_address_for_billing = $order->get('use_shipping_address_for_billing') && $order->get('use_shipping_address_for_billing') != 'off';
+        $model->use_shipping_address_for_billing = $order->get('use_shipping_address_for_billing') == 'true';
 
         // If anything in the order data has it's own column, save it
         // there, rather than in the data column.

--- a/src/Orders/EloquentOrderRepository.php
+++ b/src/Orders/EloquentOrderRepository.php
@@ -171,7 +171,7 @@ class EloquentOrderRepository implements RepositoryContract
         $model->billing_region = $order->get('billing_region');
         $model->billing_country = $order->get('billing_country');
 
-        $model->use_shipping_address_for_billing = $order->get('use_shipping_address_for_billing') == 'true';
+        $model->use_shipping_address_for_billing = $order->get('use_shipping_address_for_billing') == 'true' || $order->get('use_shipping_address_for_billing') == 'on';
 
         // If anything in the order data has it's own column, save it
         // there, rather than in the data column.

--- a/tests/Orders/EloquentOrderRepositoryTest.php
+++ b/tests/Orders/EloquentOrderRepositoryTest.php
@@ -349,6 +349,32 @@ it('can save order when bit of data has its own column', function () {
     ]);
 });
 
+it('can save use_shipping_address_for_billing column', function () {
+    $orderRecord = OrderModel::create();
+    $order = Order::find($orderRecord->id);
+
+    $order->set('use_shipping_address_for_billing', true)->save();
+    $this->assertDatabaseHas('orders', ['id' => $orderRecord->id, 'use_shipping_address_for_billing' => true]);
+
+    $order->set('use_shipping_address_for_billing', 'true')->save();
+    $this->assertDatabaseHas('orders', ['id' => $orderRecord->id, 'use_shipping_address_for_billing' => true]);
+
+    $order->set('use_shipping_address_for_billing', 'on')->save();
+    $this->assertDatabaseHas('orders', ['id' => $orderRecord->id, 'use_shipping_address_for_billing' => true]);
+
+    $order->set('use_shipping_address_for_billing', false)->save();
+    $this->assertDatabaseHas('orders', ['id' => $orderRecord->id, 'use_shipping_address_for_billing' => false]);
+
+    $order->set('use_shipping_address_for_billing', 'false')->save();
+    $this->assertDatabaseHas('orders', ['id' => $orderRecord->id, 'use_shipping_address_for_billing' => false]);
+
+    $order->set('use_shipping_address_for_billing', 'off')->save();
+    $this->assertDatabaseHas('orders', ['id' => $orderRecord->id, 'use_shipping_address_for_billing' => false]);
+
+    $order->set('use_shipping_address_for_billing', null)->save();
+    $this->assertDatabaseHas('orders', ['id' => $orderRecord->id, 'use_shipping_address_for_billing' => false]);
+});
+
 it('can save order with status log events', function () {
     $product = Product::make()->price(1000);
     $product->save();


### PR DESCRIPTION
This appears to happen before the casts() method and if the value property on the html element hydrating this is set to anything other than string "true" this was setting this to bool false.

IIRC the default for HTML checkbox inputs is to send the string "on" if checked and is always "off" unchecked. 

I've branched from the commit I've got checked out locally on this. I've not gone to the trouble of setting up composer to install from my fork, but I have tested that this via copy/pasting the line into my current installation in composer.

Fixes https://github.com/duncanmcclean/simple-commerce/issues/1212.