### PR TITLE
[7.x] Drop `allow_redirects` parameter from Stripe Payment Intent API request

### DIFF
--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -76,7 +76,6 @@ class StripeGateway extends BaseGateway implements Gateway
         if ($this->inPaymentElementsMode()) {
             $intentData['automatic_payment_methods'] = [
                 'enabled' => true,
-                'allow_redirects' => $this->config()->get('allow_redirects', 'never'),
             ];
         }
 

--- a/src/Gateways/Builtin/StripeGateway.php
+++ b/src/Gateways/Builtin/StripeGateway.php
@@ -76,7 +76,7 @@ class StripeGateway extends BaseGateway implements Gateway
         if ($this->inPaymentElementsMode()) {
             $intentData['automatic_payment_methods'] = [
                 'enabled' => true,
-                'allow_redirects' => 'never',
+                'allow_redirects' => $this->config()->get('allow_redirects', 'never'),
             ];
         }
 


### PR DESCRIPTION
Allows a configurable override to set the automatic_payment_methods.allow_redirects value for Stripe's payment elements payload.

This allows payment methods that require a redirect to work e.g. Klarna