### PR TITLE
[7.x] Clear order's gateway data when Mollie payment expires

### DIFF
--- a/src/Data/HasData.php
+++ b/src/Data/HasData.php
@@ -46,6 +46,13 @@ trait HasData
         return $this;
     }
 
+    public function remove(string $key): self
+    {
+        unset($this->data[$key]);
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return $this->data()->toArray();

--- a/src/Gateways/Builtin/MollieGateway.php
+++ b/src/Gateways/Builtin/MollieGateway.php
@@ -124,6 +124,19 @@ class MollieGateway extends BaseGateway implements Gateway
 
             event(new OrderPaymentFailed($order));
         }
+
+        if ($payment->status === MolliePaymentStatus::STATUS_EXPIRED) {
+            $order = $this->getOrderFromWebhookRequest($request);
+
+            if (! $order) {
+                throw new OrderNotFound("Order related to Mollie transaction [{$mollieId}] could not be found.");
+            }
+
+            $order
+                ->remove('mollie')
+                ->clearGatewayData()
+                ->save();
+        }
     }
 
     public function fieldtypeDisplay($value): array

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -227,6 +227,13 @@ class Order implements Contract
         return new GatewayData($this->gateway);
     }
 
+    public function clearGatewayData(): self
+    {
+        $this->gateway = null;
+
+        return $this;
+    }
+
     public function resource($resource = null)
     {
         return $this


### PR DESCRIPTION
This pull request attempts to fix an issue where checking out with an expired Mollie payment would end up creating a new payment, with a fresh ID, which wouldn't be reconciled properly when the payment succeeds.

This PR fixes it by listening to the "payment expired" webhook event and clearing the order's gateway data which means SC will create a fresh payment if the customer comes back to checkout.

Fixes #1193
