### PR TITLE
[7.x] Correct tax calculations when "Prices include tax" is false (standard tax engine)

### DIFF
--- a/src/Tax/Standard/TaxEngine.php
+++ b/src/Tax/Standard/TaxEngine.php
@@ -38,9 +38,9 @@ class TaxEngine implements Contract
             }
         }
 
-        if($taxRate->includeInPrice()){
+        if( $taxRate->includeInPrice() ){
             $taxAmount = ($lineItem->total() / 100) * ($taxRate->rate() / (100 + $taxRate->rate()));
-        }else{
+        } else {
             $taxAmount = ($lineItem->total() / 100) * ($taxRate->rate() / 100);
         }
         $itemTax = (int) round($taxAmount * 100);

--- a/src/Tax/Standard/TaxEngine.php
+++ b/src/Tax/Standard/TaxEngine.php
@@ -43,6 +43,7 @@ class TaxEngine implements Contract
         } else {
             $taxAmount = ($lineItem->total() / 100) * ($taxRate->rate() / 100);
         }
+
         $itemTax = (int) round($taxAmount * 100);
 
         return new TaxCalculation($itemTax, $taxRate->rate(), $taxRate->includeInPrice());
@@ -119,7 +120,12 @@ class TaxEngine implements Contract
             }
         }
 
-        $taxAmount = ($order->shippingTotal() / 100) * ($taxRate->rate() / (100 + $taxRate->rate()));
+        if ($taxRate->includeInPrice()) {
+            $taxAmount = ($order->shippingTotal() / 100) * ($taxRate->rate() / (100 + $taxRate->rate()));
+        } else {
+            $taxAmount = ($order->shippingTotal() / 100) * ($taxRate->rate() / 100);
+        }
+
         $itemTax = (int) round($taxAmount * 100);
 
         return new TaxCalculation($itemTax, $taxRate->rate(), $taxRate->includeInPrice());

--- a/src/Tax/Standard/TaxEngine.php
+++ b/src/Tax/Standard/TaxEngine.php
@@ -38,7 +38,7 @@ class TaxEngine implements Contract
             }
         }
 
-        if( $taxRate->includeInPrice() ){
+        if ($taxRate->includeInPrice()) {
             $taxAmount = ($lineItem->total() / 100) * ($taxRate->rate() / (100 + $taxRate->rate()));
         } else {
             $taxAmount = ($lineItem->total() / 100) * ($taxRate->rate() / 100);

--- a/src/Tax/Standard/TaxEngine.php
+++ b/src/Tax/Standard/TaxEngine.php
@@ -38,7 +38,11 @@ class TaxEngine implements Contract
             }
         }
 
-        $taxAmount = ($lineItem->total() / 100) * ($taxRate->rate() / (100 + $taxRate->rate()));
+        if($taxRate->includeInPrice()){
+            $taxAmount = ($lineItem->total() / 100) * ($taxRate->rate() / (100 + $taxRate->rate()));
+        }else{
+            $taxAmount = ($lineItem->total() / 100) * ($taxRate->rate() / 100);
+        }
         $itemTax = (int) round($taxAmount * 100);
 
         return new TaxCalculation($itemTax, $taxRate->rate(), $taxRate->includeInPrice());

--- a/tests/Tax/StandardTaxEngineTest.php
+++ b/tests/Tax/StandardTaxEngineTest.php
@@ -774,22 +774,22 @@ test('can calculate line item tax rate when excluded in price', function () {
     ]);
 
     $taxCategory = TaxCategory::make()
-        ->id('standard-vat')
-        ->name('Standard VAT');
+        ->id('vat')
+        ->name('VAT');
 
     $taxCategory->save();
 
     $taxZone = TaxZone::make()
-        ->id('uk')
-        ->name('United Kingdom')
-        ->country('GB');
+        ->id('germany')
+        ->name('Germany')
+        ->country('DE');
 
     $taxZone->save();
 
     $taxRate = TaxRate::make()
-        ->id('uk-20-vat')
-        ->name('20% VAT')
-        ->rate(20)
+        ->id('vat')
+        ->name('VAT')
+        ->rate(19)
         ->category($taxCategory->id())
         ->zone($taxZone->id())
         ->includeInPrice(false);
