### PR TITLE
[7.x] Fix error when refunding Mollie payments

### DIFF
--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -71,7 +71,13 @@ class MollieGateway extends BaseGateway implements Gateway
         }
 
         $payment = $this->mollie->payments->get($paymentId);
-        $payment->refund([]);
+
+        $payment->refund([
+            'amount' => [
+                'currency' => Currency::get($order->site())['code'],
+                'value' => (string) substr_replace($order->grandTotal(), '.', -2, 0),
+            ],
+        ]);
 
         return [];
     }


### PR DESCRIPTION
This pull request passes an `amount` when creating refunds in Mollie, to prevent the following validation error:

![image](https://github.com/user-attachments/assets/5dbbbfd2-7543-4f2f-8d0e-20b9e19e9d76)

Closes #1231.