### PR TITLE
[8.x] Sort out temporary JS imports

### DIFF
--- a/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { Fieldtype } from '@statamic/cms';
-import { Panel, PanelHeader, Heading, Card, Button, PublishContainer, PublishFieldsProvider as FieldsProvider, PublishFields as Fields, injectPublishContext } from '@statamic/cms/ui';
-import { ConfirmationModal } from '@statamic/cms/temporary';
+import { Panel, PanelHeader, Heading, Card, Button, PublishContainer, PublishFieldsProvider as FieldsProvider, PublishFields as Fields, injectPublishContext, ConfirmationModal } from '@statamic/cms/ui';
 import { computed, ref, watch } from 'vue';
 const { values, errors } = injectPublishContext()
 

--- a/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
@@ -212,7 +212,7 @@ watch(
 
                 <Card>
                     <ConfirmationModal
-                        v-if="deletingVariant === index"
+                        :open="deletingVariant === index"
                         :ref="`variant-deleter-${index}`"
                         :title="__('Delete Variant')"
                         :danger="true"

--- a/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
+++ b/resources/js/components/Fieldtypes/ProductVariantsFieldtype.vue
@@ -1,6 +1,17 @@
 <script setup>
 import { Fieldtype } from '@statamic/cms';
-import { Panel, PanelHeader, Heading, Card, Button, PublishContainer, PublishFieldsProvider as FieldsProvider, PublishFields as Fields, injectPublishContext, ConfirmationModal } from '@statamic/cms/ui';
+import {
+    Panel,
+    PanelHeader,
+    Heading,
+    Card,
+    Button,
+    PublishContainer,
+    PublishFieldsProvider as FieldsProvider,
+    PublishFields as Fields,
+    injectPublishContext,
+    ConfirmationModal
+} from '@statamic/cms/ui';
 import { computed, ref, watch } from 'vue';
 const { values, errors } = injectPublishContext()
 


### PR DESCRIPTION
Related: https://github.com/statamic/cms/pull/13475

## To Do

* [x] Update `ConfirmationModal` usage in `ProductVariantsFieldtype.vue`