@@ -797,7 +797,7 @@ test('can calculate line item tax rate when excluded in price', function () {
     $taxRate->save();
 
     $product = Product::make()
-        ->price(1000)
+        ->price(10000)
         ->taxCategory($taxCategory->id())
         ->data([
             'title' => 'Cat Food',
@@ -814,20 +814,21 @@ test('can calculate line item tax rate when excluded in price', function () {
         ],
     ])->merge([
         'billing_address' => '1 Test Street',
-        'billing_country' => 'GB',
+        'billing_country' => 'DE',
         'use_shipping_address_for_billing' => false,
     ]);
 
     $order->save();
 
     $recalculate = $order->recalculate();
+
     // Ensure tax on line items are right
     $this->assertSame($recalculate->lineItems()->first()->tax(), [
-        'amount' => 200,
-        'rate' => 20,
+        'amount' => 1900,
+        'rate' => 19,
         'price_includes_tax' => false,
     ]);
 
     // Ensure global order tax is right
-    expect(200)->toBe($recalculate->taxTotal());
+    expect(1900)->toBe($recalculate->taxTotal());
 });

--- a/tests/Tax/StandardTaxEngineTest.php
+++ b/tests/Tax/StandardTaxEngineTest.php
@@ -95,13 +95,13 @@ test('can correctly calculate line item tax rate based on country', function () 
 
     // Ensure tax on line items are right
     $this->assertSame($recalculate->lineItems()->first()->tax(), [
-        'amount' => 167,
+        'amount' => 200,
         'rate' => 20,
         'price_includes_tax' => false,
     ]);
 
     // Ensure global order tax is right
-    expect(167)->toBe($recalculate->taxTotal());
+    expect(200)->toBe($recalculate->taxTotal());
 });
 
 test('can correctly calculate line item tax rate based on region', function () {
@@ -164,13 +164,13 @@ test('can correctly calculate line item tax rate based on region', function () {
 
     // Ensure tax on line items are right
     $this->assertSame($recalculate->lineItems()->first()->tax(), [
-        'amount' => 130,
+        'amount' => 150,
         'rate' => 15,
         'price_includes_tax' => false,
     ]);
 
     // Ensure global order tax is right
-    expect(130)->toBe($recalculate->taxTotal());
+    expect(150)->toBe($recalculate->taxTotal());
 });
 
 test('can correctly calculate line item tax rate when address has region but no addresses have a region', function () {
@@ -237,13 +237,13 @@ test('can correctly calculate line item tax rate when address has region but no 
 
     // Ensure tax on line items are right
     $this->assertSame($recalculate->lineItems()->first()->tax(), [
-        'amount' => 130,
+        'amount' => 150,
         'rate' => 15,
         'price_includes_tax' => false,
     ]);
 
     // Ensure global order tax is right
-    expect(130)->toBe($recalculate->taxTotal());
+    expect(150)->toBe($recalculate->taxTotal());
 });
 
 test('can correctly calculate line item tax zones when tax rates exists both with and without region', function () {
@@ -328,13 +328,13 @@ test('can correctly calculate line item tax zones when tax rates exists both wit
 
     // Ensure tax on line items are right
     $this->assertSame($recalculate->lineItems()->first()->tax(), [
-        'amount' => 130,
+        'amount' => 150,
         'rate' => 15,
         'price_includes_tax' => false,
     ]);
 
     // Ensure global order tax is right
-    expect(130)->toBe($recalculate->taxTotal());
+    expect(150)->toBe($recalculate->taxTotal());
 });
 
 test('can calculate line item tax rate when included in price', function () {
@@ -756,13 +756,13 @@ test('tax rate with a decimal place is stored correctly', function () {
 
     // Ensure tax on line items are right
     $this->assertSame($recalculate->lineItems()->first()->tax(), [
-        'amount' => 170,
+        'amount' => 205,
         'rate' => 20.5,
         'price_includes_tax' => false,
     ]);
 
     // Ensure global order tax is right
-    expect(170)->toBe($recalculate->taxTotal());
+    expect(205)->toBe($recalculate->taxTotal());
 });
 
 // https://github.com/duncanmcclean/simple-commerce/issues/1234

--- a/tests/Tax/StandardTaxEngineTest.php
+++ b/tests/Tax/StandardTaxEngineTest.php
@@ -764,3 +764,70 @@ test('tax rate with a decimal place is stored correctly', function () {
     // Ensure global order tax is right
     expect(170)->toBe($recalculate->taxTotal());
 });
+
+// https://github.com/duncanmcclean/simple-commerce/issues/1234
+test('can calculate line item tax rate when excluded in price', function () {
+    Config::set('simple-commerce.tax_engine', StandardTaxEngine::class);
+
+    Config::set('simple-commerce.tax_engine_config', [
+        'address' => 'billing',
+    ]);
+
+    $taxCategory = TaxCategory::make()
+        ->id('standard-vat')
+        ->name('Standard VAT');
+
+    $taxCategory->save();
+
+    $taxZone = TaxZone::make()
+        ->id('uk')
+        ->name('United Kingdom')
+        ->country('GB');
+
+    $taxZone->save();
+
+    $taxRate = TaxRate::make()
+        ->id('uk-20-vat')
+        ->name('20% VAT')
+        ->rate(20)
+        ->category($taxCategory->id())
+        ->zone($taxZone->id())
+        ->includeInPrice(false);
+
+    $taxRate->save();
+
+    $product = Product::make()
+        ->price(1000)
+        ->taxCategory($taxCategory->id())
+        ->data([
+            'title' => 'Cat Food',
+        ]);
+
+    $product->save();
+
+    $order = Order::make()->lineItems([
+        [
+            'id' => app('stache')->generateId(),
+            'product' => $product->id,
+            'quantity' => 1,
+            'total' => 1000,
+        ],
+    ])->merge([
+        'billing_address' => '1 Test Street',
+        'billing_country' => 'GB',
+        'use_shipping_address_for_billing' => false,
+    ]);
+
+    $order->save();
+
+    $recalculate = $order->recalculate();
+    // Ensure tax on line items are right
+    $this->assertSame($recalculate->lineItems()->first()->tax(), [
+        'amount' => 200,
+        'rate' => 20,
+        'price_includes_tax' => false,
+    ]);
+
+    // Ensure global order tax is right
+    expect(200)->toBe($recalculate->taxTotal());
+});


### PR DESCRIPTION
Tax calculation was not correct when $taxRate->includeInPrice set to false.