### PR TITLE
[7.x] Fix download URL not generated for digital line items / product variants

### DIFF
--- a/src/Orders/Checkout/HandleDigitalProducts.php
+++ b/src/Orders/Checkout/HandleDigitalProducts.php
@@ -13,8 +13,21 @@ class HandleDigitalProducts
     public function handle(Order $order, Closure $next)
     {
         $hasDownloads = $order->lineItems()
-            ->filter(function ($lineItem) {
-                return $lineItem->product()->get('product_type') === 'digital';
+            ->filter(function ($lineItem) {;
+                if ($lineItem->product()->get('product_type') === 'digital') {
+                    return true;
+                }
+
+                $itemVariantKey = $lineItem->variant()['variant'] ?? null;
+
+                if ( ! $itemVariantKey) {
+                    return true;
+                }
+
+                $productVariants = collect($lineItem->product()->productVariants()['options']);
+                $itemVariant = $productVariants->firstWhere('key', $itemVariantKey);
+
+                return $itemVariant['is_digital_product'] ?? false;
             })
             ->each(function ($lineItem) use ($order) {
                 $order->updateLineItem($lineItem->id(), [

--- a/src/Orders/Checkout/HandleDigitalProducts.php
+++ b/src/Orders/Checkout/HandleDigitalProducts.php
@@ -13,14 +13,14 @@ class HandleDigitalProducts
     public function handle(Order $order, Closure $next)
     {
         $hasDownloads = $order->lineItems()
-            ->filter(function ($lineItem) {;
+            ->filter(function ($lineItem) {
                 if ($lineItem->product()->get('product_type') === 'digital') {
                     return true;
                 }
 
                 $itemVariantKey = $lineItem->variant()['variant'] ?? null;
 
-                if ( ! $itemVariantKey) {
+                if (! $itemVariantKey) {
                     return false;
                 }
 

--- a/src/Orders/Checkout/HandleDigitalProducts.php
+++ b/src/Orders/Checkout/HandleDigitalProducts.php
@@ -21,7 +21,7 @@ class HandleDigitalProducts
                 $itemVariantKey = $lineItem->variant()['variant'] ?? null;
 
                 if ( ! $itemVariantKey) {
-                    return true;
+                    return false;
                 }
 
                 $productVariants = collect($lineItem->product()->productVariants()['options']);


### PR DESCRIPTION
I noticed that when I mark a single variant as digital, the download URLs are not generated because the handler only looks for the digital flag on the product itself. This change means that the handler also recognises variants that are marked as digital, even if the product itself is physical.