### PR TITLE
[7.x] Mollie: Fix refunds & prevent `\x00*\x00client` and `_links` keys saving in order data

### DIFF
--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -64,7 +64,13 @@ class MollieGateway extends BaseGateway implements Gateway
     {
         $this->setupMollie();
 
-        $payment = $this->mollie->payments->get($order->get('gateway')['data']['id']);
+        $paymentId = $order->gatewayData()->data()->get('id');
+
+        if (! $paymentId) {
+            throw new \Exception("Refund failed. Couldn't find payment ID.");
+        }
+
+        $payment = $this->mollie->payments->get($paymentId);
         $payment->refund([]);
 
         return [];

--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -12,6 +12,7 @@ use DuncanMcClean\SimpleCommerce\Gateways\BaseGateway;
 use DuncanMcClean\SimpleCommerce\Orders\PaymentStatus;
 use DuncanMcClean\SimpleCommerce\SimpleCommerce;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Types\PaymentStatus as MolliePaymentStatus;
@@ -96,7 +97,7 @@ class MollieGateway extends BaseGateway implements Gateway
                 return;
             }
 
-            $order->gatewayData(data: (array) $payment);
+            $order->gatewayData(data: Arr::except((array) $payment, ["\x00*\x00client", '_links']));
             $order->save();
 
             $this->markOrderAsPaid($order);


### PR DESCRIPTION
This pull request fixes an issue with the Mollie gateway where an error would occur when attempting to refund a payment in the Control Panel.

This PR also prevents `\x00*\x00client` and `_links` keys from being saved alongside the rest of the payment metadata, as it's not that useful. 

This PR *doesn't* fix an issue where refunds issued via the Mollie dashboard aren't reflected in Statamic. This has been addressed in the next major version of Simple Commerce.

Closes #1231.